### PR TITLE
Add .mailmap — consolidate Claude co-author into primary committer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# Consolidate Claude co-author trailers into the primary author entry.
+#
+# GitHub's contributor graph and `git shortlog` count commit_email,
+# so mapping the Claude noreply address to the human committer cleans
+# the graph without rewriting any commit messages. Individual commit
+# pages still show the `Co-Authored-By:` trailer in the body — that's
+# commit-message text, which mailmap does not touch.
+#
+# Format: <canonical name + email> <commit email to rewrite>
+shiqi wang <shiqi308@gmail.com> <noreply@anthropic.com>


### PR DESCRIPTION
## Summary
- GitHub's Contributors graph counts every \`Co-Authored-By:\` trailer as a distinct contributor keyed on commit email. With ~dozen W6 commits carrying a Claude co-author trailer, Claude was outranking the human committer on the graph.
- This mailmap rewrites the Claude noreply address to \`shiqi wang <shiqi308@gmail.com>\` at display time only. Commit history, trailers, and all verifiable attribution are untouched.

## Effect
- \`/graphs/contributors\` — Claude disappears; the Claude commits' credit rolls into shiqi wang
- Per-commit \`Co-Authored-By:\` footer in the UI is unchanged (that's commit-message text; mailmap doesn't rewrite bodies)

## Test plan
- [ ] Check the Contributors page after merge — should show only human contributors