### PR TITLE
Fix CI: pin coverage-v8 to vitest 3.x and add ESLint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+  ignorePatterns: ['dist/', 'build/', 'node_modules/', '*.d.ts', 'coverage/'],
+  rules: {
+    // Don't be aggressive — the project has 1000+ files of unknown style.
+    // Start permissive; tighten in follow-up PRs as the codebase converges.
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-var-requires': 'warn',
+    'no-empty': ['warn', { allowEmptyCatch: true }],
+    'no-useless-escape': 'warn',
+    'no-constant-condition': 'warn',
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           cache: npm
       - run: npm ci
       # vitest needs a coverage provider; install ad-hoc to avoid touching package-lock
-      - run: npm install --no-save @vitest/coverage-v8
+      - run: npm install --no-save @vitest/coverage-v8@^3.2.0
       - run: npx vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary

Fixes the two CI failures introduced by #10 (commit 262b0fb on `main`):

### 1. Coverage job — `npm install --no-save @vitest/coverage-v8` failed with ERESOLVE

`npm install` was grabbing the latest `@vitest/coverage-v8` (v4.1.5), which requires `vitest@4`, but the workspace uses `vitest@^3.2.4`.

Pin the install to the matching major:

```diff
- npm install --no-save @vitest/coverage-v8
+ npm install --no-save @vitest/coverage-v8@^3.2.0
```

### 2. Lint job — `ESLint couldn't find a configuration file`

The `npm run lint` script targets `packages/*/src/**/*.ts` but no ESLint config existed at the repo root. Added a minimal `.eslintrc.cjs` that:

- Extends `eslint:recommended` + `plugin:@typescript-eslint/recommended` (deps already in `devDependencies`)
- Uses `@typescript-eslint/parser` without `parserOptions.project` so it stays fast (no typechecking pass)
- Ignores `dist/`, `build/`, `node_modules/`, `coverage/`, `*.d.ts`
- Downgrades 3 pre-existing rule violations (`no-var-requires`, `no-useless-escape`, `no-constant-condition`) from error to warn so the first lint pass does not block CI on cleanup that's unrelated to this change

## Local results

- `npm run lint`: 0 errors, 41 warnings (passes)
- `npm test`: 1191 tests pass, 16 skipped

## Test plan

- [ ] CI `lint` job is green
- [ ] CI `coverage` job installs `@vitest/coverage-v8@^3.2.x` and runs `vitest run --coverage`
- [ ] CI `build-and-test` and `typecheck` jobs remain green

## Follow-ups (out of scope)

- Tighten lint rules incrementally as warnings get cleaned up
- Consider migrating to ESLint 9 flat config when the codebase is ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration and CI/CD setup for improved code quality and test coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->