### PR TITLE
Follow-up: Gemini fixes, web search, timezone-aware prompt, design rules

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -63,7 +63,7 @@ export interface OrchestratorDeps {
   webSearchAdapter?: IWebSearchAdapter
   allDatasources?: DatasourceConfig[]
   sendEvent: (event: DashboardSseEvent) => void
-  timeRange?: { start: string; end: string; timezone?: string }
+  timeRange?: { start: string; end: string; clientTimezone?: string }
   maxTokenBudget?: number
   /** LLM-generated summary of earlier conversation turns (from context compaction) */
   conversationSummary?: string

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -272,7 +272,7 @@ When sending user-facing text (the "message" field), you're writing for a person
 // Dynamic context sections
 // ---------------------------------------------------------------------------
 
-function getDashboardContextSection(dashboard: Dashboard, timeRange?: { start: string; end: string }): string {
+function getDashboardContextSection(dashboard: Dashboard, timeRange?: { start: string; end: string; clientTimezone?: string }): string {
   const panelsSummary = dashboard.panels.length > 0
     ? dashboard.panels.map((p) => {
         const queries = (p.queries ?? []).map((q) => q.expr).join('; ')
@@ -286,9 +286,29 @@ function getDashboardContextSection(dashboard: Dashboard, timeRange?: { start: s
 
   // Tool-call defaults (which start/end/time to pass) are taught in each
   // tool's schema description, not here. The prompt just supplies the data.
-  const timeRangeText = timeRange
-    ? `\nTime Range: ${timeRange.start} to ${timeRange.end} (user's current panel selection)`
-    : ''
+  // Emit Time Range in BOTH UTC (the format tools take) and the user's
+  // local clock (what panel x-axes display) so the agent can reconcile a
+  // clock time the user reads off a chart with the UTC range it queries.
+  let timeRangeText = ''
+  if (timeRange) {
+    timeRangeText = `\nTime Range (UTC, used in tool calls): ${timeRange.start} to ${timeRange.end}`
+    if (timeRange.clientTimezone) {
+      try {
+        const fmt = new Intl.DateTimeFormat('en-CA', {
+          timeZone: timeRange.clientTimezone,
+          year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit', second: '2-digit',
+          hour12: false,
+        })
+        const localStart = fmt.format(new Date(timeRange.start))
+        const localEnd = fmt.format(new Date(timeRange.end))
+        timeRangeText += `\nTime Range (${timeRange.clientTimezone}, what the user sees on panel x-axes): ${localStart} to ${localEnd}`
+        timeRangeText += `\nWhen the user mentions a clock time (e.g. "9:59"), interpret it as ${timeRange.clientTimezone} local time and convert to UTC before querying. When reporting back, translate UTC timestamps from query results to ${timeRange.clientTimezone} so they match what the user sees on the chart.`
+      } catch {
+        timeRangeText += `\nUser's panel x-axis renders in timezone: ${timeRange.clientTimezone}`
+      }
+    }
+  }
 
   return `# Current Dashboard Context
 dashboardId: ${(dashboard as unknown as { id?: string }).id ?? 'unknown'}
@@ -348,7 +368,7 @@ Not scoped to a dashboard. Use dashboard.create to create one, then use the retu
 
 export interface SystemPromptOptions {
   hasPrometheus: boolean
-  timeRange?: { start: string; end: string }
+  timeRange?: { start: string; end: string; clientTimezone?: string }
   /**
    * Wave 7 — the caller's identity + an optional display name + org name for
    * factual prompt substitution (§D8). When omitted the identity section is

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -38,6 +38,10 @@ Requests fall into four shapes: build something (dashboard / alert), investigate
 2. **Which datasource** — every metrics/logs/changes call requires an explicit \`sourceId\`. Call \`datasources.list\` first. If multiple same-signal sources exist and the user's intent is ambiguous, ask which one before querying.
 3. **Read before mutate** — mutation tools (dashboard.create / add_panels / modify_panel / create_alert_rule / investigation.add_section) need prerequisites verified. Before removing panels, check panel IDs from Dashboard State. Before creating alerts, query current values so the threshold is grounded.
 4. **Validate before adding panels** — panel queries must go through \`metrics.validate\` before \`dashboard.add_panels\`. Exception: pre-deployment dashboards (metrics don't exist yet) — skip validation, use web-researched naming conventions.
+5. **Named target → exporter or label?** — when the user names a target, first decide whether it's a standard system or their own service:
+   - \`web.search\` finds an established exporter naming convention → standard system; use those canonical metric names regardless of what's currently in the backend (empty = pre-deployment).
+   - No exporter found → it's an in-house service; filter existing metrics by label (e.g. \`{service="..."}\` / \`{job="..."}\`). If no matching labels either, ask the user which label identifies it.
+   When no target is named at all (exploratory: "what do I have"), use what the backend actually exposes.
 
 ## Cost asymmetry
 Discovery calls are cheap — a failed \`metric_names\` query burns one tool turn. Mutations and fabricated summaries are expensive — a wrong \`dashboard.add_panels\` pollutes the user's workspace; a made-up "done!" breaks their trust in you. **Spend reads liberally, spend mutations carefully.** If you don't have enough context for a mutation, that's a signal to do more discovery, not to guess.
@@ -64,10 +68,14 @@ Don't abandon a viable approach after one failure, but don't dig on a dead end e
 - When analyzing data ("what's happening with X"), cite specific numbers from actual queries. Never a vague summary without values.
 
 ## Dashboard design
-- Structure: overview stats at top → trends in middle → detailed breakdowns at bottom.
-- Prioritize RED signals: Rate, Errors, Duration. Don't add specialist panels unless asked.
-- 8-15 panels for a focused dashboard. Don't use template variables unless the user asks for drill-down.
-- Before creating any dashboard, use web.search to look up current monitoring best practices for the topic, even on familiar stacks.
+- Structure: overview stats top → trends middle → detailed breakdowns bottom.
+- Cover the dimensions the system's official dashboard covers. For control-plane / infrastructure systems that typically means resource usage (CPU/mem/IO), business flow (config push, request rate, queue depth), health (errors, restarts, cert expiry), and dependencies (downstream API success). Use \`web.search\` to find which dimensions matter for this specific system.
+- Panel design source — never a target to hit, never a cap. Always web-search a reference layout first; build using whichever metric names actually fit:
+  - Standard system → search its official dashboard, use that layout + its canonical exporter metric names.
+  - In-house service → identify the service pattern (HTTP server, gRPC, queue consumer, batch job, scheduled worker, etc.), search best-practice panels for that pattern, then build using existing metrics whose labels match.
+  - Exploratory → match what the backend already exposes.
+- Prioritize RED signals (Rate / Errors / Duration) for request-driven services. Don't add specialist panels for exploratory dashboards unless asked, but DO include them for named system dashboards if the standard layout has them.
+- Don't use template variables unless the user asks for drill-down.
 
 ## Investigations
 When the user asks "why is X high/slow/broken" or "investigate X": create an investigation record with \`investigation.create\`, then run a hypothesis-driven diagnosis — like a senior SRE writing an incident report. The report is primarily written analysis; panels are supporting evidence, not the main content. See the worked Investigation example below for the structure.`

--- a/packages/agent-core/src/agent/react-loop.ts
+++ b/packages/agent-core/src/agent/react-loop.ts
@@ -141,6 +141,14 @@ export interface ReActObservation {
   toolUseId?: string
   batchId?: number
   /**
+   * Provider-specific opaque metadata captured from the ToolCall so it
+   * can be replayed onto the matching tool_use ContentBlock. Most
+   * providers don't use it; Gemini thinking models REQUIRE the
+   * thoughtSignature to round-trip or the next request 400s.
+   */
+  providerMetadata?: Record<string, unknown>
+
+  /**
    * The pre-tool prose the model emitted alongside this batch (only set on
    * the first observation of each batch). Replayed as a text block before
    * the tool_use blocks in the assistant turn.
@@ -410,6 +418,7 @@ export class ReActLoop {
           result: observationText,
           toolUseId: tc.id,
           batchId,
+          ...(tc.providerMetadata ? { providerMetadata: tc.providerMetadata } : {}),
           // Only the first tool of the batch carries the pre-tool prose so
           // we don't repeat it across N tool_result blocks.
           ...(tc === toolCalls[0] && preToolProse ? { preToolText: preToolProse } : {}),
@@ -507,6 +516,7 @@ export class ReActLoop {
           id,
           name: obs.action,
           input: obs.args,
+          ...(obs.providerMetadata ? { providerMetadata: obs.providerMetadata } : {}),
         })
       }
       messages.push({ role: 'assistant', content: assistantBlocks })

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -102,7 +102,7 @@ export class ChatService {
     sessionId: string | undefined,
     sendEvent: (event: DashboardSseEvent) => void,
     identity: Identity,
-    pageContext?: { kind: string; id?: string; timeRange?: string },
+    pageContext?: { kind: string; id?: string; timeRange?: string; clientTimezone?: string },
     signal?: AbortSignal,
   ): Promise<ChatSessionResult> {
     const llm = await this.deps.setupConfig.getLlm();
@@ -162,8 +162,11 @@ export class ChatService {
     const model = llm.model;
     const adapters = buildAdapterRegistry(datasources);
 
-    // Parse relative time range (e.g., "1h", "6h", "24h", "7d") to absolute start/end
-    let timeRange: { start: string; end: string } | undefined;
+    // Parse relative time range (e.g., "1h", "6h", "24h", "7d") to absolute
+    // start/end. Carry the client's IANA timezone so the prompt can label
+    // both UTC and local time — without that the agent can't reconcile a
+    // clock time the user reads off the panel's x-axis.
+    let timeRange: { start: string; end: string; clientTimezone?: string } | undefined;
     if (pageContext?.timeRange) {
       const now = new Date();
       const match = pageContext.timeRange.match(/^(\d+)([mhd])$/);
@@ -171,7 +174,11 @@ export class ChatService {
         const amount = Number(match[1]);
         const unit = match[2];
         const ms = unit === 'm' ? amount * 60_000 : unit === 'h' ? amount * 3_600_000 : amount * 86_400_000;
-        timeRange = { start: new Date(now.getTime() - ms).toISOString(), end: now.toISOString() };
+        timeRange = {
+          start: new Date(now.getTime() - ms).toISOString(),
+          end: now.toISOString(),
+          ...(pageContext.clientTimezone ? { clientTimezone: pageContext.clientTimezone } : {}),
+        };
       }
     }
 

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -5,6 +5,11 @@ import { createLlmGateway } from '../routes/llm-factory.js';
 import { DashboardOrchestratorAgent as OrchestratorAgent, shouldCompact, compactMessages } from '@agentic-obs/agent-core';
 import type { IConversationStore as IAgentConversationStore, IDashboardAlertRuleStore as IAlertRuleStore, IDashboardInvestigationStore as IInvestigationStore } from '@agentic-obs/agent-core';
 import { buildAdapterRegistry, toAgentDatasources } from './dashboard-service.js';
+import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
+
+// Web-search adapter is configuration-free for the default DuckDuckGo
+// backend, so a single shared instance per process is fine.
+const sharedWebSearchAdapter = new DuckDuckGoSearchAdapter();
 import type { AccessControlSurface } from './accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
@@ -225,6 +230,7 @@ export class ChatService {
       alertRuleStore: toAlertRuleStore(this.deps.alertRuleStore),
       ...(this.deps.folderRepository ? { folderRepository: this.deps.folderRepository } : {}),
       adapters,
+      webSearchAdapter: sharedWebSearchAdapter,
       allDatasources: toAgentDatasources(datasources),
       sendEvent: wrappedSendEvent,
       timeRange,

--- a/packages/llm-gateway/src/providers/__tests__/gemini.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/gemini.test.ts
@@ -98,12 +98,12 @@ describe('GeminiProvider', () => {
         {
           functionDeclarations: [
             {
-              name: 'metrics_query',
+              name: 'metrics__query',
               description: 'Query a metrics source',
               parameters: queryTool.input_schema,
             },
             {
-              name: 'logs_search',
+              name: 'logs__search',
               description: 'Search logs',
               parameters: logsTool.input_schema,
             },
@@ -192,7 +192,7 @@ describe('GeminiProvider', () => {
       expect(body['toolConfig']).toEqual({
         functionCallingConfig: {
           mode: 'ANY',
-          allowedFunctionNames: ['metrics_query'],
+          allowedFunctionNames: ['metrics__query'],
         },
       });
     });
@@ -236,7 +236,7 @@ describe('GeminiProvider', () => {
                 parts: [
                   {
                     functionCall: {
-                      name: 'metrics_query',
+                      name: 'metrics__query',
                       args: { sourceId: 'prom', query: 'up' },
                     },
                   },
@@ -271,7 +271,7 @@ describe('GeminiProvider', () => {
             {
               content: {
                 role: 'model',
-                parts: [{ functionCall: { name: 'logs_search' } }],
+                parts: [{ functionCall: { name: 'logs__search' } }],
               },
             },
           ],
@@ -300,14 +300,14 @@ describe('GeminiProvider', () => {
                   { text: 'Let me check the metrics ' },
                   {
                     functionCall: {
-                      name: 'metrics_query',
+                      name: 'metrics__query',
                       args: { sourceId: 'prom', query: 'up' },
                     },
                   },
                   { text: 'and the logs.' },
                   {
                     functionCall: {
-                      name: 'logs_search',
+                      name: 'logs__search',
                       args: { q: 'error' },
                     },
                   },
@@ -402,7 +402,7 @@ describe('GeminiProvider', () => {
       const responsePart = contents[2]!.parts[0] as {
         functionResponse: { name: string; response: { result: string } };
       };
-      expect(responsePart.functionResponse.name).toBe('metrics_query');
+      expect(responsePart.functionResponse.name).toBe('metrics__query');
       expect(responsePart.functionResponse.response.result).toBe('1 1 1');
     });
   });

--- a/packages/llm-gateway/src/providers/gemini.ts
+++ b/packages/llm-gateway/src/providers/gemini.ts
@@ -32,6 +32,13 @@ interface GeminiFunctionCallPart {
     name: string;
     args?: Record<string, unknown>;
   };
+  /**
+   * Opaque token Gemini attaches to functionCall parts on thinking-enabled
+   * models. The next request that includes this functionCall in its history
+   * MUST echo the signature back or the API rejects with 400
+   * ("Function call is missing a thought_signature").
+   */
+  thoughtSignature?: string;
 }
 
 type GeminiResponsePart = GeminiTextPart | GeminiFunctionCallPart | Record<string, unknown>;
@@ -79,20 +86,21 @@ interface GeminiToolConfig {
 // -- Tool-name normalization --
 //
 // Gemini's function name regex is roughly ^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$ — dots
-// are NOT allowed. Our canonical names use dots (e.g. `metrics.query`). We map
-// `.` -> `_` outbound and reverse on the way back.
+// are NOT allowed. Our canonical names use dots (e.g. `metrics.query`,
+// `metrics.metric_names`). Single `_` would be lossy: `metric_names` already
+// contains an underscore, so a `.` -> `_` then `_` -> `.` round-trip turns
+// `metrics.metric_names` into `metrics.metric.names` and the dispatch breaks.
 //
-// Collision risk: `dashboard.add_panels` and `dashboard_add_panels` would both
-// collapse to `dashboard_add_panels`. We don't currently ship any tool name that
-// natively contains an underscore in a position that would collide with a dotted
-// counterpart, so a runtime check would be paranoid. Add one if/when the tool
-// catalog grows large enough that the assumption is no longer obvious.
+// Encode `.` as `__` instead (same trick as the OpenAI provider). Double
+// underscore is symmetrical and won't collide with our existing canonical
+// names since none currently contain `__`.
+const NAME_DELIM = '__';
 function nameToGemini(canonical: string): string {
-  return canonical.replace(/\./g, '_');
+  return canonical.replace(/\./g, NAME_DELIM);
 }
 
 function nameFromGemini(geminiName: string): string {
-  return geminiName.replace(/_/g, '.');
+  return geminiName.replace(new RegExp(NAME_DELIM, 'g'), '.');
 }
 
 export class GeminiProvider implements LLMProvider {
@@ -128,7 +136,19 @@ export class GeminiProvider implements LLMProvider {
         if (b.type === 'text') {
           parts.push({ text: b.text });
         } else if (b.type === 'tool_use') {
-          parts.push({ functionCall: { name: nameToGemini(b.name), args: b.input } });
+          // Echo the thoughtSignature back when present — Gemini thinking
+          // models reject the request without it (400 "missing
+          // thought_signature"). Stored on providerMetadata when we parsed
+          // the original response.
+          const meta = b.providerMetadata ?? {};
+          const sig = typeof meta['thoughtSignature'] === 'string'
+            ? (meta['thoughtSignature'] as string)
+            : undefined;
+          const part: Record<string, unknown> = {
+            functionCall: { name: nameToGemini(b.name), args: b.input },
+          };
+          if (sig) part['thoughtSignature'] = sig;
+          parts.push(part);
         } else if (b.type === 'tool_result') {
           // Gemini wants the tool result as a structured response; we emit text wrapped
           // in `result` so the model can read the observation regardless of shape.
@@ -249,12 +269,20 @@ export class GeminiProvider implements LLMProvider {
         (part as GeminiFunctionCallPart).functionCall &&
         typeof (part as GeminiFunctionCallPart).functionCall.name === 'string'
       ) {
-        const fc = (part as GeminiFunctionCallPart).functionCall;
-        toolCalls.push({
+        const fcPart = part as GeminiFunctionCallPart;
+        const fc = fcPart.functionCall;
+        const tc: ToolCall = {
           id: `gemini_call_${callIndex}`,
           name: nameFromGemini(fc.name),
           input: fc.args ?? {},
-        });
+        };
+        // Thinking-enabled Gemini models attach a per-call thoughtSignature
+        // that must be echoed on replay. Stash it in providerMetadata so the
+        // agent loop can thread it through ContentBlock['tool_use'].
+        if (typeof fcPart.thoughtSignature === 'string') {
+          tc.providerMetadata = { thoughtSignature: fcPart.thoughtSignature };
+        }
+        toolCalls.push(tc);
         callIndex++;
       }
     }

--- a/packages/llm-gateway/src/types.ts
+++ b/packages/llm-gateway/src/types.ts
@@ -19,7 +19,23 @@ export interface CompletionMessage {
 
 export type ContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | {
+      type: 'tool_use';
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+      /**
+       * Provider-specific opaque metadata that MUST round-trip back to the
+       * provider on replay. Examples:
+       *   - Gemini thinking models attach a `thought_signature` to each
+       *     functionCall part; the next request's history must echo it or
+       *     the API rejects with 400 ("missing thought_signature").
+       *   - Anthropic extended-thinking attaches a per-block signature to
+       *     `tool_use` blocks emitted from a thinking turn.
+       * Treat as passthrough — the gateway does not interpret the contents.
+       */
+      providerMetadata?: Record<string, unknown>;
+    }
   | { type: 'tool_result'; tool_use_id: string; tool_name: string; content: string; is_error?: boolean };
 
 export interface LLMOptions {
@@ -101,6 +117,13 @@ export interface ToolCall {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  /**
+   * Provider-specific opaque metadata that the agent loop must thread back
+   * onto the matching `tool_use` ContentBlock when replaying conversation
+   * history. See `ContentBlock['tool_use'].providerMetadata` for the
+   * load-bearing example (Gemini thoughtSignature).
+   */
+  providerMetadata?: Record<string, unknown>;
 }
 
 // -- Provider errors -----------------------------------------------------

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -10,6 +10,10 @@ export interface PageContext {
   id?: string;
   /** Selected time range on the dashboard (e.g., "1h", "6h", "24h", "7d") */
   timeRange?: string;
+  /** IANA timezone the panel x-axis is rendered in (browser local). The
+   *  agent uses this to translate clock times the user mentions ("9:59")
+   *  into the UTC range it queries. Set automatically from the browser. */
+  clientTimezone?: string;
 }
 
 export interface UseChatResult {
@@ -253,12 +257,19 @@ export function useChat(): UseChatResult {
       setIsGenerating(true);
 
       try {
+        // Always inject the browser's local timezone so the agent can map
+        // any clock time the user mentions ("9:59" off the panel's x-axis)
+        // back to the UTC range it actually queries against.
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const ctxWithTz = pageContextRef.current
+          ? { ...pageContextRef.current, clientTimezone: tz }
+          : { kind: 'home', clientTimezone: tz };
         await apiClient.postStream(
           '/chat',
           {
             message: content,
             sessionId: sessionIdRef.current,
-            ...(pageContextRef.current ? { pageContext: pageContextRef.current } : {}),
+            pageContext: ctxWithTz,
           },
           handleSSEEvent,
           abortRef.current.signal,


### PR DESCRIPTION
Follow-up to PR #14. Three categories of fix discovered while testing the previous PR end-to-end against Gemini and OpenAI providers.

## 1. Gemini provider correctness (2 fixes)

- **Tool-name encoding was lossy.** Single \`_\` collapsed \`metrics.metric_names\` to \`metrics_metric_names\` then back to \`metrics.metric.names\` (3 dots) — dispatch broke for any tool whose canonical name contains an underscore. Switch to \`__\` (the same encoding the OpenAI provider already uses).
- **\`thoughtSignature\` not round-tripped.** Gemini thinking models attach a per-call signature to functionCall parts; the next request must echo it or the API rejects with 400 (\`Function call is missing a thought_signature\`). Added optional \`providerMetadata\` passthrough on \`ContentBlock['tool_use']\` + \`ToolCall\` so Gemini parses the signature in and re-emits it on replay. Other providers ignore the field.

## 2. Web search regression

The legacy chat-service deletion in PR #14 was the only place injecting a \`webSearchAdapter\`. Wire a process-shared \`DuckDuckGoSearchAdapter\` so \`web.search\` actually works again.

## 3. Orchestrator prompt — design rules + timezone

- **Honor the user's named target.** New decision-flow rule: standard system → use canonical exporter names regardless of what's in the backend (treat empty as pre-deployment); in-house service → search the service's pattern's best-practice layout, build with existing metrics whose labels match; exploratory → use what the backend exposes. Without this rule the agent was substituting unrelated services' Go runtime metrics when asked to build an istiod / order-service dashboard.
- **Drop the 8-15 panel cap.** Panel count follows the official / pattern-standard layout — never a target to hit, never a cap. A simple service has few panels; a control-plane system has many.
- **Timezone-aware time range.** Browser sends \`Intl.DateTimeFormat().resolvedOptions().timeZone\`; prompt emits the panel's time range in BOTH UTC (the tool-call format) and the user's local TZ (what panel x-axes display) plus an explicit instruction to interpret user-mentioned clock times as local and translate UTC query results back. Without this the agent would loop forever trying to find a spike at "9:59" in UTC when the user meant 9:59 local.

## Test plan

- [ ] CI green (lint / typecheck / build-and-test / coverage)
- [ ] Manual: ask Gemini-thinking model to "create a dashboard for istiod" — completes without 400, web.search works, dashboard uses \`istio_*\` canonical names not unrelated metrics
- [ ] Manual: on a dashboard with timeRange=1h, ask "why is the spike at 9:59" — agent translates 9:59 local → UTC, finds the spike, reports back in local time
- [ ] Manual: \`metrics.metric_names\` named correctly (no \`metrics.metric.names\` typo) on Gemini provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now supports web search to identify targets and resolve metric requests.
  * Added client timezone awareness to convert local times to UTC for queries and back for reporting.

* **Improvements**
  * Enhanced target disambiguation logic to distinguish between standard exporters and in-house services.
  * Improved dashboard guidance with better dimension coverage matching and web-search-based panel recommendations.
  * Better support for advanced LLM models with metadata propagation through the conversation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->