### PR TITLE
UI polish: sidebar default, hide chat on config/list pages, de-duplicate empty-state CTAs

### DIFF
--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -237,19 +237,19 @@ export default function Navigation() {
       || hasPermission('datasources:write')
       || hasPermission('datasources:create')
       || hasPermission('admin:write'));
-  // Default expanded on Home page, collapsed on others
-  const [expanded, setExpanded] = useState(location.pathname === '/');
+  // Default expanded, persisted across sessions. User's explicit toggle wins
+  // over any route-based behavior (we used to auto-collapse when leaving Home,
+  // which fought against users who preferred the expanded rail everywhere).
+  const [expanded, setExpanded] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    const saved = window.localStorage.getItem('openobs:sidebar-expanded');
+    return saved === null ? true : saved === '1';
+  });
 
-  // Auto-expand on Home, auto-collapse elsewhere (user can still toggle manually afterward)
-  const prevPathRef = useRef(location.pathname);
   useEffect(() => {
-    const prevWasHome = prevPathRef.current === '/';
-    const nowHome = location.pathname === '/';
-    if (prevWasHome !== nowHome) {
-      setExpanded(nowHome);
-    }
-    prevPathRef.current = location.pathname;
-  }, [location.pathname]);
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('openobs:sidebar-expanded', expanded ? '1' : '0');
+  }, [expanded]);
 
   const handleLogout = async () => {
     await logout();


### PR DESCRIPTION
## Summary
Six small UI polish commits landing together. All scoped to \`packages/web/src\`, no backend changes.

## Changes

### 1. Sidebar default-expanded + persist toggle (\`Navigation.tsx\`)
- Defaults to **expanded everywhere** (was: expanded only on Home, auto-collapsed everywhere else)
- User's explicit toggle is persisted in \`localStorage\` (\`openobs:sidebar-expanded\`)
- Route changes no longer override the user's choice

### 2. Hide the global ChatPanel on pages where it has no operational context (\`Layout.tsx\`)
| Path | Panel visible? |
|---|---|
| \`/\` (Home) | ❌ |
| \`/dashboards\` (list) | ❌ |
| \`/dashboards/:id\` (detail) | ✅ |
| \`/investigations\` (list) | ❌ |
| \`/investigations/:id\` (detail) | ✅ |
| \`/alerts\` (list) | ❌ |
| \`/settings\`, \`/settings/*\` | ❌ |
| \`/admin\`, \`/admin/*\` | ❌ |
| \`/feed\`, \`/actions\`, \`/evidence/:id\`, others | ✅ |

The list/config surfaces have no context for a free-form AI chat; detail pages do.

### 3. De-duplicate empty-state "create" CTAs
Both the page header (already gated on the relevant permission) and the empty state rendered the same create button. Kept the header one, dropped the duplicate:
- \`Investigations.tsx\` — "+ New Investigation" button removed from the empty state
- \`Settings.tsx\` (Datasources tab) — "Add data source" button removed from the empty state

Dashboards and Alerts already followed this pattern (Dashboards even had a comment explaining it); no change needed there.

## Commits
- \`68812e2\` Sidebar default expanded + localStorage persistence
- \`6cd50dd\` Layout: hide chat panel on Dashboards/Investigations/Alerts lists
- \`3448cd5\` Investigations: drop empty-state '+ New Investigation'
- \`932f04c\` Settings/Datasources: drop empty-state 'Add data source'
- \`02e362e\` Layout: also hide chat on Settings
- \`db64a16\` Layout: also hide chat on Admin

## Test plan
- [ ] CI green
- [ ] Sidebar: fresh browser → rail starts expanded; toggle → persists across reloads and navigation
- [ ] ChatPanel: navigate through each path in the table above; panel visibility matches
- [ ] Empty state: Investigations with 0 rows shows only the description, no big button; header \`+ New Investigation\` still works
- [ ] Empty state: Settings > Datasources with 0 rows shows only the description, no big button; header \`+ Add data source\` still works
- [ ] \`tsc --noEmit\` clean (verified locally)