### PR TITLE
fix: CI workspace package resolution in vitest coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # Workspace packages (e.g. @agentic-obs/common) have "exports" pointing
+      # at ./dist/*.js, so vitest's resolver needs the compiled output to exist
+      # before tests run. Without this build step, every test that imports a
+      # workspace package fails with "Failed to resolve entry for package".
+      - run: npm run build
       # vitest needs a coverage provider; install ad-hoc to avoid touching package-lock
       - run: npm install --no-save @vitest/coverage-v8@^3.2.0
       - run: npx vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text


### PR DESCRIPTION
## Root cause

The new coverage job added in PR #11 runs:

\`\`\`
npm ci
npm install --no-save @vitest/coverage-v8@^3.2.0
npx vitest run --coverage
\`\`\`

It skips \`npm run build\`. Workspace packages declare \`exports\` pointing at \`./dist/*.js\` (e.g. \`@agentic-obs/common/logging\` → \`./dist/logging/index.js\`), so vite's import-analysis plugin can't resolve any workspace import until \`tsc --build\` produces the dist output. 63 test files failed with the same shape:

\`\`\`
Failed to resolve entry for package \"@agentic-obs/common\".
Cannot find package '@agentic-obs/common/logging' imported from packages/llm-gateway/src/providers/anthropic.ts
Cannot find package '@agentic-obs/common/crypto' imported from packages/data-layer/src/repository/sqlite/instance-shared.ts
\`\`\`

The \`build-and-test\` matrix passes because it runs \`npm run build\` between \`npm ci\` and \`npm test\`.

## Fix

Add \`npm run build\` to the coverage job. Five lines including the comment explaining why.

## Test plan

- [ ] CI \`coverage\` job goes from 63 failed → 0 (or only unrelated test failures)
- [ ] CI \`build-and-test\` matrix stays green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to ensure all workspace dependencies are properly built before executing test coverage checks, improving build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->