### PR TITLE
UI polish + add CLAUDE.md

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -10,11 +10,15 @@ function LayoutInner() {
   const location = useLocation();
   const { events, isGenerating, sendMessage, stopGeneration, pendingNavigation, clearPendingNavigation } = useGlobalChat();
 
-  // Hide the global ChatPanel on Home and on the top-level list pages
-  // (Dashboards / Investigations / Alerts). Detail pages keep the panel
-  // because that's where a context-specific chat is actually useful.
-  const CHAT_HIDDEN_PATHS = new Set(['/', '/dashboards', '/investigations', '/alerts']);
-  const showChat = !CHAT_HIDDEN_PATHS.has(location.pathname);
+  // Hide the global ChatPanel on Home, the top-level list pages
+  // (Dashboards / Investigations / Alerts), and Settings. Detail pages
+  // keep the panel because that's where a context-specific chat is
+  // actually useful.
+  const pathname = location.pathname;
+  const chatHiddenExact = new Set(['/', '/dashboards', '/investigations', '/alerts']);
+  const showChat =
+    !chatHiddenExact.has(pathname)
+    && !(pathname === '/settings' || pathname.startsWith('/settings/'));
 
   // Handle agent-initiated navigation
   useEffect(() => {

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -11,14 +11,15 @@ function LayoutInner() {
   const { events, isGenerating, sendMessage, stopGeneration, pendingNavigation, clearPendingNavigation } = useGlobalChat();
 
   // Hide the global ChatPanel on Home, the top-level list pages
-  // (Dashboards / Investigations / Alerts), and Settings. Detail pages
-  // keep the panel because that's where a context-specific chat is
-  // actually useful.
+  // (Dashboards / Investigations / Alerts), and configuration surfaces
+  // (Settings, Admin). Detail pages keep the panel because that's
+  // where a context-specific chat is actually useful.
   const pathname = location.pathname;
   const chatHiddenExact = new Set(['/', '/dashboards', '/investigations', '/alerts']);
+  const chatHiddenPrefix = ['/settings', '/admin'];
   const showChat =
     !chatHiddenExact.has(pathname)
-    && !(pathname === '/settings' || pathname.startsWith('/settings/'));
+    && !chatHiddenPrefix.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
   // Handle agent-initiated navigation
   useEffect(() => {

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -10,7 +10,11 @@ function LayoutInner() {
   const location = useLocation();
   const { events, isGenerating, sendMessage, stopGeneration, pendingNavigation, clearPendingNavigation } = useGlobalChat();
 
-  const isHome = location.pathname === '/';
+  // Hide the global ChatPanel on Home and on the top-level list pages
+  // (Dashboards / Investigations / Alerts). Detail pages keep the panel
+  // because that's where a context-specific chat is actually useful.
+  const CHAT_HIDDEN_PATHS = new Set(['/', '/dashboards', '/investigations', '/alerts']);
+  const showChat = !CHAT_HIDDEN_PATHS.has(location.pathname);
 
   // Handle agent-initiated navigation
   useEffect(() => {
@@ -26,7 +30,7 @@ function LayoutInner() {
       <main className="flex-1 overflow-y-auto bg-surface-lowest">
         <Outlet />
       </main>
-      {!isHome && (
+      {showChat && (
         <ChatPanel
           events={events}
           isGenerating={isGenerating}

--- a/packages/web/src/pages/Investigations.tsx
+++ b/packages/web/src/pages/Investigations.tsx
@@ -160,16 +160,7 @@ export default function Investigations() {
               </svg>
             </div>
             <p className="mb-1 text-sm text-on-surface-variant">No investigations yet</p>
-            <p className="mb-4 text-xs text-[var(--color-outline)]">Start an investigation to diagnose production issues with AI</p>
-            {canCreateInvestigation && (
-              <button
-                type="button"
-                onClick={() => navigate('/')}
-                className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-on-primary-fixed"
-              >
-                + New Investigation
-              </button>
-            )}
+            <p className="text-xs text-[var(--color-outline)]">Start an investigation to diagnose production issues with AI</p>
           </div>
         )}
 

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -300,10 +300,7 @@ function DataSourcesTab({ canCreate, canWrite, canDelete }: { canCreate: boolean
             </svg>
           </div>
           <p className="text-sm text-[var(--color-on-surface-variant)] mb-1">No data sources yet</p>
-          <p className="text-xs text-[var(--color-outline)] mb-4">Add Prometheus, Loki, or another source to get started</p>
-          {canCreate && (
-            <button type="button" onClick={() => setShowAddForm(true)} className={btnPrimary}>Add data source</button>
-          )}
+          <p className="text-xs text-[var(--color-outline)]">Add Prometheus, Loki, or another source to get started</p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Follow-up UX polish to PR #4, plus a new repo-wide LLM behavioral guidelines file.

## Changes

### 1. Hide the global ChatPanel on pages with no operational context (\`Layout.tsx\`)
| Path | Panel visible? |
|---|---|
| \`/\` (Home) | ❌ (unchanged) |
| \`/dashboards\` (list) | ❌ |
| \`/dashboards/:id\` (detail) | ✅ (unchanged) |
| \`/investigations\` (list) | ❌ |
| \`/investigations/:id\` (detail) | ✅ (unchanged) |
| \`/alerts\` (list) | ❌ |
| \`/settings\`, \`/settings/*\` | ❌ |
| \`/admin\`, \`/admin/*\` | ❌ |
| \`/feed\`, \`/actions\`, \`/evidence/:id\`, etc. | ✅ (unchanged) |

### 2. De-duplicate empty-state "create" CTAs
- \`Investigations.tsx\` — "+ New Investigation" button removed from empty state (header button kept)
- \`Settings.tsx\` Datasources tab — "Add data source" button removed from empty state (header button kept)

### 3. Add \`CLAUDE.md\` repo-wide LLM guidelines
Four principles for Claude / LLM coding assistants working in this repo: think before coding, simplicity first, surgical changes, goal-driven execution. Claude Code reads this automatically; other tools can reference it manually.

## Commits
- \`6cd50dd\` Layout: hide chat panel on Dashboards/Investigations/Alerts lists
- \`3448cd5\` Investigations: drop empty-state '+ New Investigation'
- \`932f04c\` Settings/Datasources: drop empty-state 'Add data source'
- \`02e362e\` Layout: also hide chat on Settings
- \`db64a16\` Layout: also hide chat on Admin
- \`8123573\` Add CLAUDE.md with repo-wide LLM behavioral guidelines

## Test plan
- [ ] CI green
- [ ] ChatPanel visibility matches the table above
- [ ] Investigations / Datasources empty states render without the duplicate button