### PR TITLE
Agent source-agnostic refactor (metrics/logs/changes via AdapterRegistry) + token-budget loop

### DIFF
--- a/docs/tech-debt-progress.md
+++ b/docs/tech-debt-progress.md
@@ -1,4 +1,4 @@
-# Tech-debt cleanup — progress snapshot (2026-04-22)
+# Tech-debt cleanup — progress snapshot (2026-04-23)
 
 Multi-wave cleanup driven by audit at [tech-debt-audit-plan.md](./tech-debt-audit-plan.md),
 plus a follow-up sprint on permissions / UX surfaced by manual smoke test.
@@ -20,6 +20,23 @@ plus a follow-up sprint on permissions / UX surfaced by manual smoke test.
 - See "W6 verification + follow-up" at the bottom before merging to main.
 
 ## Commit history (newest first, since the original doc)
+
+### Agent source-agnostic wave — metrics/logs/changes via AdapterRegistry (2026-04-23)
+
+Driven by the AI Ops audit: the orchestrator was Prometheus-only (8 hardcoded `prometheus.*` tools + one `ctx.metricsAdapter`), even though the underlying adapter layer was already signal-agnostic by design. This wave wires the agent through a multi-source registry so the same code path serves any backend the user configures.
+
+- **`T-adapt-A+D`** — new adapter interfaces (`ILogsAdapter`, `IChangesAdapter`) + `AdapterRegistry` with typed per-signal accessors in `packages/agent-core/src/adapters/`; 9 new registry tests. Frontend `TOOL_LABELS` + `phaseOf` updated for the new tool names (mirrors the old `prometheus.*` phase mapping 1:1).
+- **`T-adapt-B`** — `LokiLogsAdapter` over `/loki/api/v1/query_range` + labels. BigInt-based nanosecond timestamp handling, AbortSignal timeouts, 12 HTTP-mocked tests.
+- **`T-adapt-C`** — orchestrator refactor: 8 `prometheus.*` tools renamed to `metrics.*` (each now takes `sourceId`); 5 new tool families (`logs.query` / `logs.labels` / `logs.label_values` / `changes.list_recent` / `datasources.list`); `ActionContext.metricsAdapter` removed and replaced with `adapters: AdapterRegistry`. System prompt rewritten to lead with `datasources.list` + explicit `sourceId`.
+- **`T-adapt-wiring`** — `packages/api-gateway/src/services/dashboard-service.ts` now exports `buildAdapterRegistry(datasources)` that iterates every configured source and instantiates the right adapter class per type (Prom / VictoriaMetrics → metrics; Loki → logs). `chat-service.ts` and `dashboard-service.ts` both call it and pass `adapters` to the orchestrator. Loki flipped from `supported: false` → `true` in the Settings datasource-type picker.
+- **Token-budget loop termination** (same commit) — addresses the "30-iter hard cap" item from the agent audit:
+  - `MAX_ITERATIONS` 30 → 200 (safety ceiling only, not the normal terminator)
+  - NEW token-budget check each turn: if estimated messages > 95% of `CONTEXT_WINDOW`, exit gracefully with an honest "ran out of budget, here's where I am" reply
+  - Iteration-ceiling fallback message rewritten — no more dishonest "I have completed the requested changes"
+
+Tests: **1143 passed / 16 skipped / 0 failed** (baseline 1120, +23 new). `npx tsc --build` clean across all packages.
+
+Out of scope, tracked as follow-ups: native Anthropic tool_use API (replace `responseFormat: 'json'`), extended thinking (`thinking` param), multi-tool-per-turn, traces adapter.
 
 ### W6 — in-memory stores → SQLite + remaining follow-ups (2026-04-22)
 

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -29,5 +29,6 @@ export type { ChangeEventAdapterConfig, ChangeQuery, WebhookPayload,
 export { ChangeEventStore, normalizeWebhook } from './change-event/index.js';
 
 export * from './prometheus/index.js';
+export * from './loki/index.js';
 export * from './execution/index.js';
 export * from './web-search/index.js';

--- a/packages/adapters/src/loki/index.ts
+++ b/packages/adapters/src/loki/index.ts
@@ -1,0 +1,6 @@
+export { LokiLogsAdapter } from './logs-adapter.js';
+export type {
+  LogEntry,
+  LogsQueryInput,
+  LogsQueryResult,
+} from './logs-adapter.js';

--- a/packages/adapters/src/loki/logs-adapter.test.ts
+++ b/packages/adapters/src/loki/logs-adapter.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for LokiLogsAdapter.
+ *
+ * We stub globalThis.fetch with a vi.fn so the adapter calls are exercised
+ * without a live Loki. Each test inspects the URL/headers the adapter sent
+ * and returns a canned Response (or throws to simulate AbortSignal timeout).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { LokiLogsAdapter } from './logs-adapter.js';
+
+type FetchArgs = [url: string, init?: RequestInit];
+
+function makeResponse(
+  body: unknown,
+  init: { status?: number; contentType?: string } = {},
+): Response {
+  const status = init.status ?? 200;
+  const headers = new Headers({
+    'content-type': init.contentType ?? 'application/json',
+  });
+  const bodyInit =
+    body === undefined
+      ? null
+      : typeof body === 'string'
+        ? body
+        : JSON.stringify(body);
+  return new Response(bodyInit, { status, headers });
+}
+
+function mockFetch(impl: (...args: FetchArgs) => Promise<Response>) {
+  const spy = vi.fn(impl);
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+describe('LokiLogsAdapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('query()', () => {
+    it('parses streams, flattens entries, converts ns → ISO-8601', async () => {
+      // 2024-01-01T00:00:00.000Z == 1704067200000ms == 1704067200000000000ns
+      const ns1 = '1704067200000000000';
+      const ns2 = '1704067260000000000'; // +60s
+      const spy = mockFetch(async () =>
+        makeResponse({
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [
+              {
+                stream: { app: 'api', level: 'info' },
+                values: [
+                  [ns1, 'hello'],
+                  [ns2, 'world'],
+                ],
+              },
+              {
+                stream: { app: 'db' },
+                values: [[ns1, 'db up']],
+              },
+            ],
+          },
+        }),
+      );
+
+      const adapter = new LokiLogsAdapter('http://loki:3100', {
+        'X-Scope-OrgID': 'tenant-a',
+      });
+      const result = await adapter.query({
+        query: '{app="api"}',
+        start: new Date('2024-01-01T00:00:00Z'),
+        end: new Date('2024-01-01T01:00:00Z'),
+      });
+
+      expect(result.entries).toHaveLength(3);
+      // backward direction ⇒ newest first after sort
+      expect(result.entries[0]).toEqual({
+        timestamp: '2024-01-01T00:01:00.000Z',
+        message: 'world',
+        labels: { app: 'api', level: 'info' },
+      });
+      // Ties broken by insertion order is fine; both must have correct ISO
+      const secondThird = [result.entries[1], result.entries[2]];
+      expect(secondThird.every((e) => e.timestamp === '2024-01-01T00:00:00.000Z')).toBe(true);
+      const msgs = secondThird.map((e) => e.message).sort();
+      expect(msgs).toEqual(['db up', 'hello']);
+      expect(result.partial).toBe(false);
+      expect(result.warnings).toBeUndefined();
+
+      // Verify URL parts
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [url, init] = spy.mock.calls[0] as FetchArgs;
+      expect(url).toContain('http://loki:3100/loki/api/v1/query_range?');
+      expect(url).toContain('query=%7Bapp%3D%22api%22%7D'); // {app="api"} encoded
+      expect(url).toContain(`start=${ns1}`);
+      expect(url).toContain('limit=100');
+      expect(url).toContain('direction=backward');
+      expect(init?.headers).toEqual({ 'X-Scope-OrgID': 'tenant-a' });
+    });
+
+    it('throws on non-2xx HTTP response with status + body preview', async () => {
+      mockFetch(async () =>
+        makeResponse('parse error: unexpected token', {
+          status: 400,
+          contentType: 'text/plain',
+        }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await expect(
+        adapter.query({
+          query: 'invalid-logql',
+          start: new Date('2024-01-01T00:00:00Z'),
+          end: new Date('2024-01-01T00:05:00Z'),
+        }),
+      ).rejects.toThrow(/HTTP 400.*parse error/);
+    });
+
+    it('forwards custom limit in the request', async () => {
+      const spy = mockFetch(async () =>
+        makeResponse({
+          status: 'success',
+          data: { resultType: 'streams', result: [] },
+        }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await adapter.query({
+        query: '{app="api"}',
+        start: new Date('2024-01-01T00:00:00Z'),
+        end: new Date('2024-01-01T00:05:00Z'),
+        limit: 500,
+      });
+      const [url] = spy.mock.calls[0] as FetchArgs;
+      expect(url).toContain('limit=500');
+    });
+
+    it('marks partial=true when returned entry count reaches limit', async () => {
+      const ns = '1704067200000000000';
+      mockFetch(async () =>
+        makeResponse({
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [
+              {
+                stream: { app: 'api' },
+                values: [
+                  [ns, 'a'],
+                  [ns, 'b'],
+                ],
+              },
+            ],
+          },
+        }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      const result = await adapter.query({
+        query: '{app="api"}',
+        start: new Date('2024-01-01T00:00:00Z'),
+        end: new Date('2024-01-01T00:05:00Z'),
+        limit: 2,
+      });
+      expect(result.entries).toHaveLength(2);
+      expect(result.partial).toBe(true);
+    });
+
+    it('surfaces a warning when resultType is matrix (metric LogQL)', async () => {
+      mockFetch(async () =>
+        makeResponse({
+          status: 'success',
+          data: {
+            resultType: 'matrix',
+            result: [{ metric: { app: 'api' }, values: [[1704067200, '5']] }],
+          },
+        }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      const result = await adapter.query({
+        query: 'rate({app="api"}[5m])',
+        start: new Date('2024-01-01T00:00:00Z'),
+        end: new Date('2024-01-01T00:05:00Z'),
+      });
+      expect(result.entries).toEqual([]);
+      expect(result.partial).toBe(true);
+      expect(result.warnings?.[0]).toMatch(/matrix/);
+    });
+  });
+
+  describe('listLabels()', () => {
+    it('returns the label list', async () => {
+      const spy = mockFetch(async () =>
+        makeResponse({ status: 'success', data: ['app', 'service', 'level'] }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      const labels = await adapter.listLabels();
+      expect(labels).toEqual(['app', 'service', 'level']);
+      const [url] = spy.mock.calls[0] as FetchArgs;
+      expect(url).toBe('http://loki:3100/loki/api/v1/labels');
+    });
+
+    it('throws on HTTP error', async () => {
+      mockFetch(async () => makeResponse('boom', { status: 500, contentType: 'text/plain' }));
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await expect(adapter.listLabels()).rejects.toThrow(/HTTP 500.*boom/);
+    });
+  });
+
+  describe('listLabelValues()', () => {
+    it('URL-encodes the label name', async () => {
+      const spy = mockFetch(async () =>
+        makeResponse({ status: 'success', data: ['nginx', 'api'] }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      const values = await adapter.listLabelValues('app/name');
+      expect(values).toEqual(['nginx', 'api']);
+      const [url] = spy.mock.calls[0] as FetchArgs;
+      expect(url).toBe(
+        `http://loki:3100/loki/api/v1/label/${encodeURIComponent('app/name')}/values`,
+      );
+    });
+  });
+
+  describe('isHealthy()', () => {
+    it('returns true when /ready is 200 and body contains "ready"', async () => {
+      mockFetch(async () =>
+        makeResponse('ready\n', { status: 200, contentType: 'text/plain' }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await expect(adapter.isHealthy()).resolves.toBe(true);
+    });
+
+    it('returns false when /ready returns a non-200', async () => {
+      mockFetch(async () =>
+        makeResponse('starting', { status: 503, contentType: 'text/plain' }),
+      );
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await expect(adapter.isHealthy()).resolves.toBe(false);
+    });
+
+    it('returns false when fetch throws (never throws itself)', async () => {
+      mockFetch(async () => {
+        throw new Error('ECONNREFUSED');
+      });
+      const adapter = new LokiLogsAdapter('http://loki:3100');
+      await expect(adapter.isHealthy()).resolves.toBe(false);
+    });
+  });
+
+  describe('timeout behavior', () => {
+    it('wraps AbortError from AbortSignal.timeout with a meaningful message', async () => {
+      // Simulate what fetch() does when AbortSignal.timeout trips: it rejects with
+      // a DOMException named "TimeoutError" (or AbortError depending on runtime).
+      mockFetch(async () => {
+        const err = new Error('The operation was aborted due to timeout');
+        err.name = 'TimeoutError';
+        throw err;
+      });
+      const adapter = new LokiLogsAdapter('http://loki:3100', {}, 10);
+      await expect(
+        adapter.query({
+          query: '{app="api"}',
+          start: new Date('2024-01-01T00:00:00Z'),
+          end: new Date('2024-01-01T00:05:00Z'),
+        }),
+      ).rejects.toThrow(/query_range request failed.*timeout/);
+    });
+  });
+});

--- a/packages/adapters/src/loki/logs-adapter.test.ts
+++ b/packages/adapters/src/loki/logs-adapter.test.ts
@@ -84,7 +84,7 @@ describe('LokiLogsAdapter', () => {
         labels: { app: 'api', level: 'info' },
       });
       // Ties broken by insertion order is fine; both must have correct ISO
-      const secondThird = [result.entries[1], result.entries[2]];
+      const secondThird = [result.entries[1]!, result.entries[2]!];
       expect(secondThird.every((e) => e.timestamp === '2024-01-01T00:00:00.000Z')).toBe(true);
       const msgs = secondThird.map((e) => e.message).sort();
       expect(msgs).toEqual(['db up', 'hello']);

--- a/packages/adapters/src/loki/logs-adapter.ts
+++ b/packages/adapters/src/loki/logs-adapter.ts
@@ -1,0 +1,212 @@
+// Types are structurally compatible with ILogsAdapter from @agentic-obs/agent-core.
+// We avoid importing from agent-core directly to prevent a circular package dependency.
+
+import { getErrorMessage } from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/common/logging';
+
+const log = createLogger('loki-logs-adapter');
+
+export interface LogEntry {
+  timestamp: string; // ISO-8601
+  message: string;
+  labels: Record<string, string>;
+}
+
+export interface LogsQueryInput {
+  query: string; // LogQL
+  start: Date;
+  end: Date;
+  limit?: number; // default 100
+}
+
+export interface LogsQueryResult {
+  entries: LogEntry[];
+  partial: boolean;
+  warnings?: string[];
+}
+
+interface LokiStream {
+  stream: Record<string, string>;
+  values: Array<[string, string]>; // [nanoseconds-as-string, message]
+}
+
+interface LokiQueryRangeResponse {
+  status?: string;
+  data?: {
+    resultType?: string;
+    result?: LokiStream[] | unknown[];
+    stats?: unknown;
+  };
+  warnings?: string[];
+}
+
+interface LokiListResponse {
+  status?: string;
+  data?: string[];
+}
+
+const DEFAULT_LIMIT = 100;
+
+export class LokiLogsAdapter {
+  constructor(
+    private baseUrl: string,
+    private headers: Record<string, string> = {},
+    private timeoutMs = 15_000,
+  ) {}
+
+  async query(input: LogsQueryInput): Promise<LogsQueryResult> {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const params = new URLSearchParams();
+    params.set('query', input.query);
+    params.set('start', String(toNanoseconds(input.start)));
+    params.set('end', String(toNanoseconds(input.end)));
+    params.set('limit', String(limit));
+    params.set('direction', 'backward');
+
+    const url = `${this.base}/loki/api/v1/query_range?${params}`;
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      throw new Error(`Loki query_range request failed: ${getErrorMessage(err)}`);
+    }
+
+    if (!res.ok) {
+      const preview = await readBodyPreview(res);
+      throw new Error(
+        `Loki returned HTTP ${res.status} for query_range: ${preview}`,
+      );
+    }
+
+    const body = (await res.json()) as LokiQueryRangeResponse;
+    const resultType = body.data?.resultType ?? 'streams';
+    const warnings: string[] = Array.isArray(body.warnings) ? [...body.warnings] : [];
+
+    if (resultType !== 'streams') {
+      // Matrix result types come from metric-style LogQL (rate, count_over_time, etc).
+      // We only flatten "streams"; surface a warning for anything else so callers can
+      // re-query or render differently, rather than silently dropping data.
+      warnings.push(
+        `Unsupported Loki resultType "${resultType}"; LokiLogsAdapter only flattens "streams".`,
+      );
+      return {
+        entries: [],
+        partial: true,
+        warnings,
+      };
+    }
+
+    const rawResult = body.data?.result;
+    const streams = (Array.isArray(rawResult) ? rawResult : []) as LokiStream[];
+    const entries: LogEntry[] = [];
+    for (const s of streams) {
+      const labels = s.stream ?? {};
+      const values = Array.isArray(s.values) ? s.values : [];
+      for (const v of values) {
+        if (!Array.isArray(v) || v.length < 2) continue;
+        const [ns, message] = v;
+        entries.push({
+          timestamp: nsToIso(ns),
+          message: typeof message === 'string' ? message : String(message ?? ''),
+          labels: { ...labels },
+        });
+      }
+    }
+
+    // Loki sort order is per-stream. Re-sort globally so callers (and humans eyeballing
+    // the feed) get a monotonic timeline across streams. "backward" direction ⇒ desc.
+    entries.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+
+    const partial = entries.length >= limit;
+    const result: LogsQueryResult = { entries, partial };
+    if (warnings.length > 0) result.warnings = warnings;
+    return result;
+  }
+
+  async listLabels(): Promise<string[]> {
+    const url = `${this.base}/loki/api/v1/labels`;
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      throw new Error(`Loki labels request failed: ${getErrorMessage(err)}`);
+    }
+    if (!res.ok) {
+      const preview = await readBodyPreview(res);
+      throw new Error(`Loki returned HTTP ${res.status} fetching labels: ${preview}`);
+    }
+    const body = (await res.json()) as LokiListResponse;
+    return Array.isArray(body.data) ? body.data : [];
+  }
+
+  async listLabelValues(label: string): Promise<string[]> {
+    const url = `${this.base}/loki/api/v1/label/${encodeURIComponent(label)}/values`;
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      throw new Error(`Loki label values request failed: ${getErrorMessage(err)}`);
+    }
+    if (!res.ok) {
+      const preview = await readBodyPreview(res);
+      throw new Error(
+        `Loki returned HTTP ${res.status} fetching label values for "${label}": ${preview}`,
+      );
+    }
+    const body = (await res.json()) as LokiListResponse;
+    return Array.isArray(body.data) ? body.data : [];
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const res = await this.fetch(`${this.base}/ready`, 5_000);
+      if (res.status !== 200) return false;
+      const text = await res.text();
+      return text.toLowerCase().includes('ready');
+    } catch (err) {
+      log.debug({ err, baseUrl: this.base }, 'loki health check failed');
+      return false;
+    }
+  }
+
+  private get base(): string {
+    return this.baseUrl.replace(/\/$/, '');
+  }
+
+  private fetch(url: string, timeoutMs?: number): Promise<Response> {
+    return fetch(url, {
+      headers: this.headers,
+      signal: AbortSignal.timeout(timeoutMs ?? this.timeoutMs),
+    });
+  }
+}
+
+function toNanoseconds(d: Date): bigint {
+  // Date has millisecond precision; Loki requires ns. Multiply in BigInt so
+  // we can render the 19-digit integer without float precision loss.
+  return BigInt(d.getTime()) * 1_000_000n;
+}
+
+function nsToIso(ns: string | number): string {
+  // Values come back as strings (19-digit ns). Truncate to ms for JS Date.
+  if (typeof ns === 'number') {
+    return new Date(Math.floor(ns / 1_000_000)).toISOString();
+  }
+  if (typeof ns === 'string' && /^\d+$/.test(ns)) {
+    const big = BigInt(ns);
+    const ms = Number(big / 1_000_000n);
+    return new Date(ms).toISOString();
+  }
+  // Fallback — let Date parse it and surface "Invalid Date" rather than crash.
+  const d = new Date(ns as string);
+  return Number.isNaN(d.getTime()) ? new Date(0).toISOString() : d.toISOString();
+}
+
+async function readBodyPreview(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    return text.slice(0, 200);
+  } catch {
+    return '<no body>';
+  }
+}

--- a/packages/agent-core/src/adapters/changes-adapter.ts
+++ b/packages/agent-core/src/adapters/changes-adapter.ts
@@ -1,0 +1,37 @@
+/**
+ * Source-agnostic change-event adapter interface.
+ *
+ * A "change" is anything that may explain a metric/log anomaly: deploys,
+ * config rollouts, feature-flag flips, manually logged incidents, etc.
+ * Concrete implementations live outside agent-core (e.g. the existing
+ * change-event adapter in @agentic-obs/adapters, future Argo/GitHub/Statuspage
+ * adapters, etc.).
+ */
+
+export type ChangeKind =
+  | 'deploy'
+  | 'config'
+  | 'feature-flag'
+  | 'incident'
+  | 'other';
+
+export interface ChangeRecord {
+  id: string;
+  service: string;
+  kind: ChangeKind;
+  summary: string;
+  /** ISO-8601 timestamp when the change took effect. */
+  at: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ChangesListInput {
+  /** Optional service filter. Omit to fetch across all services. */
+  service?: string;
+  /** Look back this many minutes from now. */
+  windowMinutes: number;
+}
+
+export interface IChangesAdapter {
+  listRecent(input: ChangesListInput): Promise<ChangeRecord[]>;
+}

--- a/packages/agent-core/src/adapters/index.ts
+++ b/packages/agent-core/src/adapters/index.ts
@@ -1,2 +1,20 @@
 export type { IWebSearchAdapter, WebSearchResult } from './web-search-adapter.js';
 export type { IMetricsAdapter, MetricSample, MetricMetadata, RangeResult } from './metrics-adapter.js';
+export type {
+  ILogsAdapter,
+  LogEntry,
+  LogsQueryInput,
+  LogsQueryResult,
+} from './logs-adapter.js';
+export type {
+  IChangesAdapter,
+  ChangeKind,
+  ChangeRecord,
+  ChangesListInput,
+} from './changes-adapter.js';
+export type {
+  AdapterEntry,
+  DatasourceInfo,
+  SignalType,
+} from './registry.js';
+export { AdapterRegistry } from './registry.js';

--- a/packages/agent-core/src/adapters/logs-adapter.ts
+++ b/packages/agent-core/src/adapters/logs-adapter.ts
@@ -1,0 +1,38 @@
+/**
+ * Source-agnostic logs adapter interface.
+ *
+ * Backends (Loki, Elasticsearch, CloudWatch Logs, etc.) implement this in
+ * package @agentic-obs/adapters. The `query` field is intentionally
+ * backend-native (e.g. LogQL for Loki, ES query DSL for Elasticsearch) —
+ * translation, if any, happens above this layer.
+ */
+
+export interface LogEntry {
+  /** ISO-8601 timestamp of the log line. */
+  timestamp: string;
+  message: string;
+  labels: Record<string, string>;
+}
+
+export interface LogsQueryInput {
+  /** Backend-native query string (LogQL for Loki, etc.). */
+  query: string;
+  start: Date;
+  end: Date;
+  /** Maximum entries to return. Adapter default: 100. */
+  limit?: number;
+}
+
+export interface LogsQueryResult {
+  entries: LogEntry[];
+  /** True when the backend indicated the result set was truncated. */
+  partial: boolean;
+  warnings?: string[];
+}
+
+export interface ILogsAdapter {
+  query(input: LogsQueryInput): Promise<LogsQueryResult>;
+  listLabels(): Promise<string[]>;
+  listLabelValues(label: string): Promise<string[]>;
+  isHealthy(): Promise<boolean>;
+}

--- a/packages/agent-core/src/adapters/registry.test.ts
+++ b/packages/agent-core/src/adapters/registry.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { AdapterRegistry, type AdapterEntry } from './registry.js';
+import type { IMetricsAdapter } from './metrics-adapter.js';
+import type { ILogsAdapter } from './logs-adapter.js';
+import type { IChangesAdapter } from './changes-adapter.js';
+
+/**
+ * Minimal stubs — we don't test adapter behavior here, only that the
+ * registry hands back the right instance.
+ */
+const metricsStub: IMetricsAdapter = {
+  listMetricNames: async () => [],
+  listLabels: async () => [],
+  listLabelValues: async () => [],
+  findSeries: async () => [],
+  fetchMetadata: async () => ({}),
+  instantQuery: async () => [],
+  rangeQuery: async () => [],
+  testQuery: async () => ({ ok: true }),
+  isHealthy: async () => true,
+};
+
+const logsStub: ILogsAdapter = {
+  query: async () => ({ entries: [], partial: false }),
+  listLabels: async () => [],
+  listLabelValues: async () => [],
+  isHealthy: async () => true,
+};
+
+const changesStub: IChangesAdapter = {
+  listRecent: async () => [],
+};
+
+function metricsEntry(id: string, name: string): AdapterEntry {
+  return {
+    info: { id, name, type: 'prometheus', signalType: 'metrics' },
+    metrics: metricsStub,
+  };
+}
+
+function logsEntry(id: string, name: string): AdapterEntry {
+  return {
+    info: { id, name, type: 'loki', signalType: 'logs' },
+    logs: logsStub,
+  };
+}
+
+function changesEntry(id: string, name: string): AdapterEntry {
+  return {
+    info: { id, name, type: 'change-event', signalType: 'changes' },
+    changes: changesStub,
+  };
+}
+
+describe('AdapterRegistry', () => {
+  it('register + get round-trip returns the same entry', () => {
+    const r = new AdapterRegistry();
+    const entry = metricsEntry('prom-1', 'Prod Prometheus');
+    r.register(entry);
+    expect(r.get('prom-1')).toBe(entry);
+  });
+
+  it('get returns undefined for missing sourceId', () => {
+    const r = new AdapterRegistry();
+    expect(r.get('nope')).toBeUndefined();
+  });
+
+  it('list() without filter returns all info sorted by name', () => {
+    const r = new AdapterRegistry();
+    r.register(metricsEntry('b', 'Beta'));
+    r.register(metricsEntry('a', 'Alpha'));
+    r.register(logsEntry('c', 'Charlie'));
+
+    const names = r.list().map((d) => d.name);
+    expect(names).toEqual(['Alpha', 'Beta', 'Charlie']);
+  });
+
+  it('list({ signalType }) filters by signal type', () => {
+    const r = new AdapterRegistry();
+    r.register(metricsEntry('m1', 'Metrics One'));
+    r.register(logsEntry('l1', 'Logs One'));
+    r.register(changesEntry('ch1', 'Changes One'));
+
+    const metricsOnly = r.list({ signalType: 'metrics' });
+    expect(metricsOnly.map((d) => d.id)).toEqual(['m1']);
+
+    const logsOnly = r.list({ signalType: 'logs' });
+    expect(logsOnly.map((d) => d.id)).toEqual(['l1']);
+
+    const changesOnly = r.list({ signalType: 'changes' });
+    expect(changesOnly.map((d) => d.id)).toEqual(['ch1']);
+  });
+
+  it('list() returns empty array when registry empty', () => {
+    const r = new AdapterRegistry();
+    expect(r.list()).toEqual([]);
+    expect(r.list({ signalType: 'metrics' })).toEqual([]);
+  });
+
+  it('typed accessors return the correct adapter instance', () => {
+    const r = new AdapterRegistry();
+    r.register(metricsEntry('m1', 'M1'));
+    r.register(logsEntry('l1', 'L1'));
+    r.register(changesEntry('ch1', 'Ch1'));
+
+    expect(r.metrics('m1')).toBe(metricsStub);
+    expect(r.logs('l1')).toBe(logsStub);
+    expect(r.changes('ch1')).toBe(changesStub);
+  });
+
+  it('typed accessors return undefined when sourceId points at wrong signal type', () => {
+    const r = new AdapterRegistry();
+    r.register(metricsEntry('m1', 'M1'));
+    r.register(logsEntry('l1', 'L1'));
+
+    expect(r.logs('m1')).toBeUndefined();
+    expect(r.changes('m1')).toBeUndefined();
+    expect(r.metrics('l1')).toBeUndefined();
+    expect(r.changes('l1')).toBeUndefined();
+  });
+
+  it('typed accessors return undefined when sourceId is unknown', () => {
+    const r = new AdapterRegistry();
+    expect(r.metrics('missing')).toBeUndefined();
+    expect(r.logs('missing')).toBeUndefined();
+    expect(r.changes('missing')).toBeUndefined();
+  });
+
+  it('register throws when the same sourceId is registered twice', () => {
+    const r = new AdapterRegistry();
+    r.register(metricsEntry('dup', 'Dup'));
+    expect(() => r.register(metricsEntry('dup', 'Dup Again'))).toThrow(
+      /already registered/,
+    );
+  });
+});

--- a/packages/agent-core/src/adapters/registry.ts
+++ b/packages/agent-core/src/adapters/registry.ts
@@ -1,0 +1,93 @@
+/**
+ * In-process AdapterRegistry: a simple Map wrapper that holds adapter
+ * instances keyed by a caller-chosen `sourceId`, grouped by signal type.
+ *
+ * This registry is purely synchronous data — no network, no health checks,
+ * no lifecycle. Wiring (construct concrete adapters, call register, run
+ * health checks) is the parent app's responsibility.
+ *
+ * Note: there is an unrelated `AdapterRegistry` class in
+ * @agentic-obs/adapters that wraps the old `DataAdapter` abstraction.
+ * They coexist without import collisions; Phase 2 will decide which one
+ * survives.
+ */
+
+import type { IMetricsAdapter } from './metrics-adapter.js';
+import type { ILogsAdapter } from './logs-adapter.js';
+import type { IChangesAdapter } from './changes-adapter.js';
+
+export type SignalType = 'metrics' | 'logs' | 'changes';
+
+export interface DatasourceInfo {
+  id: string;
+  name: string;
+  /** Concrete backend identifier, e.g. 'prometheus' | 'victoria-metrics' | 'loki' | 'change-event'. */
+  type: string;
+  url?: string;
+  signalType: SignalType;
+  isDefault?: boolean;
+}
+
+export interface AdapterEntry {
+  info: DatasourceInfo;
+  metrics?: IMetricsAdapter;
+  logs?: ILogsAdapter;
+  changes?: IChangesAdapter;
+}
+
+export class AdapterRegistry {
+  private readonly entries = new Map<string, AdapterEntry>();
+
+  /**
+   * Register a new datasource. Throws if `entry.info.id` is already registered.
+   */
+  register(entry: AdapterEntry): void {
+    const id = entry.info.id;
+    if (this.entries.has(id)) {
+      throw new Error(`Datasource '${id}' is already registered`);
+    }
+    this.entries.set(id, entry);
+  }
+
+  get(sourceId: string): AdapterEntry | undefined {
+    return this.entries.get(sourceId);
+  }
+
+  /**
+   * List registered DatasourceInfo values, sorted by `name` (ascending,
+   * locale-agnostic). Optionally filter by signal type.
+   */
+  list(filter?: { signalType?: SignalType }): DatasourceInfo[] {
+    const infos: DatasourceInfo[] = [];
+    for (const entry of this.entries.values()) {
+      if (filter?.signalType && entry.info.signalType !== filter.signalType) {
+        continue;
+      }
+      infos.push(entry.info);
+    }
+    infos.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return infos;
+  }
+
+  /**
+   * Return the metrics adapter for `sourceId`, or undefined if the source
+   * isn't registered or isn't a metrics source.
+   */
+  metrics(sourceId: string): IMetricsAdapter | undefined {
+    const entry = this.entries.get(sourceId);
+    if (!entry || entry.info.signalType !== 'metrics') return undefined;
+    return entry.metrics;
+  }
+
+  logs(sourceId: string): ILogsAdapter | undefined {
+    const entry = this.entries.get(sourceId);
+    if (!entry || entry.info.signalType !== 'logs') return undefined;
+    return entry.logs;
+  }
+
+  changes(sourceId: string): IChangesAdapter | undefined {
+    const entry = this.entries.get(sourceId);
+    if (!entry || entry.info.signalType !== 'changes') return undefined;
+    return entry.changes;
+  }
+}

--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -37,9 +37,15 @@ agentRegistry.register({
     'investigation.create', 'investigation.list',
     'investigation.add_section',
     'investigation.complete',
-    // Prometheus primitives
-    'prometheus.query', 'prometheus.range_query', 'prometheus.labels', 'prometheus.label_values',
-    'prometheus.series', 'prometheus.metadata', 'prometheus.metric_names', 'prometheus.validate',
+    // Datasource discovery (always allowed; no RBAC)
+    'datasources.list',
+    // Source-agnostic metrics primitives (each requires sourceId)
+    'metrics.query', 'metrics.range_query', 'metrics.labels', 'metrics.label_values',
+    'metrics.series', 'metrics.metadata', 'metrics.metric_names', 'metrics.validate',
+    // Source-agnostic logs primitives (each requires sourceId)
+    'logs.query', 'logs.labels', 'logs.label_values',
+    // Recent change events
+    'changes.list_recent',
     // Knowledge
     'web.search',
     // Alert rules
@@ -56,8 +62,8 @@ agentRegistry.register({
 
 agentRegistry.register({
   type: 'alert-rule-builder',
-  description: 'Generates alert rules from natural language, using dashboard context and Prometheus metric discovery',
-  allowedTools: ['create_alert_rule', 'prometheus.query', 'prometheus.labels', 'llm.complete'],
+  description: 'Generates alert rules from natural language, using dashboard context and metric discovery',
+  allowedTools: ['create_alert_rule', 'metrics.query', 'metrics.labels', 'llm.complete'],
   inputKinds: ['dashboard', 'panel'],
   outputKinds: ['alert_rule'],
   permissionMode: 'propose_only',
@@ -66,7 +72,7 @@ agentRegistry.register({
 agentRegistry.register({
   type: 'verification',
   description: 'Verifies generated artifacts (dashboards, investigation reports, alert rules) meet quality standards',
-  allowedTools: ['verifier.run', 'prometheus.query', 'llm.complete'],
+  allowedTools: ['verifier.run', 'metrics.query', 'llm.complete'],
   inputKinds: ['dashboard', 'investigation_report', 'alert_rule'],
   outputKinds: [],
   permissionMode: 'read_only',

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -20,9 +20,15 @@ export type AgentToolName =
   | 'alert_rule.list' | 'alert_rule.history'
   // Navigation
   | 'navigate'
-  // Prometheus primitives
-  | 'prometheus.query' | 'prometheus.range_query' | 'prometheus.labels' | 'prometheus.label_values'
-  | 'prometheus.series' | 'prometheus.metadata' | 'prometheus.metric_names' | 'prometheus.validate'
+  // Source-agnostic metrics primitives (each requires `sourceId`)
+  | 'metrics.query' | 'metrics.range_query' | 'metrics.labels' | 'metrics.label_values'
+  | 'metrics.series' | 'metrics.metadata' | 'metrics.metric_names' | 'metrics.validate'
+  // Source-agnostic logs primitives (each requires `sourceId`)
+  | 'logs.query' | 'logs.labels' | 'logs.label_values'
+  // Recent change events (deploys, config rollouts, incidents)
+  | 'changes.list_recent'
+  // Datasource discovery (always-allowed, no RBAC)
+  | 'datasources.list'
   // Knowledge & utility
   | 'web.search' | 'llm.complete'
   | 'verifier.run';

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -11,7 +11,7 @@ import type {
 } from '@agentic-obs/common'
 import { ac } from '@agentic-obs/common'
 import type { LLMGateway } from '@agentic-obs/llm-gateway'
-import type { IMetricsAdapter, IWebSearchAdapter } from '../adapters/index.js'
+import type { AdapterRegistry, IWebSearchAdapter, SignalType } from '../adapters/index.js'
 import type { AgentEvent } from './agent-events.js'
 import type {
   IDashboardAgentStore,
@@ -37,7 +37,13 @@ export interface ActionContext {
    *  Optional so tests / in-memory setups can omit; folder.* handlers
    *  return a clear "folder backend not configured" observation if absent. */
   folderRepository?: IFolderRepository
-  metricsAdapter?: IMetricsAdapter
+  /**
+   * Source-agnostic adapter registry. Required — the orchestrator resolves
+   * every metrics/logs/changes call through it by `sourceId`. A session with
+   * no backends configured still gets an empty registry so handlers can
+   * return "unknown datasource" observations uniformly.
+   */
+  adapters: AdapterRegistry
   webSearchAdapter?: IWebSearchAdapter
   allDatasources?: DatasourceConfig[]
   sendEvent: (event: DashboardSseEvent) => void
@@ -187,14 +193,21 @@ export async function handleInvestigationAddSection(
       ...(typeof p.colorScale === 'string' ? { colorScale: p.colorScale as PanelConfig['colorScale'] } : {}),
     }
 
-    // Capture snapshot data if metrics adapter is available
+    // Capture snapshot data if any metrics adapter is available in the
+    // registry. Evidence panels don't carry a sourceId today — pick the
+    // first registered metrics datasource (preferring default) so snapshot
+    // capture keeps working during the migration. Phase 2 may plumb the
+    // sourceId through the panel config.
     const queries = panelConfig.queries ?? []
-    if (ctx.metricsAdapter && queries.length > 0) {
+    const metricsSources = ctx.adapters.list({ signalType: 'metrics' })
+    const chosenSource = metricsSources.find((d) => d.isDefault) ?? metricsSources[0]
+    const evidenceAdapter = chosenSource ? ctx.adapters.metrics(chosenSource.id) : undefined
+    if (evidenceAdapter && queries.length > 0) {
       try {
         const hasInstantQuery = queries.some((q) => q.instant)
         if (hasInstantQuery) {
           // Instant snapshot
-          const results = await ctx.metricsAdapter.instantQuery(queries[0]!.expr)
+          const results = await evidenceAdapter.instantQuery(queries[0]!.expr)
           // For stat panels with sparkline=true, also capture a range so the
           // saved investigation renders the trend without needing live data.
           // Failure here is non-fatal — we keep the instant snapshot either way.
@@ -203,7 +216,7 @@ export async function handleInvestigationAddSection(
             try {
               const end = new Date()
               const start = new Date(end.getTime() - 60 * 60_000)
-              const sparkResults = await ctx.metricsAdapter.rangeQuery(
+              const sparkResults = await evidenceAdapter.rangeQuery(
                 queries[0]!.expr,
                 start,
                 end,
@@ -239,7 +252,7 @@ export async function handleInvestigationAddSection(
           const step = '60s'
           const rangeResults = await Promise.all(
             queries.map(async (q) => {
-              const results = await ctx.metricsAdapter!.rangeQuery(q.expr, start, end, step)
+              const results = await evidenceAdapter.rangeQuery(q.expr, start, end, step)
               return {
                 refId: q.refId,
                 series: results.map((r) => ({
@@ -675,44 +688,110 @@ export async function handleDeleteAlertRule(
 }
 
 // ---------------------------------------------------------------------------
-// Prometheus primitive tools
+// Datasource discovery (always allowed — required before metrics/logs/changes)
 // ---------------------------------------------------------------------------
 
-export async function handlePrometheusQuery(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const expr = String(args.expr ?? '')
-  if (!expr) return 'Error: "expr" is required.'
+export async function handleDatasourcesList(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const signalType = typeof args.signalType === 'string' ? args.signalType : undefined
+  const filter: { signalType?: SignalType } | undefined =
+    signalType === 'metrics' || signalType === 'logs' || signalType === 'changes'
+      ? { signalType }
+      : undefined
+  ctx.sendEvent({
+    type: 'tool_call',
+    tool: 'datasources.list',
+    args: filter ? filter : {},
+    displayText: filter ? `Listing ${filter.signalType} datasources` : 'Listing datasources',
+  })
 
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.query', args: { expr }, displayText: `Querying: ${expr.slice(0, 80)}` })
+  const infos = ctx.adapters.list(filter)
+  if (infos.length === 0) {
+    const msg = filter
+      ? `No ${filter.signalType} datasources are configured.`
+      : 'No datasources are configured.'
+    ctx.sendEvent({ type: 'tool_result', tool: 'datasources.list', summary: msg, success: true })
+    return msg
+  }
+  const lines = infos.map((d) => {
+    const tail = d.isDefault ? ' — default' : ''
+    return `id: ${d.id} (${d.type}, ${d.signalType})${tail}`
+  })
+  const summary = lines.join('\n')
+  ctx.sendEvent({
+    type: 'tool_result',
+    tool: 'datasources.list',
+    summary: `${infos.length} datasource(s)`,
+    success: true,
+  })
+  return summary
+}
+
+// ---------------------------------------------------------------------------
+// Source-agnostic metrics primitives — each takes `sourceId` and resolves the
+// concrete adapter through `ctx.adapters.metrics(sourceId)`.
+// ---------------------------------------------------------------------------
+
+function unknownMetricsSource(sourceId: string): string {
+  return `Error: unknown metrics datasource '${sourceId}'. Call datasources.list to see available sources.`
+}
+
+function unknownLogsSource(sourceId: string): string {
+  return `Error: unknown logs datasource '${sourceId}'. Call datasources.list to see available sources.`
+}
+
+export async function handleMetricsQuery(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const expr = String(args.query ?? args.expr ?? '')
+  if (!expr) return 'Error: "query" is required.'
+
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.query', args: { sourceId, query: expr }, displayText: `Querying ${sourceId}: ${expr.slice(0, 80)}` })
   try {
-    const results = await ctx.metricsAdapter.instantQuery(expr)
+    const results = await adapter.instantQuery(expr)
     const summary = results.length === 0
       ? 'Query returned no data.'
       : results.slice(0, 20).map((s) => {
           const labelStr = Object.entries(s.labels).filter(([k]) => k !== '__name__').map(([k, v]) => `${k}="${v}"`).join(', ')
           return `${labelStr || s.labels.__name__ || 'series'}: ${s.value}`
         }).join('\n') + (results.length > 20 ? `\n... and ${results.length - 20} more series` : '')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.query', summary: `${results.length} series returned`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.query', summary: `${results.length} series returned`, success: true })
     return summary
   } catch (err) {
     const msg = `Query failed: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.query', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.query', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusRangeQuery(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const expr = String(args.expr ?? '')
-  if (!expr) return 'Error: "expr" is required.'
+export async function handleMetricsRangeQuery(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const expr = String(args.query ?? args.expr ?? '')
+  if (!expr) return 'Error: "query" is required.'
   const step = String(args.step ?? '60s')
-  const durationMin = Number(args.duration_minutes ?? 60)
-  const end = new Date()
-  const start = new Date(end.getTime() - durationMin * 60_000)
 
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.range_query', args: { expr, step, duration_minutes: durationMin }, displayText: `Range query: ${expr.slice(0, 60)}` })
+  // Two input modes: (start, end) explicit ISO strings, or duration_minutes.
+  let start: Date
+  let end: Date
+  if (args.start && args.end) {
+    start = new Date(String(args.start))
+    end = new Date(String(args.end))
+  } else {
+    const durationMin = Number(args.duration_minutes ?? 60)
+    end = new Date()
+    start = new Date(end.getTime() - durationMin * 60_000)
+  }
+
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.range_query', args: { sourceId, query: expr, step }, displayText: `Range query on ${sourceId}: ${expr.slice(0, 60)}` })
   try {
-    const results = await ctx.metricsAdapter.rangeQuery(expr, start, end, step)
+    const results = await adapter.rangeQuery(expr, start, end, step)
     const summary = results.length === 0
       ? 'Range query returned no data.'
       : results.slice(0, 10).map((r) => {
@@ -720,139 +799,326 @@ export async function handlePrometheusRangeQuery(ctx: ActionContext, args: Recor
           const lastVal = r.values.length > 0 ? r.values[r.values.length - 1]![1] : 'N/A'
           return `${labelStr || r.metric.__name__ || 'series'}: ${r.values.length} points, latest=${lastVal}`
         }).join('\n') + (results.length > 10 ? `\n... and ${results.length - 10} more series` : '')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.range_query', summary: `${results.length} series returned`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.range_query', summary: `${results.length} series returned`, success: true })
     return summary
   } catch (err) {
     const msg = `Range query failed: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.range_query', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.range_query', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusLabels(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
+export async function handleMetricsLabels(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
   const metric = String(args.metric ?? '')
-  if (!metric) return 'Error: "metric" is required.'
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.labels', args: { metric }, displayText: `Listing labels for ${metric}` })
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.labels', args: { sourceId, metric }, displayText: `Listing labels${metric ? ` for ${metric}` : ''}` })
   try {
-    const labels = await ctx.metricsAdapter.listLabels(metric)
-    const summary = labels.length === 0 ? `No labels found for ${metric}.` : labels.join(', ')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.labels', summary: `${labels.length} labels`, success: true })
+    const labels = await adapter.listLabels(metric)
+    const summary = labels.length === 0 ? `No labels found${metric ? ` for ${metric}` : ''}.` : labels.join(', ')
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.labels', summary: `${labels.length} labels`, success: true })
     return summary
   } catch (err) {
     const msg = `Failed to list labels: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.labels', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.labels', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusLabelValues(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
+export async function handleMetricsLabelValues(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
   const label = String(args.label ?? '')
   if (!label) return 'Error: "label" is required.'
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.label_values', args: { label }, displayText: `Listing values for label "${label}"` })
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.label_values', args: { sourceId, label }, displayText: `Listing values for label "${label}"` })
   try {
-    const values = await ctx.metricsAdapter.listLabelValues(label)
+    const values = await adapter.listLabelValues(label)
     const summary = values.length === 0
       ? `No values found for label "${label}".`
       : values.slice(0, 50).join(', ') + (values.length > 50 ? ` ... and ${values.length - 50} more` : '')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.label_values', summary: `${values.length} values`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.label_values', summary: `${values.length} values`, success: true })
     return summary
   } catch (err) {
     const msg = `Failed to list label values: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.label_values', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.label_values', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusSeries(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const patterns = Array.isArray(args.patterns) ? args.patterns.map(String) : [String(args.pattern ?? args.patterns ?? '')]
-  if (patterns.length === 0 || !patterns[0]) return 'Error: "patterns" (array of match[] selectors) is required.'
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.series', args: { patterns }, displayText: `Finding series matching: ${patterns.join(', ').slice(0, 60)}` })
+export async function handleMetricsSeries(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const rawMatch = args.match ?? args.patterns ?? args.pattern
+  const patterns = Array.isArray(rawMatch) ? rawMatch.map(String) : [String(rawMatch ?? '')]
+  if (patterns.length === 0 || !patterns[0]) return 'Error: "match" (array of selectors) is required.'
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.series', args: { sourceId, match: patterns }, displayText: `Finding series matching: ${patterns.join(', ').slice(0, 60)}` })
   try {
-    const series = await ctx.metricsAdapter.findSeries(patterns)
+    const series = await adapter.findSeries(patterns)
     const summary = series.length === 0
       ? 'No series matched.'
       : series.slice(0, 50).join('\n') + (series.length > 50 ? `\n... and ${series.length - 50} more` : '')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.series', summary: `${series.length} series found`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.series', summary: `${series.length} series found`, success: true })
     return summary
   } catch (err) {
     const msg = `Series search failed: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.series', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.series', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusMetadata(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const metrics = Array.isArray(args.metrics) ? args.metrics.map(String) : undefined
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.metadata', args: { metrics: metrics ?? 'all' }, displayText: `Fetching metadata${metrics ? ` for ${metrics.length} metrics` : ''}` })
+export async function handleMetricsMetadata(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const metric = typeof args.metric === 'string' ? args.metric : undefined
+  const metrics = metric ? [metric] : (Array.isArray(args.metrics) ? args.metrics.map(String) : undefined)
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.metadata', args: { sourceId, metric: metric ?? metrics ?? 'all' }, displayText: `Fetching metadata${metric ? ` for ${metric}` : ''}` })
   try {
-    const metadata = await ctx.metricsAdapter.fetchMetadata(metrics)
+    const metadata = await adapter.fetchMetadata(metrics)
     const entries = Object.entries(metadata)
     const summary = entries.length === 0
       ? 'No metadata available.'
       : entries.slice(0, 30).map(([name, m]) => `${name} (${m.type}): ${m.help}`).join('\n')
         + (entries.length > 30 ? `\n... and ${entries.length - 30} more` : '')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.metadata', summary: `${entries.length} metrics`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.metadata', summary: `${entries.length} metrics`, success: true })
     return summary
   } catch (err) {
     const msg = `Metadata fetch failed: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.metadata', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.metadata', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusMetricNames(ctx: ActionContext, args: Record<string, unknown> = {}): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const filter = typeof args.filter === 'string' ? args.filter.toLowerCase() : undefined
+export async function handleMetricsMetricNames(ctx: ActionContext, args: Record<string, unknown> = {}): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const filter = typeof args.match === 'string'
+    ? args.match.toLowerCase()
+    : typeof args.filter === 'string'
+      ? args.filter.toLowerCase()
+      : undefined
 
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.metric_names', args: filter ? { filter } : {}, displayText: filter ? `Searching metrics matching "${filter}"` : 'Listing metric names' })
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.metric_names', args: { sourceId, ...(filter ? { match: filter } : {}) }, displayText: filter ? `Searching metrics matching "${filter}"` : 'Listing metric names' })
   try {
-    const allNames = await ctx.metricsAdapter.listMetricNames()
+    const allNames = await adapter.listMetricNames()
     const totalCount = allNames.length
 
     let names: string[]
     if (filter) {
-      // Filter by substring match (case-insensitive)
       names = allNames.filter((n) => n.toLowerCase().includes(filter))
     } else if (totalCount <= 500) {
-      // Small cluster — safe to return all
       names = allNames
     } else {
-      // Large cluster — return a sample + count, ask the model to use filter
       const sample = allNames.slice(0, 50)
-      const summary = `${totalCount} metrics available (too many to list). Showing first 50:\n${sample.join('\n')}\n\nUse prometheus.metric_names({ filter: "keyword" }) to search for specific metrics.`
-      ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.metric_names', summary: `${totalCount} metrics (sampled)`, success: true })
+      const summary = `${totalCount} metrics available (too many to list). Showing first 50:\n${sample.join('\n')}\n\nUse metrics.metric_names({ sourceId, match: "keyword" }) to search for specific metrics.`
+      ctx.sendEvent({ type: 'tool_result', tool: 'metrics.metric_names', summary: `${totalCount} metrics (sampled)`, success: true })
       return summary
     }
 
     const summary = names.length === 0
       ? filter ? `No metrics matching "${filter}" (${totalCount} total metrics in cluster).` : 'No metrics found.'
       : `${names.length} metrics${filter ? ` matching "${filter}"` : ''} (${totalCount} total).\n` + names.join('\n')
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.metric_names', summary: `${names.length} metrics`, success: true })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.metric_names', summary: `${names.length} metrics`, success: true })
     return summary
   } catch (err) {
     const msg = `Failed to list metrics: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.metric_names', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.metric_names', summary: msg, success: false })
     return msg
   }
 }
 
-export async function handlePrometheusValidate(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
-  if (!ctx.metricsAdapter) return 'Error: No Prometheus datasource configured.'
-  const expr = String(args.expr ?? '')
-  if (!expr) return 'Error: "expr" is required.'
-  ctx.sendEvent({ type: 'tool_call', tool: 'prometheus.validate', args: { expr }, displayText: `Validating: ${expr.slice(0, 60)}` })
+export async function handleMetricsValidate(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.metrics(sourceId)
+  if (!adapter) return unknownMetricsSource(sourceId)
+  const expr = String(args.query ?? args.expr ?? '')
+  if (!expr) return 'Error: "query" is required.'
+  ctx.sendEvent({ type: 'tool_call', tool: 'metrics.validate', args: { sourceId, query: expr }, displayText: `Validating: ${expr.slice(0, 60)}` })
   try {
-    const result = await ctx.metricsAdapter.testQuery(expr)
-    const summary = result.ok ? `Valid PromQL: ${expr}` : `Invalid PromQL: ${result.error ?? 'unknown error'}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.validate', summary, success: result.ok })
+    const result = await adapter.testQuery(expr)
+    const summary = result.ok ? `Valid query: ${expr}` : `Invalid query: ${result.error ?? 'unknown error'}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.validate', summary, success: result.ok })
     return summary
   } catch (err) {
     const msg = `Validation failed: ${err instanceof Error ? err.message : String(err)}`
-    ctx.sendEvent({ type: 'tool_result', tool: 'prometheus.validate', summary: msg, success: false })
+    ctx.sendEvent({ type: 'tool_result', tool: 'metrics.validate', summary: msg, success: false })
+    return msg
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source-agnostic logs primitives — each takes `sourceId` and resolves the
+// concrete adapter through `ctx.adapters.logs(sourceId)`.
+// ---------------------------------------------------------------------------
+
+const LOGS_QUERY_MAX_CHARS = 2000
+
+export async function handleLogsQuery(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.logs(sourceId)
+  if (!adapter) return unknownLogsSource(sourceId)
+  const query = String(args.query ?? '')
+  if (!query) return 'Error: "query" is required (backend-native — e.g. LogQL for Loki).'
+  if (!args.start || !args.end) return 'Error: "start" and "end" (ISO-8601 timestamps) are required.'
+  const start = new Date(String(args.start))
+  const end = new Date(String(args.end))
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return 'Error: "start" / "end" must be valid ISO-8601 timestamps.'
+  }
+  const limit = typeof args.limit === 'number' ? Math.max(1, Math.min(1000, args.limit)) : undefined
+
+  ctx.sendEvent({
+    type: 'tool_call',
+    tool: 'logs.query',
+    args: { sourceId, query, limit },
+    displayText: `Querying logs on ${sourceId}: ${query.slice(0, 60)}`,
+  })
+  try {
+    const result = await adapter.query({ query, start, end, ...(limit !== undefined ? { limit } : {}) })
+    if (result.entries.length === 0) {
+      const msg = 'Logs query returned no entries.'
+      ctx.sendEvent({ type: 'tool_result', tool: 'logs.query', summary: msg, success: true })
+      return msg
+    }
+    // Format: `[ts] {k=v, k=v} message` — truncate the whole blob to keep the
+    // observation reasonable even when the backend returns many rows.
+    const lines: string[] = []
+    let shown = 0
+    let totalLen = 0
+    for (const e of result.entries) {
+      const labelStr = Object.entries(e.labels).map(([k, v]) => `${k}=${v}`).join(',')
+      const line = `[${e.timestamp}]${labelStr ? ` {${labelStr}}` : ''} ${e.message}`
+      if (totalLen + line.length > LOGS_QUERY_MAX_CHARS) break
+      lines.push(line)
+      totalLen += line.length + 1
+      shown += 1
+    }
+    const truncated = shown < result.entries.length
+    const header = truncated
+      ? `${shown} of ${result.entries.length} log entries (truncated):`
+      : `${result.entries.length} log entries:`
+    const partialTail = result.partial ? '\n(Backend indicated results were partial — narrow the time window or add filters for completeness.)' : ''
+    const warnTail = result.warnings?.length ? `\nWarnings: ${result.warnings.join('; ')}` : ''
+    const summary = `${header}\n${lines.join('\n')}${partialTail}${warnTail}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.query', summary: `${result.entries.length} entries`, success: true })
+    return summary
+  } catch (err) {
+    const msg = `Logs query failed: ${err instanceof Error ? err.message : String(err)}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.query', summary: msg, success: false })
+    return msg
+  }
+}
+
+export async function handleLogsLabels(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.logs(sourceId)
+  if (!adapter) return unknownLogsSource(sourceId)
+  ctx.sendEvent({ type: 'tool_call', tool: 'logs.labels', args: { sourceId }, displayText: `Listing log labels on ${sourceId}` })
+  try {
+    const labels = await adapter.listLabels()
+    const summary = labels.length === 0 ? 'No log labels available.' : labels.join(', ')
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.labels', summary: `${labels.length} labels`, success: true })
+    return summary
+  } catch (err) {
+    const msg = `Failed to list log labels: ${err instanceof Error ? err.message : String(err)}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.labels', summary: msg, success: false })
+    return msg
+  }
+}
+
+export async function handleLogsLabelValues(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
+  const sourceId = String(args.sourceId ?? '')
+  if (!sourceId) return 'Error: "sourceId" is required. Call datasources.list to see available sources.'
+  const adapter = ctx.adapters.logs(sourceId)
+  if (!adapter) return unknownLogsSource(sourceId)
+  const label = String(args.label ?? '')
+  if (!label) return 'Error: "label" is required.'
+  ctx.sendEvent({ type: 'tool_call', tool: 'logs.label_values', args: { sourceId, label }, displayText: `Listing values for log label "${label}"` })
+  try {
+    const values = await adapter.listLabelValues(label)
+    const summary = values.length === 0
+      ? `No values found for label "${label}".`
+      : values.slice(0, 50).join(', ') + (values.length > 50 ? ` ... and ${values.length - 50} more` : '')
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.label_values', summary: `${values.length} values`, success: true })
+    return summary
+  } catch (err) {
+    const msg = `Failed to list log label values: ${err instanceof Error ? err.message : String(err)}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'logs.label_values', summary: msg, success: false })
+    return msg
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recent change events — deploys / config rollouts / incidents / feature flags
+// ---------------------------------------------------------------------------
+
+export async function handleChangesListRecent(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const explicitSource = typeof args.sourceId === 'string' && args.sourceId ? args.sourceId : undefined
+  let sourceId = explicitSource
+  if (!sourceId) {
+    const firstChange = ctx.adapters.list({ signalType: 'changes' })[0]
+    sourceId = firstChange?.id
+  }
+  if (!sourceId) {
+    const msg = 'No change-event datasource configured. Call datasources.list to see available sources.'
+    ctx.sendEvent({ type: 'tool_result', tool: 'changes.list_recent', summary: msg, success: false })
+    return msg
+  }
+  const adapter = ctx.adapters.changes(sourceId)
+  if (!adapter) {
+    const msg = `Error: unknown changes datasource '${sourceId}'. Call datasources.list to see available sources.`
+    ctx.sendEvent({ type: 'tool_result', tool: 'changes.list_recent', summary: msg, success: false })
+    return msg
+  }
+
+  const service = typeof args.service === 'string' && args.service ? args.service : undefined
+  const windowMinutes = typeof args.window_minutes === 'number'
+    ? args.window_minutes
+    : typeof args.windowMinutes === 'number' ? args.windowMinutes : 60
+
+  ctx.sendEvent({
+    type: 'tool_call',
+    tool: 'changes.list_recent',
+    args: { sourceId, service, window_minutes: windowMinutes },
+    displayText: service ? `Recent changes for ${service} (last ${windowMinutes}m)` : `Recent changes (last ${windowMinutes}m)`,
+  })
+
+  try {
+    const records = await adapter.listRecent({
+      windowMinutes,
+      ...(service ? { service } : {}),
+    })
+    if (records.length === 0) {
+      const msg = service
+        ? `No changes for ${service} in the last ${windowMinutes} minute(s).`
+        : `No changes in the last ${windowMinutes} minute(s).`
+      ctx.sendEvent({ type: 'tool_result', tool: 'changes.list_recent', summary: msg, success: true })
+      return msg
+    }
+    const bullets = records.slice(0, 30).map((r) =>
+      `- [${r.at}] ${r.service} (${r.kind}): ${r.summary}`,
+    )
+    const summary = `${records.length} change(s)${service ? ` for ${service}` : ''} in last ${windowMinutes}m:\n${bullets.join('\n')}${records.length > 30 ? `\n... and ${records.length - 30} more` : ''}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'changes.list_recent', summary: `${records.length} changes`, success: true })
+    return summary
+  } catch (err) {
+    const msg = `Failed to list recent changes: ${err instanceof Error ? err.message : String(err)}`
+    ctx.sendEvent({ type: 'tool_result', tool: 'changes.list_recent', summary: msg, success: false })
     return msg
   }
 }

--- a/packages/agent-core/src/agent/orchestrator-agent.test.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.test.ts
@@ -2,6 +2,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Dashboard, DashboardMessage, DashboardSseEvent } from '@agentic-obs/common'
 import { OrchestratorAgent } from './orchestrator-agent.js'
 import { AccessControlStub, makeTestIdentity } from './test-helpers.js'
+import { AdapterRegistry, type IMetricsAdapter } from '../adapters/index.js'
+
+/**
+ * Build a fresh AdapterRegistry that owns a single fake Prometheus metrics
+ * adapter under `id: 'prom-test'` (+ `isDefault: true`). Tests can override
+ * specific adapter methods via `overrides`.
+ */
+function buildFakeMetricsAdapters(overrides: Partial<IMetricsAdapter> = {}): AdapterRegistry {
+  const registry = new AdapterRegistry()
+  const metrics: IMetricsAdapter = {
+    listMetricNames: vi.fn().mockResolvedValue([]),
+    listLabels: vi.fn().mockResolvedValue([]),
+    listLabelValues: vi.fn().mockResolvedValue([]),
+    findSeries: vi.fn().mockResolvedValue([]),
+    fetchMetadata: vi.fn().mockResolvedValue({}),
+    instantQuery: vi.fn().mockResolvedValue([]),
+    rangeQuery: vi.fn().mockResolvedValue([]),
+    testQuery: vi.fn().mockResolvedValue({ ok: true }),
+    isHealthy: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  }
+  registry.register({
+    info: {
+      id: 'prom-test',
+      name: 'Prom Test',
+      type: 'prometheus',
+      signalType: 'metrics',
+      isDefault: true,
+    },
+    metrics,
+  })
+  return registry
+}
 
 function createDashboard(): Dashboard {
   const now = new Date().toISOString()
@@ -107,6 +140,7 @@ describe('OrchestratorAgent structured alert follow-up', () => {
       },
       investigationReportStore: { save: vi.fn() },
       alertRuleStore: alertRuleStore as any,
+      adapters: buildFakeMetricsAdapters(),
       sendEvent,
       identity: makeTestIdentity(),
       accessControl: new AccessControlStub(),
@@ -189,6 +223,7 @@ describe('OrchestratorAgent structured alert follow-up', () => {
         }),
         delete: deleteFn,
       } as any,
+      adapters: buildFakeMetricsAdapters(),
       sendEvent,
       identity: makeTestIdentity(),
       accessControl: new AccessControlStub(),
@@ -264,13 +299,7 @@ describe('OrchestratorAgent panel explanation', () => {
       },
       investigationReportStore: { save: vi.fn() },
       alertRuleStore: { create: vi.fn() } as any,
-      metricsAdapter: {
-        listMetricNames: vi.fn(),
-        listLabels: vi.fn(),
-        listLabelValues: vi.fn(),
-        findSeries: vi.fn(),
-        fetchMetadata: vi.fn(),
-        instantQuery: vi.fn(),
+      adapters: buildFakeMetricsAdapters({
         rangeQuery: vi.fn().mockResolvedValue([
           {
             metric: {},
@@ -281,9 +310,7 @@ describe('OrchestratorAgent panel explanation', () => {
             ],
           },
         ]),
-        testQuery: vi.fn(),
-        isHealthy: vi.fn(),
-      },
+      }),
       timeRange: {
         start: '2026-04-08T00:00:00.000Z',
         end: '2026-04-08T01:00:00.000Z',

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -15,7 +15,7 @@ import type {
   IAlertRuleStore,
   DatasourceConfig,
 } from './types.js'
-import type { IMetricsAdapter, IWebSearchAdapter } from '../adapters/index.js'
+import type { AdapterRegistry, IWebSearchAdapter } from '../adapters/index.js'
 import type { LLMGateway } from '@agentic-obs/llm-gateway'
 import { ActionExecutor } from './action-executor.js'
 import { AlertRuleAgent } from './alert-rule-agent.js'
@@ -52,14 +52,19 @@ import {
   handleDashboardRemovePanels,
   handleDashboardModifyPanel,
   handleDashboardAddVariable,
-  handlePrometheusQuery,
-  handlePrometheusRangeQuery,
-  handlePrometheusLabels,
-  handlePrometheusLabelValues,
-  handlePrometheusSeries,
-  handlePrometheusMetadata,
-  handlePrometheusMetricNames,
-  handlePrometheusValidate,
+  handleDatasourcesList,
+  handleMetricsQuery,
+  handleMetricsRangeQuery,
+  handleMetricsLabels,
+  handleMetricsLabelValues,
+  handleMetricsSeries,
+  handleMetricsMetadata,
+  handleMetricsMetricNames,
+  handleMetricsValidate,
+  handleLogsQuery,
+  handleLogsLabels,
+  handleLogsLabelValues,
+  handleChangesListRecent,
   handleWebSearch,
   handleDashboardList,
   handleInvestigationList,
@@ -82,7 +87,13 @@ export interface OrchestratorDeps {
    *  in-memory deployments; folder.* tools return a clear "not configured"
    *  observation if absent. */
   folderRepository?: IFolderRepository
-  metricsAdapter?: IMetricsAdapter
+  /**
+   * Source-agnostic adapter registry — the orchestrator dispatches every
+   * metrics/logs/changes tool through this. Required; pass an empty
+   * `new AdapterRegistry()` if no backends are wired (all handlers will
+   * return a uniform "unknown datasource" observation).
+   */
+  adapters: AdapterRegistry
   webSearchAdapter?: IWebSearchAdapter
   allDatasources?: DatasourceConfig[]
   sendEvent: (event: DashboardSseEvent) => void
@@ -160,10 +171,20 @@ export class OrchestratorAgent {
     }
     this.agentDef = def
 
+    // AlertRuleAgent still needs a single metrics adapter for its PromQL
+    // grounding / validation step. Pick the default metrics source (or the
+    // first one registered) — the generator is a helper scoped to one
+    // backend per call, not a multi-source tool.
+    const metricsSources = deps.adapters.list({ signalType: 'metrics' })
+    const defaultMetricsSource = metricsSources.find((d) => d.isDefault) ?? metricsSources[0]
+    const metricsForAlertRule = defaultMetricsSource
+      ? deps.adapters.metrics(defaultMetricsSource.id)
+      : undefined
+
     this.alertRuleAgent = new AlertRuleAgent({
       gateway: deps.gateway,
       model: deps.model,
-      metrics: deps.metricsAdapter,
+      metrics: metricsForAlertRule,
     })
 
     this.reactLoop = new ReActLoop({
@@ -176,7 +197,7 @@ export class OrchestratorAgent {
       conversationSummary: deps.conversationSummary,
     })
 
-    log.info(`[Orchestrator] init: agentType=${type}, metricsAdapter=${deps.metricsAdapter ? 'SET' : 'UNSET'}`)
+    log.info(`[Orchestrator] init: agentType=${type}, metricsSources=${metricsSources.length}`)
   }
 
   private emitAgentEvent(event: AgentEvent): void {
@@ -311,8 +332,9 @@ export class OrchestratorAgent {
       return finalReply
     }
 
+    const hasMetrics = this.deps.adapters.list({ signalType: 'metrics' }).length > 0
     const systemPrompt = buildSystemPrompt(dashboard ?? null, history, alertRules, activeAlertRule, this.deps.allDatasources ?? [], {
-      hasPrometheus: !!this.deps.metricsAdapter,
+      hasPrometheus: hasMetrics,
       timeRange: this.deps.timeRange ? { start: this.deps.timeRange.start, end: this.deps.timeRange.end } : undefined,
       identity: this.deps.identity,
       permissionEscalationContact: this.deps.permissionEscalationContact,
@@ -345,7 +367,7 @@ export class OrchestratorAgent {
       investigationStore: this.deps.investigationStore,
       alertRuleStore: this.deps.alertRuleStore,
       folderRepository: this.deps.folderRepository,
-      metricsAdapter: this.deps.metricsAdapter,
+      adapters: this.deps.adapters,
       webSearchAdapter: this.deps.webSearchAdapter,
       allDatasources: this.deps.allDatasources,
       sendEvent: this.deps.sendEvent,
@@ -435,15 +457,23 @@ export class OrchestratorAgent {
         case 'folder.list': return handleFolderList(ctx, args)
         // Navigation
         case 'navigate': return handleNavigate(ctx, args)
-        // Prometheus primitives
-        case 'prometheus.query': return handlePrometheusQuery(ctx, args)
-        case 'prometheus.range_query': return handlePrometheusRangeQuery(ctx, args)
-        case 'prometheus.labels': return handlePrometheusLabels(ctx, args)
-        case 'prometheus.label_values': return handlePrometheusLabelValues(ctx, args)
-        case 'prometheus.series': return handlePrometheusSeries(ctx, args)
-        case 'prometheus.metadata': return handlePrometheusMetadata(ctx, args)
-        case 'prometheus.metric_names': return handlePrometheusMetricNames(ctx, args)
-        case 'prometheus.validate': return handlePrometheusValidate(ctx, args)
+        // Datasource discovery (always allowed)
+        case 'datasources.list': return handleDatasourcesList(ctx, args)
+        // Source-agnostic metrics primitives
+        case 'metrics.query': return handleMetricsQuery(ctx, args)
+        case 'metrics.range_query': return handleMetricsRangeQuery(ctx, args)
+        case 'metrics.labels': return handleMetricsLabels(ctx, args)
+        case 'metrics.label_values': return handleMetricsLabelValues(ctx, args)
+        case 'metrics.series': return handleMetricsSeries(ctx, args)
+        case 'metrics.metadata': return handleMetricsMetadata(ctx, args)
+        case 'metrics.metric_names': return handleMetricsMetricNames(ctx, args)
+        case 'metrics.validate': return handleMetricsValidate(ctx, args)
+        // Source-agnostic logs primitives
+        case 'logs.query': return handleLogsQuery(ctx, args)
+        case 'logs.labels': return handleLogsLabels(ctx, args)
+        case 'logs.label_values': return handleLogsLabelValues(ctx, args)
+        // Recent change events
+        case 'changes.list_recent': return handleChangesListRecent(ctx, args)
         // Web search
         case 'web.search': return handleWebSearch(ctx, args)
         // 'finish' is handled as a terminal action in ReActLoop
@@ -475,7 +505,14 @@ function inferTargetType(tool: string): string | null {
   if (tool.startsWith('dashboard.')) return 'dashboard';
   if (tool.startsWith('folder.')) return 'folder';
   if (tool.startsWith('investigation.')) return 'investigation';
-  if (tool.startsWith('prometheus.')) return 'datasource';
+  if (
+    tool.startsWith('metrics.') ||
+    tool.startsWith('logs.') ||
+    tool === 'datasources.list'
+  ) {
+    return 'datasource';
+  }
+  if (tool === 'changes.list_recent') return 'changes';
   if (tool.startsWith('alert_rule.') || tool === 'create_alert_rule' || tool === 'modify_alert_rule' || tool === 'delete_alert_rule') {
     return 'alert_rule';
   }
@@ -487,7 +524,9 @@ function inferTargetId(tool: string, args: Record<string, unknown>): string | nu
   if (tool.startsWith('dashboard.')) return pickString(args.dashboardId);
   if (tool.startsWith('investigation.')) return pickString(args.investigationId);
   if (tool.startsWith('folder.')) return pickString(args.folderUid ?? args.parentUid);
-  if (tool.startsWith('prometheus.')) return pickString(args.datasourceId ?? args.datasourceUid);
+  if (tool.startsWith('metrics.') || tool.startsWith('logs.') || tool === 'changes.list_recent') {
+    return pickString(args.sourceId ?? args.datasourceId ?? args.datasourceUid);
+  }
   if (tool === 'create_alert_rule') return pickString(args.folderUid);
   if (tool === 'modify_alert_rule' || tool === 'delete_alert_rule' || tool === 'alert_rule.history') {
     return pickString(args.ruleId);

--- a/packages/agent-core/src/agent/orchestrator-prompt.test.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.test.ts
@@ -94,14 +94,17 @@ describe('buildSystemPrompt — T6.C role-conditional nudge', () => {
   it('appends the Viewer nudge when orgRole is Viewer', () => {
     const prompt = build({ orgRole: 'Viewer' });
     expect(prompt).toContain(VIEWER_LINE);
-    expect(prompt).toContain('do not propose or attempt mutations');
+    // Rephrased away from the D0-adjacent "do not propose or attempt mutations".
+    // Anchor on the gate-centric framing instead.
+    expect(prompt).toContain('the RBAC gate rejects any mutation request');
     expect(prompt).not.toContain(EDITOR_LINE);
   });
 
   it('appends the Editor nudge when orgRole is Editor', () => {
     const prompt = build({ orgRole: 'Editor' });
     expect(prompt).toContain(EDITOR_LINE);
-    expect(prompt).toContain('Layer 3 RBAC will block them anyway');
+    // Same reframing: the gate does the blocking, the agent doesn't self-censor.
+    expect(prompt).toContain('the gate will reject them');
     expect(prompt).not.toContain(VIEWER_LINE);
   });
 

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -25,31 +25,46 @@ function getSystemSection(): string {
 
 function getDoingTasksSection(): string {
   return `# Doing Tasks
-- The user will primarily request observability tasks: building dashboards, investigating issues, creating alerts, explaining metrics.
-- Do not build panels with queries you haven't validated. Discover metrics first, validate queries, then add panels.
-- When the user asks about data — analyze, explain, compare, "what's happening" — query the actual data first, then respond with specific numbers and insights. Never give a vague summary without citing real values.
-- When the user asks "why" something is happening — "why is latency high", "why are there errors" — this is an investigation. Create an investigation record with investigation.create, then query multiple metrics to diagnose the root cause.
-- **When the user says "open X", "show me X", "go to X", "打开 X", "看一下 X"** — they want to OPEN an EXISTING resource, NOT create a new one. First search with the matching list tool (dashboard.list, investigation.list, alert_rule.list) using a filter keyword, then use navigate with the resource's path (e.g., /dashboards/<id>, /investigations/<id>, /alerts). Only create a new resource if the search finds nothing AND the user's wording implies creation.
-- If an approach fails, diagnose why before switching tactics. Don't abandon a viable approach after a single failure. But don't retry the same failing call more than 3 times — inform the user and move on.
-- Do not add panels the user didn't ask for. Do not suggest follow-up actions unless explicitly asked. Do not modify the dashboard as a side effect of another action.
-- When metrics don't exist yet (pre-deployment), use web.search to find the standard metrics for that technology, then build the dashboard using well-known naming conventions. Do NOT validate queries in this case — just ensure syntax is correct.
-- Before creating any dashboard, use web.search to research monitoring best practices for the topic — even if you know it well. This ensures you follow current standards.
+Requests fall into four shapes: build something (dashboard / alert), investigate something ("why is X"), analyze data ("what's happening with Y"), or open an existing resource ("show me X"). Pick the shape first, then follow the pattern.
 
-## Finishing Honestly — CRITICAL
-- \`finish(text)\` reports what YOU actually did in the tool calls above. It is not a way to end a turn early when unsure what to do.
-- Do not claim you created / added / modified anything unless the corresponding mutation tool was called AND returned success. If a dashboard request ends without \`dashboard.create\` + \`dashboard.add_panels\` both succeeding, you did not create a dashboard — don't say you did.
-- When discovery returns less than you hoped (empty list, sparse metadata, a query that didn't match), that is not a reason to abandon the task. Discovery tools are often incomplete; try a different angle before giving up: broaden the filter, pick a related tool, or proceed with the information you already have.
-- If you genuinely cannot complete the request (missing credentials, the resource doesn't exist, the user's intent is ambiguous), use \`reply(text)\` to explain what is missing and ask the user — do NOT finish with a fabricated success message.
+## Decision flow before any tool call
+1. **Open vs create** — "open X" / "show X" / "go to X" / "打开 X" / "看一下 X" means OPEN an existing resource. List first (dashboard.list / investigation.list / alert_rule.list) with a filter keyword, then navigate. Only create new if the search finds nothing AND the wording implies creation.
+2. **Which datasource** — every metrics/logs/changes call requires an explicit \`sourceId\`. Call \`datasources.list\` first. If multiple same-signal sources exist and the user's intent is ambiguous, ask which one before querying.
+3. **Read before mutate** — mutation tools (dashboard.create / add_panels / modify_panel / create_alert_rule / investigation.add_section) need prerequisites verified. Before removing panels, check panel IDs from Dashboard State. Before creating alerts, query current values so the threshold is grounded.
+4. **Validate before adding panels** — panel queries must go through \`metrics.validate\` before \`dashboard.add_panels\`. Exception: pre-deployment dashboards (metrics don't exist yet) — skip validation, use web-researched naming conventions.
 
-## Dashboard Design
+## Cost asymmetry
+Discovery calls are cheap — a failed \`metric_names\` query burns one tool turn. Mutations and fabricated summaries are expensive — a wrong \`dashboard.add_panels\` pollutes the user's workspace; a made-up "done!" breaks their trust in you. **Spend reads liberally, spend mutations carefully.** If you don't have enough context for a mutation, that's a signal to do more discovery, not to guess.
+
+## When a tool fails, don't stop — adapt
+Pick one alternative and try it before giving up:
+- Discovery returned empty / sparse → broaden the filter, try a related tool (metric_names → series → labels)
+- Metric doesn't exist → try different naming patterns or ask web.search for conventions
+- Query parses but returns nothing → check the labels, relax the selector, widen the time range
+- Adapter reports an HTTP error → surface the error text to the user; don't hide it, don't fabricate around it
+- Same failure 3 times in a row → stop and tell the user exactly what you tried
+
+Don't abandon a viable approach after one failure, but don't dig on a dead end either. Diagnose before switching tactics.
+
+## Finishing honestly — CRITICAL
+- \`finish(text)\` reports what YOU actually did in the tool calls above. It is not a way to end a turn early when unsure.
+- Do not claim you created / added / modified anything unless the corresponding mutation tool returned success. Dashboard request that ends without \`dashboard.create\` + \`dashboard.add_panels\` both succeeding = you did not create a dashboard; do not say you did.
+- If you genuinely cannot complete the request (missing credentials, resource doesn't exist, user intent unclear), use \`reply(text)\` to explain what is missing and ask — do NOT finish with a fabricated success message.
+
+## Scope discipline
+- Do not add panels the user didn't ask for.
+- Do not suggest follow-up actions unless explicitly asked.
+- Do not modify the dashboard as a side effect of another action.
+- When analyzing data ("what's happening with X"), cite specific numbers from actual queries. Never a vague summary without values.
+
+## Dashboard design
 - Structure: overview stats at top → trends in middle → detailed breakdowns at bottom.
 - Prioritize RED signals: Rate, Errors, Duration. Don't add specialist panels unless asked.
 - 8-15 panels for a focused dashboard. Don't use template variables unless the user asks for drill-down.
+- Before creating any dashboard, use web.search to look up current monitoring best practices for the topic, even on familiar stacks.
 
-## Executing Actions with Care
-- Read-only tools (datasources.list, metrics.*, logs.*, changes.list_recent, web.search) are always safe. Use them freely.
-- Before removing panels, verify the panel IDs from Dashboard State. Before creating alerts, check current metric values to ensure the threshold makes sense.
-- NEVER silently drop errors. If a tool fails, report it to the user.`
+## Investigations
+When the user asks "why is X high/slow/broken" or "investigate X": create an investigation record with \`investigation.create\`, then run a hypothesis-driven diagnosis — like a senior SRE writing an incident report. The report is primarily written analysis; panels are supporting evidence, not the main content. See the worked Investigation example below for the structure.`
 }
 
 function getExamplesSection(): string {
@@ -62,14 +77,14 @@ Each example shows one representative scenario. The model should generalize thes
 User: "Create a dashboard for HTTP monitoring"
   1. datasources.list({ signalType: "metrics" }) → id: prom-prod (prometheus, metrics) — default
   2. web.search({ query: "http service monitoring dashboard best practices RED method" })
-  3. metrics.metric_names({ sourceId: "prom-prod", match: "http" }) → found prometheus_http_requests_total, etc.
-  4. metrics.metadata({ sourceId: "prom-prod", metric: "prometheus_http_requests_total" }) → counter
+  3. metrics.metric_names({ sourceId: "prom-prod", match: "http" }) → found http_requests_total, etc.
+  4. metrics.metadata({ sourceId: "prom-prod", metric: "http_requests_total" }) → counter
   5. dashboard.create({ title: "HTTP Service Monitoring" }) → dashboardId: "abc-123"
   6. metrics.validate({ sourceId: "prom-prod", query: "sum(rate(...))" }) → Valid (repeat for each query)
   7. dashboard.add_panels({ dashboardId: "abc-123", panels: [
-       { title: "Request Rate", visualization: "stat", queries: [{ refId: "A", expr: "sum(rate(prometheus_http_requests_total[5m]))", instant: true }], unit: "reqps" },
-       { title: "Error Rate", visualization: "gauge", queries: [{ refId: "A", expr: "sum(rate(prometheus_http_requests_total{code=~\\"5..\\"}[5m])) / sum(rate(prometheus_http_requests_total[5m]))", instant: true }], unit: "percentunit" },
-       { title: "Latency p95", visualization: "time_series", queries: [{ refId: "A", expr: "histogram_quantile(0.95, sum(rate(prometheus_http_request_duration_seconds_bucket[5m])) by (le))" }], unit: "seconds" }
+       { title: "Request Rate", visualization: "stat", queries: [{ refId: "A", expr: "sum(rate(http_requests_total[5m]))", instant: true }], unit: "reqps" },
+       { title: "Error Rate", visualization: "gauge", queries: [{ refId: "A", expr: "sum(rate(http_requests_total{code=~\\"5..\\"}[5m])) / sum(rate(http_requests_total[5m]))", instant: true }], unit: "percentunit" },
+       { title: "Latency p95", visualization: "time_series", queries: [{ refId: "A", expr: "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))" }], unit: "seconds" }
      ] })
   8. finish("Created HTTP Monitoring dashboard with 3 panels: request rate, error rate, p95 latency.")
 </example>
@@ -92,7 +107,7 @@ User: "Create a monitoring dashboard for our new Redis deployment"
 <example>
 User: "Analyze the request rate by handler data"
   1. datasources.list({ signalType: "metrics" }) → id: prom-prod (prometheus, metrics) — default
-  2. metrics.query({ sourceId: "prom-prod", query: "topk(5, sum(rate(prometheus_http_requests_total[5m])) by (handler))" })
+  2. metrics.query({ sourceId: "prom-prod", query: "topk(5, sum(rate(http_requests_total[5m])) by (handler))" })
      → /api/v1/query: 2.3, /api/v1/label: 1.1, /metrics: 0.8, ...
   3. reply("**Top 5 handlers by traffic:** /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic is stable, no anomalies.")
 </example>
@@ -147,7 +162,7 @@ User: "Why is p99 latency so high?"
   4. metrics.range_query({ sourceId: "prom-prod", query: request rate, duration_minutes: 60, step: "60s" }) → stable 0.19 req/s
   5. metrics.query({ sourceId: "prom-prod", query: error rate }) → 0 errors
   6. metrics.query({ sourceId: "prom-prod", query: p99 by handler }) → /api/v1/query_range=120ms, others <50ms
-  7. changes.list_recent({ service: "prometheus", window_minutes: 120 }) → no deploys in window
+  7. changes.list_recent({ service: "api-gateway", window_minutes: 120 }) → no deploys in window
   — Now write the report with all evidence gathered —
   6. investigation.add_section({ type: "text", content: "## Initial Assessment\n\nThe p99 latency is currently at 99ms while the median (p50) sits at 50ms, representing a 2x gap. This is a significant tail latency issue — the slowest 1% of requests take nearly twice as long as the typical request. Looking at the historical trend, this gap has been consistent over the past hour rather than appearing as a sudden spike, which suggests a structural cause rather than a transient event." })
   7. investigation.add_section({ type: "evidence", content: "The chart below shows both p99 and p50 latency. Note the consistent ~2x gap between them.", panel: { title: "p99 vs p50 Latency Over Time", queries: [...], unit: "seconds" } })
@@ -212,143 +227,23 @@ User: "What's the difference between rate() and irate()?"
 | Latency heatmap | heatmap | false | sum by (le) (rate(x_bucket[5m])) |
 | Detailed values | table | true | topk(20, x) |
 
-## Panel Polish Defaults
-The frontend renders much better when panels carry visual hints. Apply these
-defaults when calling \`dashboard.add_panels\`:
+## Panel Correctness — non-obvious rules that will make a panel look broken if ignored
+- **Call \`metrics.metadata\` first** to learn the metric type (counter / gauge / histogram_bucket / summary). The type dictates viz choice and whether to wrap in \`rate()\`.
+- **Counters** (\`_total\` / \`_count\`): always wrap in \`rate(m[5m])\` or \`increase(m[1h])\`. Raw counter values are cumulative since process start — visually meaningless.
+- **Histogram buckets** (\`_bucket\`, \`le\` label): heatmap query MUST be \`sum by (le) (rate(<metric>_bucket[5m]))\`. A bare \`*_bucket\` renders as one solid color. Single-percentile trends use \`histogram_quantile(0.95, ...)\`.
+- **Gauges**: always set \`max\` on a \`gauge\` viz (or use \`unit: "percent"\` for implicit 100). A gauge with no ceiling is meaningless.
+- **Don't pick these by mistake**: \`stat\` for a time-evolving counter without rate() → giant growing number; \`bar\` for time-evolving data → bars are snapshots; \`pie\` for time-series → pie is proportional shares at an instant.
+- **Series cap**: if a \`time_series\` panel would have >30 series, wrap the query in \`topk(10, ...)\` or split by another label.
+- **Annotations**: for \`time_series\` / \`heatmap\` panels covering an alerting metric, fetch \`alert_rule.history(...)\` once and pass the returned JSON as \`panel.annotations\`. Skip annotations when no related alert rule exists.
 
-**Every panel:**
-- \`description\`: 1 short sentence the user can hover to see (renders as an ⓘ tooltip).
+The frontend auto-adapts legend layout, y-scale (log when >3 orders of magnitude), point markers, stat coloring at 100%, and bar/pie truncation. You don't need to set these unless overriding the default.
 
-**stat panels** — these dominate the dashboard's first-glance read:
-- Sparkline trend is **on by default**; only set \`sparkline: false\` for
-  truly time-invariant metrics (config counts, version strings).
-- \`graphMode: "area"\` — fills the sparkline so the trend reads at a glance.
-- \`colorMode: "value"\` — colors the number itself using the threshold scale.
-  Use \`"background"\` only for critical-state panels (e.g. "Cluster Down").
+## Dashboard Grouping (RED for services, USE for resources)
+For multi-panel dashboards, group with \`sectionLabel\` using the standard methodology that fits:
+- **RED** for request-driven services — sections "Rate" / "Errors" / "Duration"
+- **USE** for resources (nodes, pods, queues) — sections "Utilization" / "Saturation" / "Errors"
 
-**time_series panels:**
-- \`lineWidth: 1\` — Grafana-default thin lines.
-- \`fillOpacity: 0.1\` — subtle area fill for single-series and small-N panels;
-  set to \`0\` for high-density panels (>8 series) so they don't muddy.
-- \`legendStats\`: pick by panel intent —
-  - error rate / saturation panels → \`["mean","max"]\`
-  - request rate / counter panels → \`["last","mean"]\`
-  - latency percentile panels → \`["last","mean","max"]\`
-  - default if unsure → \`["last","mean"]\`
-
-**heatmap panels — CRITICAL:**
-- The query MUST be \`sum by (le) (rate(<metric>_bucket[$__rate_interval]))\`.
-  Bare \`*_bucket\` queries are cumulative counters and render as one solid
-  color — they look broken. Always wrap in \`rate()\` and \`sum by (le)\`.
-- \`colorScale: "sqrt"\` (default if omitted) handles long-tailed distributions
-  well. Use \`"log"\` only when one bucket dwarfs all others by 100×+.
-
-**Annotations on time-axis panels** (deploy / incident / alert overlays):
-- For \`time_series\` and \`heatmap\` panels covering an alerting metric, call
-  \`alert_rule.history({ruleId: "<rule>", sinceMinutes: <range>})\` and pass
-  the returned JSON as \`panel.annotations\`. Vertical event lines on the
-  chart are the single most useful aid for "did this latency spike correlate
-  with an alert firing?"
-- Skip annotations on panels covering metrics with no related alert rule —
-  empty annotations are noise.
-- For dashboards spanning many metrics, prefer \`alert_rule.history()\` (no
-  ruleId, all rules) once and reuse the result across panels — avoids N
-  redundant tool calls.
-
-**bar_gauge panels** (use for SLO ratios, capacity %, quota usage — anywhere
-N items each compare against the SAME known ceiling):
-- \`barGaugeMax\`: the shared ceiling. For percent units, defaults to 100 if
-  omitted; otherwise pass it explicitly so each bar reads as a fraction of
-  the cap, not normalized to the largest item.
-- \`barGaugeMode\`: \`"gradient"\` (default, single colored bar) or
-  \`"lcd"\` (segmented like a VU meter — distinctive for crowded panels).
-- Use \`bar_gauge\` over \`bar\` whenever the ceiling matters. \`bar\` is
-  for "biggest item wins" comparisons; \`bar_gauge\` is for "how full?"
-
-## Viz Selection Decision Tree
-**ALWAYS call \`metrics.metadata({ sourceId, metric })\` first** to learn the
-metric type before picking a visualization. Then apply the rules below.
-
-**counter** (suffix \`_total\` or \`_count\`):
-- Always wrap in \`rate(metric[5m])\` or \`increase(metric[1h])\`. Raw counter
-  values are cumulative since process start — visually meaningless.
-- Trend over time → \`time_series\` with the rate
-- Current rate → \`stat\` with \`sum(rate(metric[5m]))\`, sparkline on
-- Top-N comparison → \`bar\` with \`topk(10, sum by(label) (rate(metric[5m])))\`
-
-**gauge** (utilization, ratio, queue depth, pod count):
-- Trend over time → \`time_series\`
-- Current value vs known max (CPU%, mem%, SLO%) → \`gauge\` with \`max\` set
-- Spot value, no upper bound (pod count, queue depth) → \`stat\`
-- Compare instances → \`bar\` (instant) or \`time_series\` (trend)
-
-**histogram bucket** (suffix \`_bucket\`, has \`le\` label):
-- Distribution over time → \`heatmap\` with
-  \`sum by (le) (rate(metric_bucket[5m]))\` — NEVER raw \`_bucket\`
-- Single percentile trend → \`time_series\` with
-  \`histogram_quantile(0.95, sum by (le) (rate(metric_bucket[5m])))\`
-- Multiple percentiles in one panel → \`time_series\` with one query per
-  quantile (p50, p95, p99), \`legendStats: ["last","max"]\`
-
-**summary** (has \`quantile\` label, pre-aggregated):
-- Use directly: \`time_series\` of \`metric{quantile="0.95"}\`
-- No \`rate()\` needed — the server already aggregated.
-
-## Viz Anti-Patterns — DO NOT
-- **Don't** use \`stat\` for a time-evolving metric without \`rate()\` —
-  the user sees the cumulative counter (a giant number that only grows).
-- **Don't** use \`bar\` for time-evolving data. Bars are for instant
-  snapshots of "top N right now".
-- **Don't** use \`heatmap\` without \`rate()\` and \`sum by (le)\`. Bare
-  \`_bucket\` queries render as one solid color.
-- **Don't** put more than ~30 series in a single \`time_series\` panel.
-  Either split by another label, or wrap in \`topk(10, ...)\`.
-- **Don't** use \`gauge\` without setting \`max\` (or implicit 100% for
-  percent units). A gauge with no ceiling is meaningless.
-- **Don't** use \`pie\` for time-series data. Pie is for proportional
-  shares at a single instant (e.g. response status code distribution).
-
-## Auto-Adaptation You Can Rely On
-The frontend already adapts these without explicit config — don't fight it:
-
-- Time-series legend: defaults to **list** for ≤6 series with ≤1 stat;
-  auto-switches to **table** when series ≥ 7 OR when \`legendStats.length ≥ 2\`
-  (multi-stat columns need alignment, list mode would crowd them);
-  caps at top-15 with a "+N more" expander for >20 series. You only
-  need to pick \`legendStats\` — the rest is automatic.
-- Time-series y-scale: auto-switches to **log** when the data spans >3
-  orders of magnitude. Pass \`yScale: "linear"\` only to force-disable.
-- Time-series point markers: auto-shown when data is sparse (>25px per
-  sample). No config needed.
-- Heatmap empty buckets: histogram-mode heatmaps auto-collapse all-zero
-  rows so the data fills the panel. Pass \`collapseEmptyBuckets: false\`
-  only when comparing two heatmaps that need identical y axes.
-- Stat coloring at 100%: \`unit: "percent"\` panels with value ≥95%
-  switch to a faint background tint instead of a giant green number.
-  Don't override with \`colorMode: "value"\`.
-- Bar truncation: bars beyond the top-15 fold into a "…+N more" row.
-  Still — prefer explicit \`topk()\` in the query so the agent's intent
-  is recorded in the PromQL.
-- Pie "Other" slice: slices <1.5% or beyond the 8th fold into a single
-  "Other" slice. Always good UX; no opt-out.
-
-## Section Grouping by Intent
-For multi-panel dashboards, group with \`sectionLabel\` by **standard
-methodology**. Pick whichever fits the subject:
-
-**RED** (request-driven services — APIs, RPC servers):
-- "Rate" — request throughput (\`stat\` of total + \`time_series\` by route/method)
-- "Errors" — error rate / error% (\`stat\` of error% + \`time_series\` by status code)
-- "Duration" — latency (stat of p99 + heatmap of distribution)
-
-**USE** (resources — nodes, pods, queues, databases):
-- "Utilization" — % busy (CPU, memory, disk, GPU)
-- "Saturation" — backlog (queue depth, run queue, IO wait)
-- "Errors" — failures (OOMs, restarts, error logs rate)
-
-Each section: one **stat** header row at top + 1-2 **detail panels** below.
-This pattern lets the user glance at the section header for status, drill
-into the time series for context.`
+Each section: one \`stat\` header row + 1-2 detail panels below.`
 }
 
 function getToolsSection(hasMetrics: boolean): string {
@@ -362,7 +257,7 @@ All metrics tools require a \`sourceId\` — resolve it with \`datasources.list(
 - metrics.label_values({ sourceId, label, match? }) — List all values for a label.
 - metrics.query({ sourceId, query }) — Instant query. Returns current values (up to 20 series).
 - metrics.range_query({ sourceId, query, start?, end?, step? }) — Range query. Default: last 60 min at 60s step.
-- metrics.validate({ sourceId, query }) — Test if a query is valid. ALWAYS validate before adding panels (unless metrics don't exist yet).
+- metrics.validate({ sourceId, query }) — Test whether a query is syntactically valid and returns data. Used as the validation gate before \`dashboard.add_panels\`.
 
 ## Logs Tools (read-only, source-agnostic)
 All logs tools require a \`sourceId\` — resolve it with \`datasources.list({ signalType: "logs" })\` first. The \`query\` string is backend-native (LogQL for Loki, ES DSL for Elasticsearch, etc.).
@@ -597,15 +492,18 @@ function getRoleHint(orgRole: string | undefined): string {
   if (!orgRole) return ''
   const role = orgRole.toLowerCase()
   if (role === 'viewer') {
+    // Factual, not prescriptive — the RBAC gate does the actual blocking;
+    // the prompt just tells the model what the gate will do so it can
+    // relay rejections honestly rather than try to self-censor.
     return (
-      `You are operating as a Viewer. Answer questions with read-only tools; do not propose or attempt mutations. ` +
-      `If the user asks for a change, explain that they lack permission and suggest contacting an editor/admin.`
+      `You are operating as a Viewer. Your tools are scoped to read-only operations; the RBAC gate rejects any mutation request. ` +
+      `When a user asks for a change, relay the access restriction plainly instead of trying a blocked tool.`
     )
   }
   if (role === 'editor') {
     return (
-      `You are operating as an Editor. You may propose and perform mutations within your assigned workspace. ` +
-      `Avoid admin-only actions (instance config, user/role management) — Layer 3 RBAC will block them anyway.`
+      `You are operating as an Editor. You have read-write access within your workspace. ` +
+      `Admin-only actions (instance config, user/role management) are outside your scope — the gate will reject them, so don't treat those rejections as something to solve.`
     )
   }
   return ''

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -47,7 +47,7 @@ function getDoingTasksSection(): string {
 - 8-15 panels for a focused dashboard. Don't use template variables unless the user asks for drill-down.
 
 ## Executing Actions with Care
-- Read-only tools (prometheus.*, web.search) are always safe. Use them freely.
+- Read-only tools (datasources.list, metrics.*, logs.*, changes.list_recent, web.search) are always safe. Use them freely.
 - Before removing panels, verify the panel IDs from Dashboard State. Before creating alerts, check current metric values to ensure the threshold makes sense.
 - NEVER silently drop errors. If a tool fails, report it to the user.`
 }
@@ -60,17 +60,18 @@ Each example shows one representative scenario. The model should generalize thes
 ## Creating a Dashboard (metrics exist)
 <example>
 User: "Create a dashboard for HTTP monitoring"
-  1. web.search({ query: "http service monitoring dashboard best practices RED method" })
-  2. prometheus.metric_names({ filter: "http" }) → found prometheus_http_requests_total, etc.
-  3. prometheus.metadata({ metrics: ["prometheus_http_requests_total", ...] }) → counter, histogram
-  4. dashboard.create({ title: "HTTP Service Monitoring" }) → dashboardId: "abc-123"
-  5. prometheus.validate({ expr: "sum(rate(...))" }) → Valid (repeat for each query)
-  6. dashboard.add_panels({ dashboardId: "abc-123", panels: [
+  1. datasources.list({ signalType: "metrics" }) → id: prom-prod (prometheus, metrics) — default
+  2. web.search({ query: "http service monitoring dashboard best practices RED method" })
+  3. metrics.metric_names({ sourceId: "prom-prod", match: "http" }) → found prometheus_http_requests_total, etc.
+  4. metrics.metadata({ sourceId: "prom-prod", metric: "prometheus_http_requests_total" }) → counter
+  5. dashboard.create({ title: "HTTP Service Monitoring" }) → dashboardId: "abc-123"
+  6. metrics.validate({ sourceId: "prom-prod", query: "sum(rate(...))" }) → Valid (repeat for each query)
+  7. dashboard.add_panels({ dashboardId: "abc-123", panels: [
        { title: "Request Rate", visualization: "stat", queries: [{ refId: "A", expr: "sum(rate(prometheus_http_requests_total[5m]))", instant: true }], unit: "reqps" },
        { title: "Error Rate", visualization: "gauge", queries: [{ refId: "A", expr: "sum(rate(prometheus_http_requests_total{code=~\\"5..\\"}[5m])) / sum(rate(prometheus_http_requests_total[5m]))", instant: true }], unit: "percentunit" },
        { title: "Latency p95", visualization: "time_series", queries: [{ refId: "A", expr: "histogram_quantile(0.95, sum(rate(prometheus_http_request_duration_seconds_bucket[5m])) by (le))" }], unit: "seconds" }
      ] })
-  7. finish("Created HTTP Monitoring dashboard with 3 panels: request rate, error rate, p95 latency.")
+  8. finish("Created HTTP Monitoring dashboard with 3 panels: request rate, error rate, p95 latency.")
 </example>
 
 ## Creating a Dashboard (metrics don't exist yet — pre-deployment)
@@ -90,15 +91,16 @@ User: "Create a monitoring dashboard for our new Redis deployment"
 ## Explaining / Analyzing Panel Data
 <example>
 User: "Analyze the request rate by handler data"
-  1. prometheus.query({ expr: "topk(5, sum(rate(prometheus_http_requests_total[5m])) by (handler))" })
+  1. datasources.list({ signalType: "metrics" }) → id: prom-prod (prometheus, metrics) — default
+  2. metrics.query({ sourceId: "prom-prod", query: "topk(5, sum(rate(prometheus_http_requests_total[5m])) by (handler))" })
      → /api/v1/query: 2.3, /api/v1/label: 1.1, /metrics: 0.8, ...
-  2. reply("**Top 5 handlers by traffic:** /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic is stable, no anomalies.")
+  3. reply("**Top 5 handlers by traffic:** /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic is stable, no anomalies.")
 </example>
 
 ## Modifying Panels
 <example>
 User: "Change the latency panel to show p99 instead of p95"
-  1. prometheus.validate({ expr: "histogram_quantile(0.99, ...)" }) → Valid
+  1. metrics.validate({ sourceId: "prom-prod", query: "histogram_quantile(0.99, ...)" }) → Valid
   2. dashboard.modify_panel({ dashboardId: "...", panelId: "panel-id-from-context", title: "Latency p99", queries: [{ refId: "A", expr: "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))" }] })
   3. finish("Changed latency panel from p95 to p99.")
 </example>
@@ -106,7 +108,7 @@ User: "Change the latency panel to show p99 instead of p95"
 ## Creating an Alert Rule
 <example>
 User: "Alert me when error rate goes above 5%"
-  1. prometheus.query({ expr: "sum(rate(http_errors_total[5m])) / sum(rate(http_requests_total[5m]))" }) → 0.023 (2.3%, so 5% threshold is reasonable)
+  1. metrics.query({ sourceId: "prom-prod", query: "sum(rate(http_errors_total[5m])) / sum(rate(http_requests_total[5m]))" }) → 0.023 (2.3%, so 5% threshold is reasonable)
   2. create_alert_rule({ prompt: "Alert when HTTP error rate exceeds 5% for 5 minutes" })
   3. finish("Created alert rule 'High Error Rate' — fires when error rate > 5%. Current rate is 2.3%.")
 </example>
@@ -139,11 +141,13 @@ IMPORTANT: You MUST call investigation.complete at the end. Without it, all sect
 
 <example>
 User: "Why is p99 latency so high?"
-  1. investigation.create({ question: "Why is p99 latency high?" }) → inv-789
-  2. prometheus.query(p99) → 99ms; prometheus.query(p50) → 50ms
-  3. prometheus.range_query(request rate) → stable 0.19 req/s
-  4. prometheus.query(error rate) → 0 errors
-  5. prometheus.query(p99 by handler) → /api/v1/query_range=120ms, others <50ms
+  1. datasources.list({ signalType: "metrics" }) → id: prom-prod (prometheus, metrics) — default
+  2. investigation.create({ question: "Why is p99 latency high?" }) → inv-789
+  3. metrics.query({ sourceId: "prom-prod", query: p99 }) → 99ms; metrics.query({ sourceId: "prom-prod", query: p50 }) → 50ms
+  4. metrics.range_query({ sourceId: "prom-prod", query: request rate, duration_minutes: 60, step: "60s" }) → stable 0.19 req/s
+  5. metrics.query({ sourceId: "prom-prod", query: error rate }) → 0 errors
+  6. metrics.query({ sourceId: "prom-prod", query: p99 by handler }) → /api/v1/query_range=120ms, others <50ms
+  7. changes.list_recent({ service: "prometheus", window_minutes: 120 }) → no deploys in window
   — Now write the report with all evidence gathered —
   6. investigation.add_section({ type: "text", content: "## Initial Assessment\n\nThe p99 latency is currently at 99ms while the median (p50) sits at 50ms, representing a 2x gap. This is a significant tail latency issue — the slowest 1% of requests take nearly twice as long as the typical request. Looking at the historical trend, this gap has been consistent over the past hour rather than appearing as a sudden spike, which suggests a structural cause rather than a transient event." })
   7. investigation.add_section({ type: "evidence", content: "The chart below shows both p99 and p50 latency. Note the consistent ~2x gap between them.", panel: { title: "p99 vs p50 Latency Over Time", queries: [...], unit: "seconds" } })
@@ -262,7 +266,7 @@ N items each compare against the SAME known ceiling):
   for "biggest item wins" comparisons; \`bar_gauge\` is for "how full?"
 
 ## Viz Selection Decision Tree
-**ALWAYS call \`prometheus.metadata({metrics: [name]})\` first** to learn the
+**ALWAYS call \`metrics.metadata({ sourceId, metric })\` first** to learn the
 metric type before picking a visualization. Then apply the rules below.
 
 **counter** (suffix \`_total\` or \`_count\`):
@@ -349,18 +353,33 @@ into the time series for context.`
 
 function getToolsSection(hasMetrics: boolean): string {
   const metricsTools = hasMetrics ? `
-## Metrics Tools (read-only)
-- prometheus.metric_names(filter?) — Search metric names by keyword. ALWAYS pass a filter (e.g., { filter: "http" }). Returns matching names. Without filter: returns all if <500, otherwise asks you to filter.
-- prometheus.series(patterns) — Find series matching selectors. E.g., { patterns: ['{__name__=~"http.*"}'] }.
-- prometheus.metadata(metrics?) — Get metric type and help text. ESSENTIAL for writing correct queries.
-- prometheus.labels(metric) — List label names for a metric.
-- prometheus.label_values(label) — List all values for a label.
-- prometheus.query(expr) — Instant query. Returns current values (up to 20 series).
-- prometheus.range_query(expr, step?, duration_minutes?) — Range query. Default: last 60 min.
-- prometheus.validate(expr) — Test if a query is valid. ALWAYS validate before adding panels (unless metrics don't exist yet).
+## Metrics Tools (read-only, source-agnostic)
+All metrics tools require a \`sourceId\` — resolve it with \`datasources.list({ signalType: "metrics" })\` first.
+- metrics.metric_names({ sourceId, match? }) — Search metric names by keyword. ALWAYS pass a \`match\` (e.g. { match: "http" }). Without filter: returns all if <500, otherwise asks you to filter.
+- metrics.series({ sourceId, match }) — Find series matching selectors. E.g. { match: ['{__name__=~"http.*"}'] }.
+- metrics.metadata({ sourceId, metric? }) — Get metric type and help text. ESSENTIAL for writing correct queries.
+- metrics.labels({ sourceId, metric? }) — List label names for a metric (omit metric for the full set).
+- metrics.label_values({ sourceId, label, match? }) — List all values for a label.
+- metrics.query({ sourceId, query }) — Instant query. Returns current values (up to 20 series).
+- metrics.range_query({ sourceId, query, start?, end?, step? }) — Range query. Default: last 60 min at 60s step.
+- metrics.validate({ sourceId, query }) — Test if a query is valid. ALWAYS validate before adding panels (unless metrics don't exist yet).
+
+## Logs Tools (read-only, source-agnostic)
+All logs tools require a \`sourceId\` — resolve it with \`datasources.list({ signalType: "logs" })\` first. The \`query\` string is backend-native (LogQL for Loki, ES DSL for Elasticsearch, etc.).
+- logs.query({ sourceId, query, start, end, limit? }) — Run a logs query over an explicit ISO-8601 window. Returns \`[timestamp] {labels} message\` lines, truncated to keep observations compact.
+- logs.labels({ sourceId }) — List available log labels.
+- logs.label_values({ sourceId, label }) — List values for a log label.
+
+## Changes Tool (read-only)
+- changes.list_recent({ sourceId?, service?, window_minutes? }) — Recent deploys, config rollouts, feature-flag flips, and incidents. If \`sourceId\` is omitted, the first registered change-event datasource is used. Defaults: window_minutes=60, all services. Use early in investigations to correlate anomalies with known changes.
 ` : ''
 
   return `# Available Tools
+
+**Datasource discovery**: before querying metrics/logs/changes, call \`datasources.list\` to see what's configured. Every query tool requires a \`sourceId\`. Never guess — if the user's intent is ambiguous between multiple sources, ask which one.
+
+## Datasource Discovery (always allowed, no permissions required)
+- datasources.list({ signalType? }) — List every configured datasource with its \`id\`, backend \`type\`, and signal kind. \`signalType\` is one of \`"metrics" | "logs" | "changes"\`; omit to see all. **Call this first** before any metrics/logs/changes query.
 ${metricsTools}
 ## Dashboard Tools
 All mutation tools require "dashboardId" — create one first with dashboard.create if needed.
@@ -398,7 +417,7 @@ All mutation tools require "dashboardId" — create one first with dashboard.cre
 function getQueryKnowledgeSection(): string {
   return `# Query Knowledge
 
-## Metric Types — check with prometheus.metadata before writing queries
+## Metric Types — check with metrics.metadata before writing queries
 - **counter** (_total, _count): Always rate() or increase(). Never raw values.
 - **gauge** (_bytes, _ratio, no suffix): Use directly or avg_over_time().
 - **histogram** (_bucket, _sum, _count): histogram_quantile() for percentiles. Never avg() for latency.

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -304,9 +304,10 @@ All mutation tools require "dashboardId" — create one first with dashboard.cre
 - delete_alert_rule(ruleId) — Delete alert rule (irreversible).
 
 ## Terminal Actions
-- reply(text) — Conversational reply, no tools needed.
-- finish(text) — Summarize outcome after tool actions. Be specific.
-- ask_user(question) — Clarifying question. Use VERY sparingly.`
+Put the final answer in the top-level \`message\` field and leave \`args\` empty. See Response Format below.
+- \`reply\` — Conversational answer, no tool actions taken this turn.
+- \`finish\` — Summarize what your tool calls above actually accomplished. Be specific.
+- \`ask_user\` — Clarifying question. Use VERY sparingly.`
 }
 
 function getQueryKnowledgeSection(): string {
@@ -393,8 +394,13 @@ function getHistorySection(history: DashboardMessage[]): string {
 
 function getDatasourceSection(allDatasources: DatasourceConfig[]): string {
   if (allDatasources.length === 0) return ''
+  // Expose `sourceId` explicitly — the name field (e.g. "demo") looks like
+  // an id to the model and leads to a two-step recovery where the first
+  // tool call fails with "unknown datasource 'demo'" before the model calls
+  // datasources.list to get the real UUID. Putting id front-and-center
+  // saves those two steps.
   return `\n# Datasources\n${allDatasources.map((d) =>
-    `- ${d.name} (${d.type}${d.environment ? `, ${d.environment}` : ''}${d.isDefault ? ', DEFAULT' : ''})`).join('\n')}`
+    `- sourceId="${d.id}" name="${d.name}" type=${d.type}${d.environment ? ` env=${d.environment}` : ''}${d.isDefault ? ' DEFAULT' : ''}`).join('\n')}`
 }
 
 function getAlertRulesSection(

--- a/packages/agent-core/src/agent/permission-gate.test.ts
+++ b/packages/agent-core/src/agent/permission-gate.test.ts
@@ -3,6 +3,7 @@ import { checkPermission, denialObservation } from './permission-gate.js';
 import type { AgentDefinition } from './agent-definition.js';
 import type { ActionContext } from './orchestrator-action-handlers.js';
 import { AccessControlStub, makeTestIdentity } from './test-helpers.js';
+import { AdapterRegistry } from '../adapters/index.js';
 
 function makeCtx(allowAll = true): ActionContext {
   return {
@@ -11,6 +12,7 @@ function makeCtx(allowAll = true): ActionContext {
     store: {} as ActionContext['store'],
     investigationReportStore: {} as ActionContext['investigationReportStore'],
     alertRuleStore: {} as ActionContext['alertRuleStore'],
+    adapters: new AdapterRegistry(),
     allDatasources: [{ id: 'ds-prom', type: 'prometheus', name: 'Prom', url: 'http://x', isDefault: true }],
     sendEvent: () => {},
     sessionId: 's',
@@ -28,7 +30,7 @@ function makeCtx(allowAll = true): ActionContext {
 const writeAgent: AgentDefinition = {
   type: 'orchestrator',
   description: 'test orchestrator',
-  allowedTools: ['dashboard.create', 'dashboard.list', 'prometheus.query'],
+  allowedTools: ['dashboard.create', 'dashboard.list', 'metrics.query'],
   inputKinds: ['dashboard'],
   outputKinds: [],
   permissionMode: 'artifact_mutation',

--- a/packages/agent-core/src/agent/react-loop-permissions.test.ts
+++ b/packages/agent-core/src/agent/react-loop-permissions.test.ts
@@ -16,6 +16,11 @@ import { ac, type Evaluator, type Identity } from '@agentic-obs/common';
 import { OrchestratorAgent } from './orchestrator-agent.js';
 import type { IAuditWriter } from './types-permissions.js';
 import { AccessControlStub, makeTestIdentity } from './test-helpers.js';
+import { AdapterRegistry } from '../adapters/index.js';
+
+function makeEmptyAdapters(): AdapterRegistry {
+  return new AdapterRegistry();
+}
 
 type LLMResponse = { content: string };
 
@@ -98,6 +103,7 @@ function build(opts: {
     },
     investigationReportStore: { save: vi.fn() },
     alertRuleStore: { create: vi.fn() } as any,
+    adapters: makeEmptyAdapters(),
     sendEvent,
     identity: opts.identity ?? makeTestIdentity(),
     accessControl: opts.accessControl ?? new AccessControlStub(),
@@ -151,7 +157,7 @@ describe('Scenario 3 — mixed: query allowed, create denied', () => {
     const mixed = new AccessControlStub((_id, e) => !e.string().includes('dashboards:create'));
     const { agent, audit } = build({
       llmResponses: [
-        asStep('query first', 'prometheus.query', { expr: 'up', datasourceId: 'ds-prom' }),
+        asStep('query first', 'metrics.query', { query: 'up', sourceId: 'ds-prom' }),
         asStep('try to create', 'dashboard.create', { folderUid: 'prod', title: 'x' }),
         asStep('explain', 'finish', {}, 'Queried but cannot create.'),
       ],
@@ -161,9 +167,9 @@ describe('Scenario 3 — mixed: query allowed, create denied', () => {
     const rows = audit.entries as Array<{ action: string }>;
     const called = rows.filter((e) => e.action === 'agent.tool_called').length;
     const denied = rows.filter((e) => e.action === 'agent.tool_denied').length;
-    // prometheus.query fails because the test has no metrics adapter → that
-    // still runs through the gate as ALLOWED. Only dashboard.create should
-    // be denied.
+    // metrics.query has no registered adapter in the empty AdapterRegistry,
+    // so the handler emits an "unknown datasource" observation — but the gate
+    // still passes it as ALLOWED. Only dashboard.create should be denied.
     expect(denied).toBe(1);
     expect(called).toBeGreaterThanOrEqual(1);
   });
@@ -227,7 +233,7 @@ describe('Scenario 7 — propose_only agent + dashboard.create', () => {
 });
 
 describe('Scenario 5 / 16 — cross-org / datasource isolation', () => {
-  it('denies prometheus.query when the datasource scope is not granted', async () => {
+  it('denies metrics.query when the datasource scope is not granted', async () => {
     const deny = new AccessControlStub((_id, e: Evaluator) => {
       // Grant query on prom-app, deny on prom-infra.
       if (e.string().includes('datasources:uid:prom-app')) return true;
@@ -236,8 +242,8 @@ describe('Scenario 5 / 16 — cross-org / datasource isolation', () => {
     });
     const { agent, audit } = build({
       llmResponses: [
-        asStep('ok', 'prometheus.query', { datasourceId: 'prom-app', expr: 'up' }),
-        asStep('denied', 'prometheus.query', { datasourceId: 'prom-infra', expr: 'up' }),
+        asStep('ok', 'metrics.query', { sourceId: 'prom-app', query: 'up' }),
+        asStep('denied', 'metrics.query', { sourceId: 'prom-infra', query: 'up' }),
         asStep('explain', 'finish', {}, 'Mixed result.'),
       ],
       accessControl: deny,
@@ -287,6 +293,7 @@ describe('Prompt template population (Scenario 11)', () => {
       },
       investigationReportStore: { save: vi.fn() },
       alertRuleStore: { create: vi.fn() } as any,
+      adapters: makeEmptyAdapters(),
       sendEvent,
       identity: makeTestIdentity({ orgRole: 'Viewer', userId: 'u-viewer' }),
       accessControl: new AccessControlStub(),

--- a/packages/agent-core/src/agent/react-loop.ts
+++ b/packages/agent-core/src/agent/react-loop.ts
@@ -6,10 +6,27 @@ import type {
 import { createLogger } from '@agentic-obs/common/logging'
 import type { DashboardSseEvent, Identity } from '@agentic-obs/common'
 import type { IAccessControlService } from './types-permissions.js'
+import { estimateMessagesTokens, CONTEXT_WINDOW } from './token-utils.js'
 
 const log = createLogger('react-loop')
 
-const MAX_ITERATIONS = 30
+/**
+ * Safety ceiling on iterations to prevent pathological infinite loops
+ * (LLM stuck emitting parse errors, provider returning identical results,
+ * etc). This is NOT the normal terminator — under well-behaved operation
+ * the LLM emits `reply` / `ask_user` / `finish` long before this is hit.
+ * The real budget is tokens (see TOKEN_BUDGET_BYTES below), matching the
+ * way Claude Code's loop terminates.
+ */
+const MAX_ITERATIONS = 200
+
+/**
+ * Soft token budget: when the messages about to be sent to the LLM would
+ * exceed this, exit the loop with a graceful "reached context limit" reply
+ * rather than letting the gateway reject the request. Set slightly under
+ * CONTEXT_WINDOW to leave headroom for the model's own completion tokens.
+ */
+const TOKEN_BUDGET_TOKENS = Math.floor(CONTEXT_WINDOW * 0.95)
 /** Keep the last N observations in full; older ones are summarized to save context. */
 const OBSERVATION_KEEP_RECENT = 6
 /** Truncate individual observation text to this many characters. */
@@ -183,6 +200,17 @@ export class ReActLoop {
     for (let i = 0; i < MAX_ITERATIONS; i++) {
       const messages = this.buildMessages(systemPrompt, userMessage, observations)
 
+      // Token-budget termination — the primary "we're done" signal once the
+      // LLM stops emitting terminal actions on its own. Estimated, not exact,
+      // so leave headroom (TOKEN_BUDGET_TOKENS < CONTEXT_WINDOW).
+      const estimatedTokens = estimateMessagesTokens(messages)
+      if (estimatedTokens > TOKEN_BUDGET_TOKENS) {
+        log.warn({ step: i, estimatedTokens, budget: TOKEN_BUDGET_TOKENS }, 'token budget exhausted — ending loop')
+        const reply = `I've worked through ${i} step${i === 1 ? '' : 's'} on this task, but the conversation has grown past the context budget. Here's a summary of where I am so far — ask me a focused follow-up if you need more detail.`
+        this.deps.sendEvent({ type: 'reply', content: reply })
+        return reply
+      }
+
       let step: ReActStep
       let rawContent = ''
       try {
@@ -311,8 +339,11 @@ export class ReActLoop {
       return finalReply
     }
 
-    // Max iterations reached - emit a fallback reply
-    const fallback = 'I have completed the requested changes to your dashboard.'
+    // Iteration ceiling reached — safety net, not a normal completion path.
+    // Be honest: we didn't converge, the user needs to know to retry with a
+    // narrower scope rather than assume success.
+    log.warn({ iterations: MAX_ITERATIONS }, 'iteration ceiling reached without terminal action')
+    const fallback = `I ran through ${MAX_ITERATIONS} steps without reaching a clear stopping point. This usually means the task branched more than expected or I got stuck on a loop. Try narrowing the request, or ask me what I learned along the way.`
     this.deps.sendEvent({ type: 'reply', content: fallback })
     return fallback
   }

--- a/packages/agent-core/src/agent/react-loop.ts
+++ b/packages/agent-core/src/agent/react-loop.ts
@@ -288,9 +288,16 @@ export class ReActLoop {
 
       // --- Terminal actions: exit the loop immediately ---
       if (TERMINAL_ACTIONS.has(action)) {
+        // The prompt documents "put the answer in top-level `message`, leave
+        // args empty" — that lands in `chatReply`. But models routinely drift
+        // to args.text / args.message / args.content. Accept any of them so
+        // a harmless format variation doesn't drop the whole reply. Order:
+        // top-level message → args.text → args.message → args.content.
+        const pickString = (v: unknown): string | undefined =>
+          typeof v === 'string' && v.trim() ? v : undefined
         const text = action === 'ask_user'
-          ? (chatReply ?? (typeof step.args.question === 'string' ? step.args.question : ''))
-          : (chatReply ?? (typeof step.args.text === 'string' ? step.args.text : ''))
+          ? (chatReply ?? pickString(step.args.question) ?? pickString(step.args.text) ?? pickString(step.args.message) ?? '')
+          : (chatReply ?? pickString(step.args.text) ?? pickString(step.args.message) ?? pickString(step.args.content) ?? '')
         if (text) {
           this.deps.sendEvent({ type: 'reply', content: text })
         }

--- a/packages/agent-core/src/agent/tool-permissions.test.ts
+++ b/packages/agent-core/src/agent/tool-permissions.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { TOOL_PERMS, UNGATED_TOOLS, buildToolEvaluator } from './tool-permissions.js';
 import { agentRegistry } from './agent-registry.js';
 import type { ActionContext } from './orchestrator-action-handlers.js';
+import { AdapterRegistry } from '../adapters/index.js';
 
 /**
- * Minimal ctx stub — only fields the builders consult. Prometheus builders
- * pick up a default datasource from ctx.allDatasources; alert-rule async
- * builders pull the folderUid from the alertRuleStore.
+ * Minimal ctx stub — only fields the builders consult. Metrics/logs/changes
+ * builders take `sourceId` straight from args; alert-rule async builders
+ * pull the folderUid from the alertRuleStore.
  */
 function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
   return {
@@ -17,6 +18,7 @@ function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
     alertRuleStore: {
       findById: async () => null,
     } as unknown as ActionContext['alertRuleStore'],
+    adapters: new AdapterRegistry(),
     allDatasources: [{ id: 'ds-prom', type: 'prometheus', name: 'Prom', url: 'http://x', isDefault: true }],
     sendEvent: () => {},
     sessionId: 'sess-1',
@@ -64,17 +66,31 @@ describe('TOOL_PERMS — per-builder scope derivation', () => {
     );
   });
 
-  it('prometheus.query maps datasourceId to scope', () => {
-    const e = TOOL_PERMS['prometheus.query']!({ datasourceId: 'prom-prod', expr: 'up' }, makeCtx());
+  it('metrics.query maps sourceId to scope', () => {
+    const e = TOOL_PERMS['metrics.query']!({ sourceId: 'prom-prod', query: 'up' }, makeCtx());
     expect((e as { string: () => string }).string()).toBe(
       'datasources:query on datasources:uid:prom-prod',
     );
   });
 
-  it('prometheus.query falls back to the default ctx datasource', () => {
-    const e = TOOL_PERMS['prometheus.query']!({ expr: 'up' }, makeCtx());
+  it('metrics.query falls back to wildcard when sourceId is missing', () => {
+    const e = TOOL_PERMS['metrics.query']!({ query: 'up' }, makeCtx());
     expect((e as { string: () => string }).string()).toBe(
-      'datasources:query on datasources:uid:ds-prom',
+      'datasources:query on datasources:uid:*',
+    );
+  });
+
+  it('logs.query derives the datasource scope from sourceId', () => {
+    const e = TOOL_PERMS['logs.query']!({ sourceId: 'loki-prod' }, makeCtx());
+    expect((e as { string: () => string }).string()).toBe(
+      'datasources:query on datasources:uid:loki-prod',
+    );
+  });
+
+  it('changes.list_recent requires investigations:read', () => {
+    const e = TOOL_PERMS['changes.list_recent']!({}, makeCtx());
+    expect((e as { string: () => string }).string()).toBe(
+      'investigations:read on investigations:*',
     );
   });
 

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -25,26 +25,24 @@ import type { ActionContext } from './orchestrator-action-handlers.js';
 import type { ToolPermissionBuilder } from './types-permissions.js';
 
 /**
- * Resolve the datasource UID for a Prometheus tool call. The LLM MAY pass
- * `datasourceId` in args; when it doesn't, we fall back to the default
- * Prometheus datasource from ctx (matches how the existing handlers pick the
- * adapter). If nothing resolves, we scope to `datasources:uid:*` so the gate
- * still runs — an org-wide `datasources:query` grant covers this, but a
- * per-UID grant does not (fail-closed for narrow grants).
+ * Resolve the datasource UID for a source-agnostic metrics / logs / changes
+ * tool call. The LLM is now required to pass `sourceId` (see orchestrator
+ * system prompt — "Datasource discovery first"); we still accept the older
+ * `datasourceId` / `datasourceUid` aliases for leniency. When nothing
+ * resolves we scope to `datasources:uid:*` so the gate still runs — an
+ * org-wide `datasources:query` grant covers this, but a per-UID grant does
+ * not (fail-closed for narrow grants).
  */
-function resolveDatasourceScope(
-  args: Record<string, unknown>,
-  ctx: ActionContext,
-): string {
+function resolveDatasourceScope(args: Record<string, unknown>): string {
+  if (typeof args.sourceId === 'string' && args.sourceId) {
+    return `datasources:uid:${args.sourceId}`;
+  }
   if (typeof args.datasourceId === 'string' && args.datasourceId) {
     return `datasources:uid:${args.datasourceId}`;
   }
   if (typeof args.datasourceUid === 'string' && args.datasourceUid) {
     return `datasources:uid:${args.datasourceUid}`;
   }
-  const defaults = (ctx.allDatasources ?? []).find((d) => d.isDefault);
-  const prom = defaults ?? (ctx.allDatasources ?? []).find((d) => d.type === 'prometheus');
-  if (prom?.id) return `datasources:uid:${prom.id}`;
   return 'datasources:uid:*';
 }
 
@@ -147,23 +145,37 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
       `alert.rules:uid:${String(args.ruleId ?? '*')}`,
     ),
 
-  // -- Prometheus primitives ------------------------------------------------
-  'prometheus.query': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.range_query': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.labels': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.label_values': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.series': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.metadata': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.metric_names': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
-  'prometheus.validate': (args: Record<string, unknown>, ctx: ActionContext) =>
-    ac.eval('datasources:query', resolveDatasourceScope(args, ctx)),
+  // -- Metrics primitives (source-agnostic; sourceId is required) ----------
+  'metrics.query': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.range_query': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.labels': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.label_values': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.series': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.metadata': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.metric_names': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'metrics.validate': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+
+  // -- Logs primitives (source-agnostic; sourceId is required) -------------
+  'logs.query': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'logs.labels': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+  'logs.label_values': (args: Record<string, unknown>) =>
+    ac.eval('datasources:query', resolveDatasourceScope(args)),
+
+  // -- Recent change events ------------------------------------------------
+  // Gated as an investigation-style read so Viewer+ roles can consult
+  // deploy / incident history while diagnosing anomalies.
+  'changes.list_recent': () =>
+    ac.eval('investigations:read', 'investigations:*'),
 
   // -- Web / knowledge ------------------------------------------------------
   'web.search': () => ac.eval('chat:use'),
@@ -189,6 +201,10 @@ export const UNGATED_TOOLS: ReadonlySet<string> = new Set([
   'ask_user',
   'llm.complete',
   'verifier.run',
+  // Discovery is always allowed — the caller needs to see what's configured
+  // BEFORE they can form a gated call. This is a read of the in-process
+  // registry; no backend side effect.
+  'datasources.list',
 ]);
 
 /**

--- a/packages/api-gateway/src/services/__tests__/dashboard-service.test.ts
+++ b/packages/api-gateway/src/services/__tests__/dashboard-service.test.ts
@@ -13,6 +13,16 @@ vi.mock('@agentic-obs/agent-core', () => ({
       consumeNavigate: vi.fn().mockReturnValue(undefined),
     };
   }),
+  AdapterRegistry: vi.fn(function MockAdapterRegistry() {
+    return {
+      register: vi.fn(),
+      get: vi.fn(),
+      list: vi.fn(() => []),
+      metrics: vi.fn(),
+      logs: vi.fn(),
+      changes: vi.fn(),
+    };
+  }),
 }));
 
 import { DashboardService } from '../dashboard-service.js';

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -4,8 +4,7 @@ import type { DashboardSseEvent, Identity } from '@agentic-obs/common';
 import { createLlmGateway } from '../routes/llm-factory.js';
 import { DashboardOrchestratorAgent as OrchestratorAgent, shouldCompact, compactMessages, estimateTokens } from '@agentic-obs/agent-core';
 import type { IDashboardAlertRuleStore as IAlertRuleStore, IDashboardInvestigationStore as IInvestigationStore } from '@agentic-obs/agent-core';
-import { PrometheusMetricsAdapter } from '@agentic-obs/adapters';
-import { resolvePrometheusDatasource, toAgentDatasources } from './dashboard-service.js';
+import { buildAdapterRegistry, toAgentDatasources } from './dashboard-service.js';
 import type { AccessControlSurface } from './accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
@@ -150,11 +149,7 @@ export class ChatService {
 
     const gateway = createLlmGateway(llm);
     const model = llm.model;
-    const prom = resolvePrometheusDatasource(datasources);
-
-    const metricsAdapter = prom
-      ? new PrometheusMetricsAdapter(prom.url, prom.headers)
-      : undefined;
+    const adapters = buildAdapterRegistry(datasources);
 
     // Parse relative time range (e.g., "1h", "6h", "24h", "7d") to absolute start/end
     let timeRange: { start: string; end: string } | undefined;
@@ -234,7 +229,7 @@ export class ChatService {
       investigationStore: this.deps.investigationStore as IInvestigationStore | undefined,
       alertRuleStore: toAlertRuleStore(this.deps.alertRuleStore),
       ...(this.deps.folderRepository ? { folderRepository: this.deps.folderRepository } : {}),
-      metricsAdapter,
+      adapters,
       allDatasources: toAgentDatasources(datasources),
       sendEvent: wrappedSendEvent,
       timeRange,

--- a/packages/api-gateway/src/services/dashboard-service.ts
+++ b/packages/api-gateway/src/services/dashboard-service.ts
@@ -6,9 +6,9 @@ const log = createLogger('dashboard-service');
 import type { IGatewayDashboardStore, IConversationStore } from '../repositories/types.js';
 import type { IInvestigationReportRepository, IAlertRuleRepository, IGatewayInvestigationStore, IGatewayFeedStore } from '@agentic-obs/data-layer';
 import { createLlmGateway } from '../routes/llm-factory.js';
-import { DashboardOrchestratorAgent as OrchestratorAgent } from '@agentic-obs/agent-core';
+import { DashboardOrchestratorAgent as OrchestratorAgent, AdapterRegistry } from '@agentic-obs/agent-core';
 import type { IDashboardAlertRuleStore as IAlertRuleStore, IDashboardInvestigationStore as IInvestigationStore } from '@agentic-obs/agent-core';
-import { PrometheusMetricsAdapter } from '@agentic-obs/adapters';
+import { PrometheusMetricsAdapter, LokiLogsAdapter } from '@agentic-obs/adapters';
 import type { AccessControlSurface } from './accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
@@ -76,6 +76,46 @@ export function resolvePrometheusDatasource(datasources: InstanceDatasource[]): 
   }
 
   return { url: prom.url, headers };
+}
+
+/** Build HTTP auth headers from an InstanceDatasource's stored credentials. */
+export function datasourceHeaders(ds: InstanceDatasource): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (ds.username && ds.password) {
+    headers.Authorization = `Basic ${Buffer.from(`${ds.username}:${ds.password}`).toString('base64')}`;
+  } else if (ds.apiKey) {
+    headers.Authorization = `Bearer ${ds.apiKey}`;
+  }
+  return headers;
+}
+
+/**
+ * Build an AdapterRegistry from the user's configured datasources.
+ *
+ * Each recognized datasource type is instantiated with the appropriate
+ * backend adapter class and registered under its `id`. Unrecognized types
+ * are skipped silently (the setup wizard may let users save types that
+ * we don't have an adapter for yet; those just won't be queryable by the
+ * agent until an adapter lands).
+ */
+export function buildAdapterRegistry(datasources: InstanceDatasource[]): AdapterRegistry {
+  const registry = new AdapterRegistry();
+  for (const ds of datasources) {
+    const headers = datasourceHeaders(ds);
+    if (ds.type === 'prometheus' || ds.type === 'victoria-metrics') {
+      registry.register({
+        info: { id: ds.id, name: ds.name, type: ds.type, url: ds.url, signalType: 'metrics', isDefault: ds.isDefault },
+        metrics: new PrometheusMetricsAdapter(ds.url, headers),
+      });
+    } else if (ds.type === 'loki') {
+      registry.register({
+        info: { id: ds.id, name: ds.name, type: ds.type, url: ds.url, signalType: 'logs', isDefault: ds.isDefault },
+        logs: new LokiLogsAdapter(ds.url, headers),
+      });
+    }
+    // elasticsearch / clickhouse / tempo / jaeger / otel: adapters not yet implemented
+  }
+  return registry;
 }
 
 // -- Dashboard lock (prevents concurrent mutations on same dashboard)
@@ -182,11 +222,7 @@ export class DashboardService {
 
     const gateway = createLlmGateway(llm);
     const model = llm.model;
-    const prom = resolvePrometheusDatasource(datasources);
-
-    const metricsAdapter = prom
-      ? new PrometheusMetricsAdapter(prom.url, prom.headers)
-      : undefined;
+    const adapters = buildAdapterRegistry(datasources);
 
     const orchestrator = new OrchestratorAgent({
       gateway,
@@ -197,7 +233,7 @@ export class DashboardService {
       investigationStore: this.investigationStore as IInvestigationStore | undefined,
       alertRuleStore: toAlertRuleStore(this.alertRuleStore),
       ...(this.folderRepository ? { folderRepository: this.folderRepository } : {}),
-      metricsAdapter,
+      adapters,
       allDatasources: toAgentDatasources(datasources),
       sendEvent,
       timeRange: timeRange?.start && timeRange?.end

--- a/packages/web/src/components/chat/event-processing.ts
+++ b/packages/web/src/components/chat/event-processing.ts
@@ -85,15 +85,23 @@ export const USER_VISIBLE_TOOLS = new Set([
   'investigate_plan',
   'investigate_query',
   'investigate_analyze',
-  // Prometheus primitives (runtime-first toolized access)
-  'prometheus.query',
-  'prometheus.range_query',
-  'prometheus.labels',
-  'prometheus.label_values',
-  'prometheus.series',
-  'prometheus.metadata',
-  'prometheus.metric_names',
-  'prometheus.validate',
+  // Data source discovery
+  'datasources.list',
+  // Metrics primitives (runtime-first toolized access, source-agnostic)
+  'metrics.query',
+  'metrics.range_query',
+  'metrics.labels',
+  'metrics.label_values',
+  'metrics.series',
+  'metrics.metadata',
+  'metrics.metric_names',
+  'metrics.validate',
+  // Logs primitives
+  'logs.query',
+  'logs.labels',
+  'logs.label_values',
+  // Changes / deployment events
+  'changes.list_recent',
   // Dashboard mutation primitives
   'dashboard.add_panels',
   'dashboard.remove_panels',
@@ -111,11 +119,21 @@ export const USER_VISIBLE_TOOLS = new Set([
  * Convention: tool names with common prefix group together.
  */
 export function phaseOf(tool: string): string {
-  // Prometheus primitives — group by activity type
-  if (tool === 'prometheus.metric_names' || tool === 'prometheus.series' || tool === 'prometheus.metadata') return 'discover';
-  if (tool === 'prometheus.labels' || tool === 'prometheus.label_values') return 'discover';
-  if (tool === 'prometheus.query' || tool === 'prometheus.range_query') return 'query';
-  if (tool === 'prometheus.validate') return 'validate';
+  // Data source discovery
+  if (tool === 'datasources.list') return 'discover';
+
+  // Metrics primitives — group by activity type (mirrors old prometheus mapping 1:1)
+  if (tool === 'metrics.metric_names' || tool === 'metrics.series' || tool === 'metrics.metadata') return 'discover';
+  if (tool === 'metrics.labels' || tool === 'metrics.label_values') return 'discover';
+  if (tool === 'metrics.query' || tool === 'metrics.range_query') return 'query';
+  if (tool === 'metrics.validate') return 'validate';
+
+  // Logs primitives — same split as metrics
+  if (tool === 'logs.labels' || tool === 'logs.label_values') return 'discover';
+  if (tool === 'logs.query') return 'query';
+
+  // Changes / deployment events
+  if (tool === 'changes.list_recent') return 'discover';
 
   // Dashboard mutation primitives
   if (tool.startsWith('dashboard.')) return 'dashboard';
@@ -148,15 +166,23 @@ export const TOOL_LABELS: Record<string, string> = {
   validate_query: 'Validating queries',
   fix_query: 'Fixing queries',
   critic: 'Reviewing panels',
-  // Prometheus primitives
-  'prometheus.query': 'Querying Prometheus',
-  'prometheus.range_query': 'Querying time range',
-  'prometheus.labels': 'Discovering labels',
-  'prometheus.label_values': 'Discovering label values',
-  'prometheus.series': 'Searching series',
-  'prometheus.metadata': 'Fetching metadata',
-  'prometheus.metric_names': 'Listing metrics',
-  'prometheus.validate': 'Validating PromQL',
+  // Data source discovery
+  'datasources.list': 'Listing data sources',
+  // Metrics primitives (source-agnostic)
+  'metrics.query': 'Querying metrics',
+  'metrics.range_query': 'Range-querying metrics',
+  'metrics.labels': 'Listing metric labels',
+  'metrics.label_values': 'Listing label values',
+  'metrics.series': 'Finding metric series',
+  'metrics.metadata': 'Fetching metric metadata',
+  'metrics.metric_names': 'Listing metric names',
+  'metrics.validate': 'Validating query',
+  // Logs primitives
+  'logs.query': 'Searching logs',
+  'logs.labels': 'Listing log labels',
+  'logs.label_values': 'Listing log label values',
+  // Changes / deployment events
+  'changes.list_recent': 'Checking recent changes',
   // Dashboard mutation primitives
   'dashboard.add_panels': 'Adding panels',
   'dashboard.remove_panels': 'Removing panels',

--- a/packages/web/src/constants/datasource-types.ts
+++ b/packages/web/src/constants/datasource-types.ts
@@ -31,7 +31,7 @@ export interface DatasourceTypeInfo {
 export const DATASOURCE_TYPES: DatasourceTypeInfo[] = [
   { value: 'prometheus',       label: 'Prometheus',       category: 'Metrics', supported: true,  icon: 'P',  color: '#06E5F2' },
   { value: 'victoria-metrics', label: 'VictoriaMetrics',  category: 'Metrics', supported: true,  icon: 'VM', color: '#D2619C' },
-  { value: 'loki',             label: 'Loki',             category: 'Logs',    supported: false, icon: 'L',  color: '#7FA835' },
+  { value: 'loki',             label: 'Loki',             category: 'Logs',    supported: true,  icon: 'L',  color: '#7FA835' },
   { value: 'elasticsearch',    label: 'Elasticsearch',    category: 'Logs',    supported: false, icon: 'ES', color: '#00B0F3' },
   { value: 'clickhouse',       label: 'ClickHouse',       category: 'Logs',    supported: false, icon: 'CH', color: '#FFCC00' },
   { value: 'tempo',            label: 'Tempo',            category: 'Traces',  supported: false, icon: 'T',  color: '#FF701F' },


### PR DESCRIPTION
## Summary
Makes the orchestrator work with **whatever data sources the user configures**, not just Prometheus. Also addresses two items from the earlier agent audit:
1. 8 `prometheus.*` tools → `metrics.*` with a required `sourceId` param
2. New `logs.*` (Loki), `changes.list_recent` (wraps existing change-event adapter), and `datasources.list` (discovery) tool families
3. `ctx.metricsAdapter` (single instance) → `ctx.adapters: AdapterRegistry` (per-source)
4. 30-iter hard cap → 200-iter safety ceiling + graceful token-budget termination

Positions the agent for the AI-Ops goal: auto-diagnose using whatever mix of metrics + logs + change correlation the org has installed.

## What's in this PR

### 1. Adapter interfaces + registry (\`T-adapt-A+D\`)
- New \`ILogsAdapter\`, \`IChangesAdapter\`, \`AdapterRegistry\` in \`packages/agent-core/src/adapters/\`
- Frontend \`TOOL_LABELS\` + \`phaseOf\` rewritten for the new tool names (phases mirror the old prometheus.* mapping 1:1)
- 9 new registry tests

### 2. Loki logs adapter (\`T-adapt-B\`)
- \`LokiLogsAdapter\` over \`/loki/api/v1/query_range\` + label discovery endpoints
- BigInt nanosecond timestamp handling, AbortSignal timeouts, structured error mapping matching the Prom adapter style
- 12 HTTP-mocked tests covering happy path, errors, timeouts, matrix-result warning

### 3. Orchestrator refactor (\`T-adapt-C\`)
- **Tool renames** (8): \`prometheus.query\` → \`metrics.query\` (every tool now takes \`sourceId\`)
- **Tool additions** (5): \`logs.query\`, \`logs.labels\`, \`logs.label_values\`, \`changes.list_recent\`, \`datasources.list\`
- **ActionContext**: \`metricsAdapter?: IMetricsAdapter\` removed; \`adapters: AdapterRegistry\` required
- System prompt rewritten to lead with **"call \`datasources.list\` first; every query tool requires \`sourceId\`"**
- Permission scopes mapped 1:1 (metrics.*/logs.* → datasources:read; changes.list_recent → investigations:read; datasources.list → ungated)

### 4. Wiring (\`T-adapt-wiring\`)
- \`packages/api-gateway/src/services/dashboard-service.ts\` now exports \`buildAdapterRegistry(datasources)\` that iterates every configured source and instantiates the right adapter class per type:
  - \`prometheus\` / \`victoria-metrics\` → \`PrometheusMetricsAdapter\` (metrics)
  - \`loki\` → \`LokiLogsAdapter\` (logs)
  - \`elasticsearch\` / \`clickhouse\` / \`tempo\` / \`jaeger\` / \`otel\` — skipped silently (adapters not yet implemented)
- \`chat-service.ts\` + \`dashboard-service.ts\` both call the helper and pass \`adapters\` to the orchestrator
- Settings UI: \`loki\` \`supported: false\` → \`true\` in \`DATASOURCE_TYPES\`

### 5. Token-budget loop termination (\`T-adapt-wiring\`, same commit)
- \`MAX_ITERATIONS\` **30 → 200** (safety ceiling, not a normal terminator)
- NEW token-budget check: estimate messages each turn; if > 95% of \`CONTEXT_WINDOW\` (~121k), exit gracefully with \"ran out of budget, here's where I am\" rather than letting the gateway 429 / context-overflow
- Iteration-ceiling fallback message rewritten — **no more dishonest \"I have completed the requested changes\"** when we actually didn't

## Verification

- \`npx tsc --build\` — clean across 10 packages
- \`npm test\` — **1143 passed / 16 skipped / 0 failed** (baseline 1120, +23 new)
- Mock update in \`packages/api-gateway/src/services/__tests__/dashboard-service.test.ts\` to add \`AdapterRegistry\` to the agent-core mock (was causing 4 failures on first run)

## Manual smoke (recommended before merge)

1. Settings → add 2 Prom datasources with different names + 1 Loki
2. Chat: \"what datasources do I have?\" → expect \`datasources.list\` call listing all 3
3. Chat: \"query up{} against <name-of-second-prom>\" → expect \`metrics.query\` with correct \`sourceId\`
4. Chat: \"show me nginx errors from the last hour\" → expect \`logs.query\` hitting Loki
5. Agent should never silently pick a default when ambiguous between multiple same-signal sources

## Deliberately out of scope (follow-ups)

- **Native Anthropic tool_use API** replacing \`responseFormat: 'json'\` — largest perceived-intelligence lift; separate refactor
- **Extended thinking** (\`thinking\` param) — needs provider capability probe + conditional wiring
- **Multi-tool-per-turn** — still single-action ReAct
- **Traces adapter** (Tempo / Jaeger) — no adapter yet
- **Change-event source registration** — existing in-memory change-event adapter isn't wired into \`buildAdapterRegistry\` yet; \`changes.list_recent\` will return \"no changes datasource\" until that lands

## Commits
- \`f3ae1c9\` T-adapt-A+D: adapter interfaces/registry + frontend labels
- \`303fef5\` T-adapt-B: LokiLogsAdapter over LogQL /query_range + labels
- \`a27e01a\` T-adapt-C: orchestrator source-agnostic tools (metrics/logs/changes)
- \`0de9ee0\` T-adapt-wiring: AdapterRegistry bootstrap + token-budget loop termination
- \`870e087\` docs: log the wave in tech-debt-progress.md