### PR TITLE
Add policy-gated Ops command connectors

### DIFF
--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -50,6 +50,8 @@ agentRegistry.register({
     'logs.query', 'logs.labels', 'logs.label_values',
     // Recent change events
     'changes.list_recent',
+    // Kubernetes / Ops integrations (requires configured connector + RBAC)
+    'ops.run_command',
     // Knowledge
     'web.search',
     // Alert rules

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -27,6 +27,8 @@ export type AgentToolName =
   | 'logs.query' | 'logs.labels' | 'logs.label_values'
   // Recent change events (deploys, config rollouts, incidents)
   | 'changes.list_recent'
+  // Kubernetes / Ops integrations
+  | 'ops.run_command'
   // Datasource discovery (always-allowed, no RBAC)
   | 'datasources.list'
   // Knowledge & utility

--- a/packages/agent-core/src/agent/handlers/__tests__/ops.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/ops.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AdapterRegistry } from '../../../adapters/index.js';
+import { handleOpsRunCommand } from '../ops.js';
+import type { ActionContext } from '../_context.js';
+
+function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    gateway: {} as ActionContext['gateway'],
+    model: 'test',
+    store: {} as ActionContext['store'],
+    investigationReportStore: {} as ActionContext['investigationReportStore'],
+    alertRuleStore: {} as ActionContext['alertRuleStore'],
+    adapters: new AdapterRegistry(),
+    sendEvent: vi.fn(),
+    sessionId: 'session-1',
+    identity: { userId: 'u1', orgId: 'org1', orgRole: 'Admin', isServerAdmin: false, authenticatedBy: 'session' },
+    accessControl: {
+      evaluate: async () => true,
+      filterByPermission: async (_id, rows) => rows,
+    },
+    actionExecutor: {} as ActionContext['actionExecutor'],
+    alertRuleAgent: {} as ActionContext['alertRuleAgent'],
+    emitAgentEvent: vi.fn(),
+    makeAgentEvent: ((type: string) => ({ type, agentType: 'orchestrator', timestamp: '' })) as ActionContext['makeAgentEvent'],
+    pushConversationAction: vi.fn(),
+    setNavigateTo: vi.fn(),
+    investigationSections: new Map(),
+    ...overrides,
+  } as ActionContext;
+}
+
+describe('handleOpsRunCommand', () => {
+  it('returns a clear not-configured observation when no runner is wired', async () => {
+    const ctx = makeCtx();
+    const result = await handleOpsRunCommand(ctx, {
+      connectorId: 'kube-prod',
+      command: 'kubectl get pods',
+      intent: 'read',
+    });
+
+    expect(result).toContain('Ops command runner is not configured');
+  });
+
+  it('does not call the runner when no connectors are configured', async () => {
+    const runCommand = vi.fn();
+    const ctx = makeCtx({
+      opsCommandRunner: {
+        listConnectors: async () => [],
+        runCommand,
+      },
+    });
+
+    const result = await handleOpsRunCommand(ctx, {
+      connectorId: 'kube-prod',
+      command: 'kubectl get pods',
+      intent: 'read',
+    });
+
+    expect(result).toContain('No Ops connectors are configured');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('passes connectorId, command, intent, identity, and sessionId to the runner', async () => {
+    const runCommand = vi.fn(async () => ({ observation: 'pods listed' }));
+    const ctx = makeCtx({
+      opsConnectors: [{ id: 'kube-prod', name: 'Production' }],
+      opsCommandRunner: { runCommand },
+    });
+
+    const result = await handleOpsRunCommand(ctx, {
+      connectorId: 'kube-prod',
+      command: 'kubectl get pods -n api',
+      intent: 'read',
+    });
+
+    expect(result).toBe('pods listed');
+    expect(runCommand).toHaveBeenCalledWith({
+      connectorId: 'kube-prod',
+      command: 'kubectl get pods -n api',
+      intent: 'read',
+      identity: ctx.identity,
+      sessionId: 'session-1',
+    });
+  });
+});

--- a/packages/agent-core/src/agent/handlers/_context.ts
+++ b/packages/agent-core/src/agent/handlers/_context.ts
@@ -22,6 +22,8 @@ import type {
   IInvestigationStore,
   IAlertRuleStore,
   DatasourceConfig,
+  OpsCommandRunner,
+  OpsConnectorConfig,
 } from '../types.js';
 import type { ActionExecutor } from '../action-executor.js';
 import type { AlertRuleAgent } from '../alert-rule-agent.js';
@@ -48,6 +50,8 @@ export interface ActionContext {
   adapters: AdapterRegistry;
   webSearchAdapter?: IWebSearchAdapter;
   allDatasources?: DatasourceConfig[];
+  opsCommandRunner?: OpsCommandRunner;
+  opsConnectors?: OpsConnectorConfig[];
   sendEvent: (event: DashboardSseEvent) => void;
   sessionId: string;
 

--- a/packages/agent-core/src/agent/handlers/index.ts
+++ b/packages/agent-core/src/agent/handlers/index.ts
@@ -58,3 +58,4 @@ export { handleDatasourcesList } from './datasources.js';
 export { handleWebSearch } from './web.js';
 export { handleNavigate } from './navigation.js';
 export { handleFolderCreate, handleFolderList } from './folder.js';
+export { handleOpsRunCommand } from './ops.js';

--- a/packages/agent-core/src/agent/handlers/ops.ts
+++ b/packages/agent-core/src/agent/handlers/ops.ts
@@ -1,0 +1,64 @@
+import type { ActionContext } from './_context.js';
+import { withToolEventBoundary } from './_shared.js';
+
+export async function handleOpsRunCommand(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const connectorId = typeof args.connectorId === 'string' ? args.connectorId.trim() : '';
+  const command = typeof args.command === 'string' ? args.command.trim() : '';
+  const intent = typeof args.intent === 'string' && args.intent.trim()
+    ? args.intent.trim()
+    : 'read';
+
+  return withToolEventBoundary(
+    ctx.sendEvent,
+    'ops.run_command',
+    { connectorId, command, intent },
+    connectorId ? `Running ops command on ${connectorId}` : 'Running ops command',
+    async () => {
+      if (!ctx.opsCommandRunner) {
+        return 'Ops command runner is not configured. Connect a Kubernetes/Ops integration before querying cluster state.';
+      }
+      if (!connectorId) {
+        return 'ops.run_command requires connectorId. List configured Ops connectors in Settings and choose one before running a command.';
+      }
+      if (!command) {
+        return 'ops.run_command requires a command.';
+      }
+
+      const connectors = ctx.opsConnectors ?? await ctx.opsCommandRunner.listConnectors?.();
+      if (Array.isArray(connectors)) {
+        if (connectors.length === 0) {
+          return 'No Ops connectors are configured. Connect a Kubernetes/Ops integration before querying cluster state.';
+        }
+        const selected = connectors.find((connector) => connector.id === connectorId);
+        if (!selected) {
+          return `Ops connector "${connectorId}" is not configured. Choose one of: ${connectors.map((connector) => connector.id).join(', ')}.`;
+        }
+      }
+
+      const result = await ctx.opsCommandRunner.runCommand({
+        connectorId,
+        command,
+        intent,
+        identity: ctx.identity,
+        sessionId: ctx.sessionId,
+      });
+
+      return formatOpsCommandResult(result);
+    },
+  );
+}
+
+function formatOpsCommandResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  if (result && typeof result === 'object') {
+    const record = result as Record<string, unknown>;
+    if (typeof record.observation === 'string') return record.observation;
+    if (typeof record.summary === 'string') return record.summary;
+    if (typeof record.message === 'string') return record.message;
+    return JSON.stringify(record);
+  }
+  return String(result ?? 'Ops command completed with no output.');
+}

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -48,6 +48,9 @@ export type {
   IInvestigationStore,
   IAlertRuleStore,
   DatasourceConfig,
+  OpsCommandIntent,
+  OpsConnectorConfig,
+  OpsCommandRunner,
 } from './types.js'
 
 // Context compaction

--- a/packages/agent-core/src/agent/orchestrator-action-context.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-context.ts
@@ -13,6 +13,8 @@ import type { AlertRuleAgent } from './alert-rule-agent.js';
 import type { ActionContext } from './orchestrator-action-handlers.js';
 import type {
   DatasourceConfig,
+  OpsCommandRunner,
+  OpsConnectorConfig,
   IDashboardAgentStore,
   IAlertRuleStore,
   IConversationStore,
@@ -33,6 +35,8 @@ export interface OrchestratorActionContextDeps {
   adapters: AdapterRegistry;
   webSearchAdapter?: IWebSearchAdapter;
   allDatasources?: DatasourceConfig[];
+  opsCommandRunner?: OpsCommandRunner;
+  opsConnectors?: OpsConnectorConfig[];
   sendEvent: (event: DashboardSseEvent) => void;
   identity: Identity;
   accessControl: IAccessControlService;
@@ -64,6 +68,8 @@ export function buildActionContext(
     adapters: deps.adapters,
     webSearchAdapter: deps.webSearchAdapter,
     allDatasources: deps.allDatasources,
+    opsCommandRunner: deps.opsCommandRunner,
+    opsConnectors: deps.opsConnectors,
     sendEvent: deps.sendEvent,
     sessionId: runtime.sessionId,
     identity: deps.identity,

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -45,4 +45,5 @@ export {
   handleNavigate,
   handleFolderCreate,
   handleFolderList,
+  handleOpsRunCommand,
 } from './handlers/index.js';

--- a/packages/agent-core/src/agent/orchestrator-action-runner.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-runner.ts
@@ -40,6 +40,7 @@ import {
   handleNavigate,
   handleFolderCreate,
   handleFolderList,
+  handleOpsRunCommand,
 } from './orchestrator-action-handlers.js';
 import type { ToolAuditReporter } from './orchestrator-audit-reporter.js';
 
@@ -186,6 +187,8 @@ async function dispatchAction(
     case 'logs.label_values': return handleLogsLabelValues(ctx, args);
     // Recent change events
     case 'changes.list_recent': return handleChangesListRecent(ctx, args);
+    // Kubernetes / Ops integrations
+    case 'ops.run_command': return handleOpsRunCommand(ctx, args);
     // Web search
     case 'web.search': return handleWebSearch(ctx, args);
     // 'finish' is handled as a terminal action in ReActLoop

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -15,6 +15,8 @@ import type {
   IInvestigationStore,
   IAlertRuleStore,
   DatasourceConfig,
+  OpsCommandRunner,
+  OpsConnectorConfig,
 } from './types.js'
 import type { AdapterRegistry, IWebSearchAdapter } from '../adapters/index.js'
 import type { LLMGateway } from '@agentic-obs/llm-gateway'
@@ -62,6 +64,8 @@ export interface OrchestratorDeps {
   adapters: AdapterRegistry
   webSearchAdapter?: IWebSearchAdapter
   allDatasources?: DatasourceConfig[]
+  opsCommandRunner?: OpsCommandRunner
+  opsConnectors?: OpsConnectorConfig[]
   sendEvent: (event: DashboardSseEvent) => void
   timeRange?: { start: string; end: string; clientTimezone?: string }
   maxTokenBudget?: number
@@ -264,6 +268,7 @@ export class OrchestratorAgent {
       timeRange: this.deps.timeRange ? { start: this.deps.timeRange.start, end: this.deps.timeRange.end } : undefined,
       identity: this.deps.identity,
       permissionEscalationContact: this.deps.permissionEscalationContact,
+      opsConnectors: this.deps.opsConnectors,
     })
 
     try {

--- a/packages/agent-core/src/agent/orchestrator-audit-reporter.ts
+++ b/packages/agent-core/src/agent/orchestrator-audit-reporter.ts
@@ -87,6 +87,7 @@ function inferTargetType(tool: string): string | null {
     return 'datasource';
   }
   if (tool === 'changes.list_recent') return 'changes';
+  if (tool.startsWith('ops.')) return 'ops_connector';
   if (tool.startsWith('alert_rule.') || tool === 'create_alert_rule' || tool === 'modify_alert_rule' || tool === 'delete_alert_rule') {
     return 'alert_rule';
   }
@@ -101,6 +102,7 @@ function inferTargetId(tool: string, args: Record<string, unknown>): string | nu
   if (tool.startsWith('metrics.') || tool.startsWith('logs.') || tool === 'changes.list_recent') {
     return pickString(args.sourceId ?? args.datasourceId ?? args.datasourceUid);
   }
+  if (tool.startsWith('ops.')) return pickString(args.connectorId);
   if (tool === 'create_alert_rule') return pickString(args.folderUid);
   if (tool === 'modify_alert_rule' || tool === 'delete_alert_rule' || tool === 'alert_rule.history') {
     return pickString(args.ruleId);

--- a/packages/agent-core/src/agent/orchestrator-prompt.test.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.test.ts
@@ -87,6 +87,39 @@ describe('buildSystemPrompt — identity section is suppressed without identity'
   });
 });
 
+describe('buildSystemPrompt — Ops connector guidance', () => {
+  it('states that cluster queries require a configured connector and write commands propose approval', () => {
+    const prompt = build();
+    expect(prompt).toContain('cluster/Kubernetes questions require a configured Ops connector');
+    expect(prompt).toContain('do not invent a cluster');
+    expect(prompt).toContain('intent="read"');
+    expect(prompt).toContain('intent="propose"');
+    expect(prompt).toContain('approval/proposal');
+  });
+
+  it('shows not connected when no Ops connectors are configured', () => {
+    const prompt = build();
+    expect(prompt).toContain('# Ops Integrations\nnot connected');
+  });
+
+  it('lists configured Ops connectors when provided', () => {
+    const prompt = buildSystemPrompt(null, [], [], null, [], {
+      hasPrometheus: false,
+      now: '2026-04-18T00:00:00.000Z',
+      opsConnectors: [{
+        id: 'kube-prod',
+        name: 'Production Kubernetes',
+        environment: 'prod',
+        namespaces: ['default', 'api'],
+        capabilities: ['read', 'propose'],
+      }],
+    });
+    expect(prompt).toContain('connectorId="kube-prod"');
+    expect(prompt).toContain('namespaces=default,api');
+    expect(prompt).toContain('capabilities=read,propose');
+  });
+});
+
 describe('buildSystemPrompt — T6.C role-conditional nudge', () => {
   const VIEWER_LINE = 'You are operating as a Viewer.';
   const EDITOR_LINE = 'You are operating as an Editor.';

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -1,6 +1,6 @@
 import type { Dashboard, DashboardMessage, Identity } from '@agentic-obs/common'
 import type { AlertRuleSummary } from './orchestrator-alert-helpers.js'
-import type { DatasourceConfig } from './types.js'
+import type { DatasourceConfig, OpsConnectorConfig } from './types.js'
 import { buildStructuredAlertHistory } from './orchestrator-alert-helpers.js'
 
 // ---------------------------------------------------------------------------
@@ -36,9 +36,10 @@ Requests fall into four shapes: build something (dashboard / alert), investigate
 ## Decision flow before any tool call
 1. **Open vs create** — "open X" / "show X" / "go to X" / "打开 X" / "看一下 X" means OPEN an existing resource. List first (dashboard.list / investigation.list / alert_rule.list) with a filter keyword, then navigate. Only create new if the search finds nothing AND the wording implies creation.
 2. **Which datasource** — every metrics/logs/changes call requires an explicit \`sourceId\`. Call \`datasources.list\` first. If multiple same-signal sources exist and the user's intent is ambiguous, ask which one before querying.
-3. **Read before mutate** — mutation tools (dashboard.create / add_panels / modify_panel / create_alert_rule / investigation.add_section) need prerequisites verified. Before removing panels, check panel IDs from Dashboard State. Before creating alerts, query current values so the threshold is grounded.
-4. **Validate before adding panels** — panel queries must go through \`metrics.validate\` before \`dashboard.add_panels\`. Exception: pre-deployment dashboards (metrics don't exist yet) — skip validation, use web-researched naming conventions.
-5. **Named target → exporter or label?** — when the user names a target, first decide whether it's a standard system or their own service:
+3. **Ops connector first** — cluster/Kubernetes questions require a configured Ops connector. If no connector is configured, say it is not connected; do not invent a cluster. Read-only commands may run through \`ops.run_command\` with \`intent="read"\`; write/mutating commands must use \`intent="propose"\` so the connector returns an approval/proposal unless an approved execution is explicitly being run.
+4. **Read before mutate** — mutation tools (dashboard.create / add_panels / modify_panel / create_alert_rule / investigation.add_section) need prerequisites verified. Before removing panels, check panel IDs from Dashboard State. Before creating alerts, query current values so the threshold is grounded.
+5. **Validate before adding panels** — panel queries must go through \`metrics.validate\` before \`dashboard.add_panels\`. Exception: pre-deployment dashboards (metrics don't exist yet) — skip validation, use web-researched naming conventions.
+6. **Named target → exporter or label?** — when the user names a target, first decide whether it's a standard system or their own service:
    - \`web.search\` finds an established exporter naming convention → standard system; use those canonical metric names regardless of what's currently in the backend (empty = pre-deployment).
    - No exporter found → it's an in-house service; filter existing metrics by label (e.g. \`{service="..."}\` / \`{job="..."}\`). If no matching labels either, ask the user which label identifies it.
    When no target is named at all (exploratory: "what do I have"), use what the backend actually exposes.
@@ -338,6 +339,17 @@ function getDatasourceSection(allDatasources: DatasourceConfig[]): string {
     `- sourceId="${d.id}" name="${d.name}" type=${d.type}${d.environment ? ` env=${d.environment}` : ''}${d.isDefault ? ' DEFAULT' : ''}`).join('\n')}`
 }
 
+function getOpsConnectorSection(connectors: OpsConnectorConfig[] | undefined): string {
+  if (!connectors || connectors.length === 0) {
+    return '\n# Ops Integrations\nnot connected'
+  }
+  return `\n# Ops Integrations\n${connectors.map((connector) => {
+    const namespaces = connector.namespaces?.length ? ` namespaces=${connector.namespaces.join(',')}` : ''
+    const capabilities = connector.capabilities?.length ? ` capabilities=${connector.capabilities.join(',')}` : ''
+    return `- connectorId="${connector.id}" name="${connector.name}"${connector.environment ? ` env=${connector.environment}` : ''}${namespaces}${capabilities}`
+  }).join('\n')}`
+}
+
 function getAlertRulesSection(
   alertRules: AlertRuleSummary[],
   activeAlertRule: AlertRuleSummary | null,
@@ -383,6 +395,7 @@ export interface SystemPromptOptions {
   permissionEscalationContact?: string
   /** Override for deterministic tests. Defaults to `new Date().toISOString()`. */
   now?: string
+  opsConnectors?: OpsConnectorConfig[]
 }
 
 /**
@@ -486,6 +499,7 @@ export function buildSystemPrompt(
     dashboard ? getDashboardContextSection(dashboard, options?.timeRange) : getSessionModeSection(),
     getHistorySection(history),
     getDatasourceSection(allDatasources),
+    getOpsConnectorSection(options?.opsConnectors),
     getAlertRulesSection(alertRules, activeAlertRule, history),
   ]
 

--- a/packages/agent-core/src/agent/tool-permissions.test.ts
+++ b/packages/agent-core/src/agent/tool-permissions.test.ts
@@ -95,6 +95,23 @@ describe('TOOL_PERMS — per-builder scope derivation', () => {
     );
   });
 
+  it('ops.run_command is gated by connector scope', () => {
+    const e = TOOL_PERMS['ops.run_command']!(
+      { connectorId: 'kube-prod', command: 'kubectl get pods', intent: 'read' },
+      makeCtx(),
+    );
+    expect((e as { string: () => string }).string()).toBe(
+      'any(ops.commands:run on ops.connectors:id:kube-prod, instance.config:write)',
+    );
+  });
+
+  it('ops.run_command falls back to wildcard connector scope when connectorId is missing', () => {
+    const e = TOOL_PERMS['ops.run_command']!({}, makeCtx());
+    expect((e as { string: () => string }).string()).toBe(
+      'any(ops.commands:run on ops.connectors:id:*, instance.config:write)',
+    );
+  });
+
   it('investigation.add_section scopes to the investigation UID', () => {
     const e = TOOL_PERMS['investigation.add_section']!(
       { investigationId: 'inv-7', type: 'text', content: 'x' },

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -20,7 +20,7 @@
  */
 
 import type { Evaluator } from '@agentic-obs/common';
-import { ac } from '@agentic-obs/common';
+import { ACTIONS, ac } from '@agentic-obs/common';
 import type { ActionContext } from './orchestrator-action-handlers.js';
 import type { ToolPermissionBuilder } from './types-permissions.js';
 
@@ -176,6 +176,16 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
   // deploy / incident history while diagnosing anomalies.
   'changes.list_recent': () =>
     ac.eval('investigations:read', 'investigations:*'),
+
+  // -- Kubernetes / Ops integrations --------------------------------------
+  'ops.run_command': (args: Record<string, unknown>) =>
+    ac.any(
+      ac.eval(
+        ACTIONS.OpsCommandsRun,
+        `ops.connectors:id:${String(args.connectorId ?? '*')}`,
+      ),
+      ac.eval(ACTIONS.InstanceConfigWrite),
+    ),
 
   // -- Web / knowledge ------------------------------------------------------
   'web.search': () => ac.eval('chat:use'),

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -212,6 +212,28 @@ export const TOOL_SCHEMAS: Record<string, ToolDefinition> = {
   },
 
   // -------------------------------------------------------------------------
+  // Kubernetes / Ops integrations. Requires an operator-configured connector.
+  // -------------------------------------------------------------------------
+  'ops.run_command': {
+    name: 'ops.run_command',
+    description:
+      'Run a Kubernetes/Ops command through a configured connector. Only use when the user asks to inspect or operate on cluster state and a connectorId is known. Read commands may run with intent="read"; write/mutating commands must use intent="propose" unless the user is executing an approved proposal.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        connectorId: { type: 'string', description: 'Ops connector id configured in Settings' },
+        command: { type: 'string', description: 'The exact kubectl/ops command to run or propose' },
+        intent: {
+          type: 'string',
+          enum: ['read', 'propose', 'execute_approved'],
+          description: 'read runs safe inspection commands; propose returns an approval/proposal for write commands; execute_approved is only for an already approved command.',
+        },
+      },
+      required: ['connectorId', 'command', 'intent'],
+    },
+  },
+
+  // -------------------------------------------------------------------------
   // Dashboard lifecycle + mutation primitives
   // -------------------------------------------------------------------------
   'dashboard.create': {

--- a/packages/agent-core/src/agent/types.ts
+++ b/packages/agent-core/src/agent/types.ts
@@ -92,3 +92,24 @@ export interface DatasourceConfig {
   label?: string
   isDefault?: boolean
 }
+
+export type OpsCommandIntent = 'read' | 'propose' | 'execute_approved' | string
+
+export interface OpsConnectorConfig {
+  id: string
+  name: string
+  environment?: string
+  namespaces?: string[]
+  capabilities?: string[]
+}
+
+export interface OpsCommandRunner {
+  listConnectors?(): OpsConnectorConfig[] | Promise<OpsConnectorConfig[]>
+  runCommand(params: {
+    connectorId: string
+    command: string
+    intent: OpsCommandIntent
+    identity: import('@agentic-obs/common').Identity
+    sessionId: string
+  }): unknown | Promise<unknown>
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -17,6 +17,9 @@ export {
   type IAlertRuleStore,
   type IInvestigationStore,
   type DatasourceConfig,
+  type OpsCommandRunner,
+  type OpsConnectorConfig,
+  type OpsCommandIntent,
   // Compat aliases
   type IConversationStore as IDashboardConversationStore,
   type IAlertRuleStore as IDashboardAlertRuleStore,

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -45,6 +45,7 @@ import { createNotificationsRouter } from '../routes/notifications.js';
 import { createVersionRouter } from '../routes/versions.js';
 import { createSearchRouter } from '../routes/search.js';
 import { createChatRouter } from '../routes/chat.js';
+import { createOpsConnectorsRouter } from '../routes/ops-connectors.js';
 import { bootstrapAware } from '../middleware/bootstrap-aware.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { createOrgContextMiddleware } from '../middleware/org-context.js';
@@ -172,6 +173,8 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     chatSessionStore: repos.chatSessions,
     chatMessageStore: repos.chatMessages,
     chatEventStore: repos.chatSessionEvents,
+    opsConnectorStore: repos.opsConnectors,
+    approvalStore: repos.approvals,
     accessControl,
     auditWriter: authSub.audit,
     folderRepository: sharedFolderRepo,
@@ -197,4 +200,14 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     store: repos.versions,
     ac: accessControl,
   }));
+  app.use(
+    '/api/ops/connectors',
+    authMiddleware,
+    userRateLimiter,
+    createOrgContextMiddleware({ orgUsers: authRepos.orgUsers }),
+    createOpsConnectorsRouter({
+      connectors: repos.opsConnectors,
+      ac: accessControl,
+    }),
+  );
 }

--- a/packages/api-gateway/src/routes/ops-connectors.test.ts
+++ b/packages/api-gateway/src/routes/ops-connectors.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Evaluator, Identity, ResolvedPermission } from '@agentic-obs/common';
+import type {
+  IOpsConnectorRepository,
+  NewOpsConnector,
+  OpsConnector,
+  OpsConnectorPatch,
+  OpsConnectorReadOptions,
+} from '@agentic-obs/data-layer';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import { createOpsConnectorsRouter } from './ops-connectors.js';
+
+function makeAccessControl(): AccessControlSurface {
+  return {
+    getUserPermissions: async (): Promise<ResolvedPermission[]> => [],
+    ensurePermissions: async (): Promise<ResolvedPermission[]> => [],
+    evaluate: async (_id: Identity, _evaluator: Evaluator): Promise<boolean> => true,
+    filterByPermission: async <T>(): Promise<T[]> => [],
+  };
+}
+
+class MemoryOpsConnectorRepository implements IOpsConnectorRepository {
+  private readonly rows = new Map<string, OpsConnector>();
+
+  async listByOrg(orgId: string, opts: OpsConnectorReadOptions = {}): Promise<OpsConnector[]> {
+    return [...this.rows.values()]
+      .filter((row) => row.orgId === orgId)
+      .map((row) => mask(row, opts));
+  }
+
+  async findByIdInOrg(
+    orgId: string,
+    id: string,
+    opts: OpsConnectorReadOptions = {},
+  ): Promise<OpsConnector | null> {
+    const row = this.rows.get(id);
+    return row?.orgId === orgId ? mask(row, opts) : null;
+  }
+
+  async create(input: NewOpsConnector): Promise<OpsConnector> {
+    const now = new Date().toISOString();
+    const row: OpsConnector = {
+      id: input.id ?? `k8s-${this.rows.size + 1}`,
+      orgId: input.orgId,
+      type: 'kubernetes',
+      name: input.name,
+      environment: input.environment ?? null,
+      config: input.config ?? {},
+      secretRef: input.secretRef ?? null,
+      secret: input.secret ?? null,
+      allowedNamespaces: input.allowedNamespaces ?? [],
+      capabilities: input.capabilities ?? [],
+      status: input.status ?? 'unknown',
+      lastCheckedAt: input.lastCheckedAt ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rows.set(row.id, row);
+    return row;
+  }
+
+  async update(orgId: string, id: string, patch: OpsConnectorPatch): Promise<OpsConnector | null> {
+    const existing = this.rows.get(id);
+    if (!existing || existing.orgId !== orgId) return null;
+    const updated: OpsConnector = {
+      ...existing,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    };
+    this.rows.set(id, updated);
+    return updated;
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const existing = this.rows.get(id);
+    if (!existing || existing.orgId !== orgId) return false;
+    this.rows.delete(id);
+    return true;
+  }
+}
+
+function mask(row: OpsConnector, opts: OpsConnectorReadOptions): OpsConnector {
+  return opts.masked && row.secret ? { ...row, secret: '••••••' } : { ...row };
+}
+
+function makeApp(repo: IOpsConnectorRepository, orgId = 'org_a') {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as express.Request & { auth?: Identity }).auth = {
+      userId: 'u_1',
+      orgId,
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  });
+  app.use('/api/ops/connectors', createOpsConnectorsRouter({
+    connectors: repo,
+    ac: makeAccessControl(),
+  }));
+  return app;
+}
+
+describe('ops connectors routes', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+  let repo: MemoryOpsConnectorRepository;
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-ops-connector-routes-xxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  beforeEach(() => {
+    repo = new MemoryOpsConnectorRepository();
+  });
+
+  it('creates and lists connectors in the authenticated org', async () => {
+    const app = makeApp(repo, 'org_a');
+
+    const created = await request(app)
+      .post('/api/ops/connectors')
+      .send({
+        id: 'k8s-a',
+        name: 'Prod K8s',
+        config: { apiServer: 'https://k8s.example.com' },
+        secretRef: 'vault://openobs/k8s/prod',
+        allowedNamespaces: ['default'],
+      })
+      .expect(201);
+
+    expect(created.body.connector.orgId).toBe('org_a');
+    expect(created.body.connector.secretRef).toBe('vault://openobs/k8s/prod');
+
+    const listed = await request(app).get('/api/ops/connectors').expect(200);
+    expect(listed.body.connectors).toHaveLength(1);
+    expect(listed.body.connectors[0].id).toBe('k8s-a');
+  });
+
+  it('does not expose connectors from another org', async () => {
+    await repo.create({
+      id: 'k8s-b',
+      orgId: 'org_b',
+      name: 'Other Org',
+      config: { clusterName: 'other' },
+    });
+
+    const app = makeApp(repo, 'org_a');
+    const listed = await request(app).get('/api/ops/connectors').expect(200);
+    expect(listed.body.connectors).toEqual([]);
+
+    await request(app).get('/api/ops/connectors/k8s-b').expect(404);
+  });
+
+  it('deletes existing connectors and returns 404 for missing connectors', async () => {
+    await repo.create({
+      id: 'k8s-a',
+      orgId: 'org_a',
+      name: 'Prod',
+      config: { clusterName: 'prod' },
+    });
+    const app = makeApp(repo, 'org_a');
+
+    await request(app).delete('/api/ops/connectors/k8s-a').expect(200);
+    await request(app).get('/api/ops/connectors/k8s-a').expect(404);
+    await request(app).delete('/api/ops/connectors/k8s-missing').expect(404);
+  });
+
+  it('tests connector structure without requiring a Kubernetes cluster', async () => {
+    await repo.create({
+      id: 'k8s-a',
+      orgId: 'org_a',
+      name: 'Prod',
+      config: { apiServer: 'https://k8s.example.com' },
+      secretRef: 'vault://openobs/k8s/prod',
+    });
+    const app = makeApp(repo, 'org_a');
+
+    const tested = await request(app).post('/api/ops/connectors/k8s-a/test').expect(200);
+    expect(tested.body.status).toBe('connected');
+    expect(tested.body.checks.runner).toBe('skipped');
+  });
+});

--- a/packages/api-gateway/src/routes/ops-connectors.ts
+++ b/packages/api-gateway/src/routes/ops-connectors.ts
@@ -1,0 +1,185 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { ACTIONS, ac } from '@agentic-obs/common';
+import type {
+  IOpsConnectorRepository,
+  NewOpsConnector,
+  OpsConnector,
+  OpsConnectorConfig,
+  OpsConnectorPatch,
+} from '@agentic-obs/data-layer';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { createRequirePermission } from '../middleware/require-permission.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import {
+  StructuralKubernetesConnectorRunner,
+  validateKubernetesConnector,
+  type KubernetesConnectorRunner,
+} from '../services/ops-connector-service.js';
+
+export interface OpsConnectorsRouterDeps {
+  connectors: IOpsConnectorRepository;
+  ac: AccessControlSurface;
+  runner?: KubernetesConnectorRunner;
+}
+
+interface OpsConnectorBody {
+  id?: string;
+  type?: 'kubernetes';
+  name?: string;
+  environment?: string | null;
+  config?: OpsConnectorConfig;
+  secretRef?: string | null;
+  secret?: string | null;
+  allowedNamespaces?: string[];
+  capabilities?: string[];
+}
+
+function orgIdFromReq(req: Request): string | null {
+  return (req as AuthenticatedRequest).auth?.orgId ?? null;
+}
+
+function requireOrg(req: Request, res: Response): string | null {
+  const orgId = orgIdFromReq(req);
+  if (!orgId) {
+    res.status(403).json({
+      error: { code: 'FORBIDDEN', message: 'org context is required' },
+    });
+    return null;
+  }
+  return orgId;
+}
+
+function validateBody(body: OpsConnectorBody): string | null {
+  if (body.type !== undefined && body.type !== 'kubernetes') {
+    return 'type must be kubernetes';
+  }
+  if (body.allowedNamespaces !== undefined && !Array.isArray(body.allowedNamespaces)) {
+    return 'allowedNamespaces must be an array';
+  }
+  if (body.capabilities !== undefined && !Array.isArray(body.capabilities)) {
+    return 'capabilities must be an array';
+  }
+  return validateKubernetesConnector(body.config ?? {});
+}
+
+function maskForWire(connector: OpsConnector): OpsConnector {
+  return {
+    ...connector,
+    secret: connector.secret ? '••••••' : null,
+  };
+}
+
+export function createOpsConnectorsRouter(deps: OpsConnectorsRouterDeps): Router {
+  const router = Router();
+  const requirePermission = createRequirePermission(deps.ac);
+  const requireRead = requirePermission(() =>
+    ac.any(
+      ac.eval(ACTIONS.OpsConnectorsRead, 'ops.connectors:*'),
+      ac.eval(ACTIONS.InstanceConfigRead),
+    ),
+  );
+  const requireWrite = requirePermission(() =>
+    ac.any(
+      ac.eval(ACTIONS.OpsConnectorsWrite, 'ops.connectors:*'),
+      ac.eval(ACTIONS.InstanceConfigWrite),
+    ),
+  );
+  const runner = deps.runner ?? new StructuralKubernetesConnectorRunner();
+
+  router.get('/', requireRead, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const connectors = await deps.connectors.listByOrg(orgId, { masked: true });
+    res.json({ connectors });
+  });
+
+  router.post('/', requireWrite, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+
+    const body = req.body as OpsConnectorBody;
+    if (!body?.name) {
+      res.status(400).json({
+        error: { code: 'VALIDATION', message: 'name is required' },
+      });
+      return;
+    }
+    const validation = validateBody(body);
+    if (validation) {
+      res.status(400).json({ error: { code: 'VALIDATION', message: validation } });
+      return;
+    }
+    if (body.id && (await deps.connectors.findByIdInOrg(orgId, body.id))) {
+      res.status(409).json({
+        error: { code: 'CONFLICT', message: `Ops connector "${body.id}" already exists` },
+      });
+      return;
+    }
+
+    const input: NewOpsConnector = {
+      id: body.id,
+      orgId,
+      type: 'kubernetes',
+      name: body.name,
+      environment: body.environment ?? null,
+      config: body.config ?? {},
+      secretRef: body.secretRef ?? null,
+      secret: body.secret ?? null,
+      allowedNamespaces: body.allowedNamespaces ?? [],
+      capabilities: body.capabilities ?? [],
+    };
+    const created = await deps.connectors.create(input);
+    res.status(201).json({ connector: maskForWire(created) });
+  });
+
+  router.get('/:id', requireRead, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const id = req.params['id'] ?? '';
+    const connector = await deps.connectors.findByIdInOrg(orgId, id, { masked: true });
+    if (!connector) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: `Ops connector "${id}" not found` },
+      });
+      return;
+    }
+    res.json({ connector });
+  });
+
+  router.delete('/:id', requireWrite, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const id = req.params['id'] ?? '';
+    const deleted = await deps.connectors.delete(orgId, id);
+    if (!deleted) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: `Ops connector "${id}" not found` },
+      });
+      return;
+    }
+    res.json({ ok: true });
+  });
+
+  router.post('/:id/test', requireRead, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const id = req.params['id'] ?? '';
+    const connector = await deps.connectors.findByIdInOrg(orgId, id);
+    if (!connector) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: `Ops connector "${id}" not found` },
+      });
+      return;
+    }
+    const result = await runner.test(connector);
+    const status = result.status === 'error' ? 400 : 200;
+    await deps.connectors.update(orgId, id, {
+      status: result.status,
+      lastCheckedAt: new Date().toISOString(),
+    } satisfies OpsConnectorPatch);
+    res.status(status).json(result);
+  });
+
+  return router;
+}

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -5,6 +5,7 @@ import { createLlmGateway } from '../routes/llm-factory.js';
 import { DashboardOrchestratorAgent as OrchestratorAgent, shouldCompact, compactMessages } from '@agentic-obs/agent-core';
 import type { IConversationStore as IAgentConversationStore, IDashboardAlertRuleStore as IAlertRuleStore, IDashboardInvestigationStore as IInvestigationStore } from '@agentic-obs/agent-core';
 import { buildAdapterRegistry, toAgentDatasources } from './dashboard-service.js';
+import { OpsCommandRunnerService } from './ops-command-runner-service.js';
 import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
 
 // Web-search adapter is configuration-free for the default DuckDuckGo
@@ -14,7 +15,7 @@ import type { AccessControlSurface } from './accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
 import type { IGatewayDashboardStore } from '../repositories/types.js';
-import type { IInvestigationReportRepository, IAlertRuleRepository, IGatewayInvestigationStore, IChatSessionRepository, IChatMessageRepository, IChatSessionEventRepository } from '@agentic-obs/data-layer';
+import type { IInvestigationReportRepository, IAlertRuleRepository, IGatewayInvestigationStore, IChatSessionRepository, IChatMessageRepository, IChatSessionEventRepository, IOpsConnectorRepository, IApprovalRequestRepository } from '@agentic-obs/data-layer';
 
 const log = createLogger('chat-service');
 
@@ -48,6 +49,8 @@ export interface ChatServiceDeps {
   chatSessionStore?: IChatSessionRepository;
   chatMessageStore?: IChatMessageRepository;
   chatEventStore?: IChatSessionEventRepository;
+  opsConnectorStore?: IOpsConnectorRepository;
+  approvalStore?: IApprovalRequestRepository;
   /** Wave 7 — RBAC surface for the agent permission gate. Required. */
   accessControl: AccessControlSurface;
   /** Audit-log writer. Optional but strongly recommended in production. */
@@ -161,6 +164,13 @@ export class ChatService {
     const gateway = createLlmGateway(llm);
     const model = llm.model;
     const adapters = buildAdapterRegistry(datasources);
+    const opsCommandRunner = this.deps.opsConnectorStore && this.deps.approvalStore
+      ? new OpsCommandRunnerService({
+          connectors: this.deps.opsConnectorStore,
+          approvals: this.deps.approvalStore,
+        }, identity.orgId)
+      : undefined;
+    const opsConnectors = opsCommandRunner ? await opsCommandRunner.listConnectors() : undefined;
 
     // Parse relative time range (e.g., "1h", "6h", "24h", "7d") to absolute
     // start/end. Carry the client's IANA timezone so the prompt can label
@@ -239,6 +249,7 @@ export class ChatService {
       adapters,
       webSearchAdapter: sharedWebSearchAdapter,
       allDatasources: toAgentDatasources(datasources),
+      ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
       sendEvent: wrappedSendEvent,
       timeRange,
       conversationSummary,

--- a/packages/api-gateway/src/services/ops-command-runner-service.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IApprovalRequestRepository, IOpsConnectorRepository, OpsConnector } from '@agentic-obs/data-layer';
+import { OpsCommandRunnerService, classifyOpsCommand } from './ops-command-runner-service.js';
+
+const baseConnector: OpsConnector = {
+  id: 'k8s-prod',
+  orgId: 'org_a',
+  type: 'kubernetes',
+  name: 'Production',
+  environment: 'prod',
+  config: { clusterName: 'prod' },
+  secretRef: 'vault://k8s/prod',
+  secret: null,
+  allowedNamespaces: ['default'],
+  capabilities: ['read', 'propose'],
+  status: 'connected',
+  lastCheckedAt: null,
+  createdAt: 'now',
+  updatedAt: 'now',
+};
+
+function identity() {
+  return {
+    userId: 'u_1',
+    orgId: 'org_a',
+    orgRole: 'Admin',
+    isServerAdmin: false,
+    authenticatedBy: 'session',
+  } as const;
+}
+
+describe('classifyOpsCommand', () => {
+  it('allows read-only kubectl inspection commands', () => {
+    expect(classifyOpsCommand('kubectl get pods -n api').decision).toBe('read');
+    expect(classifyOpsCommand('kubectl rollout status deployment/api').decision).toBe('read');
+  });
+
+  it('requires approval for mutating commands and denies dangerous commands', () => {
+    expect(classifyOpsCommand('kubectl rollout restart deployment/api').decision).toBe('approval_required');
+    expect(classifyOpsCommand('kubectl exec -it pod/api -- sh').decision).toBe('denied');
+    expect(classifyOpsCommand('kubectl get secret prod -o yaml').decision).toBe('denied');
+  });
+});
+
+describe('OpsCommandRunnerService', () => {
+  let connectors: IOpsConnectorRepository;
+  let approvals: IApprovalRequestRepository;
+
+  beforeEach(() => {
+    connectors = {
+      listByOrg: vi.fn(async () => [baseConnector]),
+      findByIdInOrg: vi.fn(async (_orgId, id) => id === baseConnector.id ? baseConnector : null),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    approvals = {
+      submit: vi.fn(async (params) => ({
+        id: 'approval-1',
+        action: params.action,
+        context: params.context,
+        status: 'pending' as const,
+        createdAt: 'now',
+        expiresAt: 'later',
+      })),
+      findById: vi.fn(),
+      listPending: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+      override: vi.fn(),
+    };
+  });
+
+  it('lists configured connectors for the current org', async () => {
+    const service = new OpsCommandRunnerService({ connectors, approvals }, 'org_a');
+    await expect(service.listConnectors()).resolves.toEqual([
+      {
+        id: 'k8s-prod',
+        name: 'Production',
+        environment: 'prod',
+        namespaces: ['default'],
+        capabilities: ['read', 'propose'],
+      },
+    ]);
+    expect(connectors.listByOrg).toHaveBeenCalledWith('org_a', { masked: true });
+  });
+
+  it('uses the existing approvals repository for mutating command proposals', async () => {
+    const service = new OpsCommandRunnerService({ connectors, approvals }, 'org_a');
+    const result = await service.runCommand({
+      connectorId: 'k8s-prod',
+      command: 'kubectl rollout restart deployment/api -n default',
+      intent: 'propose',
+      identity: identity(),
+      sessionId: 'session-1',
+    });
+
+    expect(result.decision).toBe('approval_required');
+    expect(result.approvalId).toBe('approval-1');
+    expect(approvals.submit).toHaveBeenCalledWith(expect.objectContaining({
+      action: expect.objectContaining({
+        type: 'ops.run_command',
+        params: expect.objectContaining({ connectorId: 'k8s-prod' }),
+      }),
+    }));
+  });
+});

--- a/packages/api-gateway/src/services/ops-command-runner-service.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.ts
@@ -1,0 +1,294 @@
+import type { Identity } from '@agentic-obs/common';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import type {
+  IApprovalRequestRepository,
+  IOpsConnectorRepository,
+  OpsConnector,
+} from '@agentic-obs/data-layer';
+
+export type OpsCommandDecision = 'read' | 'approval_required' | 'denied';
+
+export interface OpsCommandRunnerServiceDeps {
+  connectors: IOpsConnectorRepository;
+  approvals: IApprovalRequestRepository;
+}
+
+interface AgentOpsConnectorConfig {
+  id: string;
+  name: string;
+  environment?: string;
+  namespaces?: string[];
+  capabilities?: string[];
+}
+
+export class OpsCommandRunnerService {
+  constructor(private readonly deps: OpsCommandRunnerServiceDeps, private readonly orgId: string) {}
+
+  async listConnectors(): Promise<AgentOpsConnectorConfig[]> {
+    const connectors = await this.deps.connectors.listByOrg(this.orgId, { masked: true });
+    return connectors.map((connector) => ({
+      id: connector.id,
+      name: connector.name,
+      environment: connector.environment ?? undefined,
+      namespaces: connector.allowedNamespaces,
+      capabilities: connector.capabilities,
+    }));
+  }
+
+  async runCommand(params: {
+    connectorId: string;
+    command: string;
+    intent: string;
+    identity: Identity;
+    sessionId: string;
+  }): Promise<{ observation: string; decision: OpsCommandDecision; approvalId?: string }> {
+    const connector = await this.deps.connectors.findByIdInOrg(this.orgId, params.connectorId);
+    if (!connector) {
+      return {
+        decision: 'denied',
+        observation: `Ops connector "${params.connectorId}" is not configured for this org.`,
+      };
+    }
+
+    const policy = classifyOpsCommand(params.command);
+    if (policy.decision === 'denied') {
+      return {
+        decision: 'denied',
+        observation: `Denied by Ops command policy: ${policy.reason}.`,
+      };
+    }
+
+    if (!connector.secret && !connector.secretRef) {
+      return {
+        decision: 'denied',
+        observation: `Ops connector "${connector.id}" is not connected: no credential secret or secretRef is configured.`,
+      };
+    }
+
+    if (policy.decision === 'approval_required' || params.intent === 'propose') {
+      const approval = await this.deps.approvals.submit({
+        action: {
+          type: 'ops.run_command',
+          targetService: connector.name,
+          params: {
+            connectorId: connector.id,
+            command: params.command.trim(),
+            intent: 'execute_approved',
+            policyReason: policy.reason,
+            sessionId: params.sessionId,
+          },
+        },
+        context: {
+          requestedBy: params.identity.userId,
+          reason: `Run Kubernetes/Ops command on connector "${connector.name}": ${params.command.trim()}`,
+        },
+      });
+      return {
+        decision: 'approval_required',
+        approvalId: approval.id,
+        observation: `Command requires approval. Existing approvals workflow created request ${approval.id}. Do not execute until it is approved.`,
+      };
+    }
+
+    if (params.intent === 'execute_approved') {
+      return {
+        decision: 'approval_required',
+        observation:
+          'Approved Ops command execution is not wired to a kubectl runner yet. Use the existing approval record as the control point; do not execute this command directly.',
+      };
+    }
+
+    return this.runReadCommand(connector, params.command);
+  }
+
+  private async runReadCommand(
+    connector: OpsConnector,
+    command: string,
+  ): Promise<{ observation: string; decision: OpsCommandDecision }> {
+    if (!connector.secret) {
+      return {
+        decision: 'denied',
+        observation:
+          `Read command is allowed by policy for connector "${connector.name}", but this server cannot resolve secretRef credentials yet.`,
+      };
+    }
+    if (!looksLikeKubeconfig(connector.secret)) {
+      return {
+        decision: 'denied',
+        observation:
+          'Read command was not executed because only kubeconfig credentials are supported for live kubectl execution in this build.',
+      };
+    }
+
+    const namespaceError = validateNamespacePolicy(command, connector.allowedNamespaces);
+    if (namespaceError) {
+      return { decision: 'denied', observation: namespaceError };
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'openobs-kube-'));
+    const kubeconfigPath = join(tempDir, 'config');
+    try {
+      await writeFile(kubeconfigPath, connector.secret, { encoding: 'utf8', mode: 0o600 });
+      const args = tokenizeKubectlCommand(command).slice(1);
+      const result = await runKubectl(args, kubeconfigPath);
+      return {
+        decision: 'read',
+        observation: formatKubectlObservation(command, result),
+      };
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export function classifyOpsCommand(command: string): { decision: OpsCommandDecision; reason: string } {
+  const normalized = command.trim().replace(/\s+/g, ' ');
+  const lower = normalized.toLowerCase();
+
+  if (!lower.startsWith('kubectl ')) {
+    return { decision: 'denied', reason: 'only kubectl commands are supported for Kubernetes connectors' };
+  }
+
+  const deniedPatterns = [
+    /^kubectl\s+exec\b/,
+    /^kubectl\s+cp\b/,
+    /^kubectl\s+port-forward\b/,
+    /^kubectl\s+proxy\b/,
+    /^kubectl\s+edit\b/,
+    /^kubectl\s+(get|describe)\s+secrets?\b/,
+    /^kubectl\s+delete\s+secrets?\b/,
+  ];
+  if (deniedPatterns.some((pattern) => pattern.test(lower))) {
+    return { decision: 'denied', reason: 'command can expose secrets or open an interactive/network tunnel' };
+  }
+
+  const readPatterns = [
+    /^kubectl\s+get\b/,
+    /^kubectl\s+describe\b/,
+    /^kubectl\s+logs\b/,
+    /^kubectl\s+top\b/,
+    /^kubectl\s+rollout\s+(status|history)\b/,
+    /^kubectl\s+events\b/,
+    /^kubectl\s+api-(resources|versions)\b/,
+    /^kubectl\s+version\b/,
+    /^kubectl\s+config\s+current-context\b/,
+  ];
+  if (readPatterns.some((pattern) => pattern.test(lower))) {
+    return { decision: 'read', reason: 'read-only inspection command' };
+  }
+
+  const mutatingPatterns = [
+    /^kubectl\s+(apply|patch|scale|create|delete|replace|set|annotate|label)\b/,
+    /^kubectl\s+rollout\s+(restart|undo|pause|resume)\b/,
+    /^kubectl\s+(cordon|uncordon|drain|taint)\b/,
+  ];
+  if (mutatingPatterns.some((pattern) => pattern.test(lower))) {
+    return { decision: 'approval_required', reason: 'mutating cluster command' };
+  }
+
+  return { decision: 'approval_required', reason: 'unclassified kubectl command must be reviewed' };
+}
+
+function looksLikeKubeconfig(secret: string): boolean {
+  return /\bapiVersion\s*:/.test(secret) && /\bkind\s*:\s*Config\b/.test(secret);
+}
+
+function validateNamespacePolicy(command: string, allowedNamespaces: string[]): string | null {
+  if (allowedNamespaces.length === 0) return null;
+  const args = tokenizeKubectlCommand(command);
+  const namespace = findNamespaceArg(args);
+  if (!namespace) {
+    return `Command was not executed: connector is restricted to namespaces ${allowedNamespaces.join(', ')}, so the command must include --namespace or -n.`;
+  }
+  if (!allowedNamespaces.includes(namespace)) {
+    return `Command was not executed: namespace "${namespace}" is outside this connector's allowed namespaces (${allowedNamespaces.join(', ')}).`;
+  }
+  return null;
+}
+
+function findNamespaceArg(args: string[]): string | null {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-n' || arg === '--namespace') return args[i + 1] ?? null;
+    if (arg?.startsWith('--namespace=')) return arg.slice('--namespace='.length);
+  }
+  return null;
+}
+
+function tokenizeKubectlCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i]!;
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function runKubectl(
+  args: string[],
+  kubeconfigPath: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('kubectl', ['--kubeconfig', kubeconfigPath, ...args], {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      child.kill();
+      stderr += '\nkubectl command timed out after 15s';
+    }, 15_000);
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      resolve({ exitCode: 127, stdout, stderr: err.message });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function formatKubectlObservation(
+  command: string,
+  result: { exitCode: number; stdout: string; stderr: string },
+): string {
+  const stdout = truncate(result.stdout.trim(), 12_000);
+  const stderr = truncate(result.stderr.trim(), 4_000);
+  if (result.exitCode === 0) {
+    return stdout
+      ? `kubectl read command succeeded: ${command}\n\n${stdout}`
+      : `kubectl read command succeeded: ${command}\n\n(no output)`;
+  }
+  return `kubectl read command failed with exit code ${result.exitCode}: ${command}\n\n${stderr || stdout || 'no output'}`;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}\n... truncated ...`;
+}

--- a/packages/api-gateway/src/services/ops-connector-service.ts
+++ b/packages/api-gateway/src/services/ops-connector-service.ts
@@ -1,0 +1,70 @@
+import type { OpsConnector, OpsConnectorConfig, OpsConnectorStatus } from '@agentic-obs/data-layer';
+
+export interface OpsConnectorTestResult {
+  status: Exclude<OpsConnectorStatus, 'unknown'>;
+  checks: {
+    structure: 'ok' | 'failed';
+    credentials: 'ok' | 'missing';
+    runner: 'skipped';
+  };
+  message: string;
+}
+
+export interface KubernetesConnectorRunner {
+  test(connector: OpsConnector): Promise<OpsConnectorTestResult>;
+}
+
+export class StructuralKubernetesConnectorRunner implements KubernetesConnectorRunner {
+  async test(connector: OpsConnector): Promise<OpsConnectorTestResult> {
+    const validation = validateKubernetesConnector(connector.config);
+    if (validation) {
+      return {
+        status: 'error',
+        checks: { structure: 'failed', credentials: 'missing', runner: 'skipped' },
+        message: validation,
+      };
+    }
+
+    const hasCredentials = Boolean(connector.secretRef || connector.secret);
+    return {
+      status: hasCredentials ? 'connected' : 'degraded',
+      checks: {
+        structure: 'ok',
+        credentials: hasCredentials ? 'ok' : 'missing',
+        runner: 'skipped',
+      },
+      message: hasCredentials
+        ? 'Kubernetes connector structure is valid; live cluster probe is not enabled yet.'
+        : 'Kubernetes connector structure is valid, but no secret or secretRef is configured.',
+    };
+  }
+}
+
+export function validateKubernetesConnector(config: OpsConnectorConfig): string | null {
+  const apiServer = config.apiServer;
+  if (apiServer !== undefined && typeof apiServer !== 'string') {
+    return 'config.apiServer must be a string when provided';
+  }
+  if (typeof apiServer === 'string' && apiServer.length > 0) {
+    try {
+      const parsed = new URL(apiServer);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        return 'config.apiServer must use http or https';
+      }
+    } catch {
+      return 'config.apiServer must be a valid URL';
+    }
+  }
+
+  if (config.clusterName !== undefined && typeof config.clusterName !== 'string') {
+    return 'config.clusterName must be a string when provided';
+  }
+  if (config.context !== undefined && typeof config.context !== 'string') {
+    return 'config.context must be a string when provided';
+  }
+  if (!config.apiServer && !config.clusterName && !config.context) {
+    return 'one of config.apiServer, config.clusterName, or config.context is required';
+  }
+
+  return null;
+}

--- a/packages/common/src/rbac/actions.test.ts
+++ b/packages/common/src/rbac/actions.test.ts
@@ -39,6 +39,8 @@ describe('rbac/actions catalog', () => {
       'approvals:read',
       'chat:use',
       'agents.config:read',
+      'ops.connectors:read',
+      'ops.commands:run',
     ];
     for (const a of categories) {
       expect(ALL_ACTIONS).toContain(a as RbacAction);
@@ -54,5 +56,6 @@ describe('rbac/actions catalog', () => {
     expect(ACTIONS.DashboardsRead).toBe('dashboards:read');
     expect(ACTIONS.AlertRulesCreate).toBe('alert.rules:create');
     expect(ACTIONS.ApprovalsOverride).toBe('approvals:override');
+    expect(ACTIONS.OpsCommandsRun).toBe('ops.commands:run');
   });
 });

--- a/packages/common/src/rbac/actions.ts
+++ b/packages/common/src/rbac/actions.ts
@@ -147,6 +147,9 @@ export const ACTIONS = {
   ChatUse: 'chat:use',
   AgentsConfigRead: 'agents.config:read',
   AgentsConfigWrite: 'agents.config:write',
+  OpsConnectorsRead: 'ops.connectors:read',
+  OpsConnectorsWrite: 'ops.connectors:write',
+  OpsCommandsRun: 'ops.commands:run',
   // [openobs-extension] — instance-wide config: LLM provider, notification
   // channels, and dev reset. Granted to Admin+ via ADMIN_ONLY_PERMISSIONS.
   // Lives in the `instance_config` SQLite table (see migration 019). No

--- a/packages/common/src/rbac/fixed-roles-def.ts
+++ b/packages/common/src/rbac/fixed-roles-def.ts
@@ -683,6 +683,36 @@ const AGENTS_CONFIG_WRITER = def(
   ],
 );
 
+const OPS_CONNECTORS_READER = def(
+  'fixed:ops.connectors:reader',
+  'Ops connectors reader',
+  'Read configured Ops/Kubernetes connectors.',
+  'Ops',
+  [{ action: ACTIONS.OpsConnectorsRead, scope: 'ops.connectors:*' }],
+);
+
+const OPS_CONNECTORS_WRITER = def(
+  'fixed:ops.connectors:writer',
+  'Ops connectors writer',
+  'Create and update Ops/Kubernetes connectors.',
+  'Ops',
+  [
+    { action: ACTIONS.OpsConnectorsRead, scope: 'ops.connectors:*' },
+    { action: ACTIONS.OpsConnectorsWrite, scope: 'ops.connectors:*' },
+  ],
+);
+
+const OPS_COMMANDS_RUNNER = def(
+  'fixed:ops.commands:runner',
+  'Ops command runner',
+  'Run policy-gated Ops/Kubernetes commands through configured connectors.',
+  'Ops',
+  [
+    { action: ACTIONS.OpsConnectorsRead, scope: 'ops.connectors:*' },
+    { action: ACTIONS.OpsCommandsRun, scope: 'ops.connectors:*' },
+  ],
+);
+
 // -- Final catalog --------------------------------------------------------
 
 export const FIXED_ROLE_DEFINITIONS: readonly FixedRoleDefinition[] =
@@ -744,6 +774,9 @@ export const FIXED_ROLE_DEFINITIONS: readonly FixedRoleDefinition[] =
     APPROVALS_OVERRIDER,
     AGENTS_CONFIG_READER,
     AGENTS_CONFIG_WRITER,
+    OPS_CONNECTORS_READER,
+    OPS_CONNECTORS_WRITER,
+    OPS_COMMANDS_RUNNER,
   ]);
 
 /**

--- a/packages/common/src/rbac/roles-def.ts
+++ b/packages/common/src/rbac/roles-def.ts
@@ -177,6 +177,9 @@ const ADMIN_ONLY_PERMISSIONS: BuiltinPermission[] = [
   { action: ACTIONS.ApprovalsOverride, scope: 'approvals:*' },
   { action: ACTIONS.AgentsConfigRead, scope: '' },
   { action: ACTIONS.AgentsConfigWrite, scope: '' },
+  { action: ACTIONS.OpsConnectorsRead, scope: 'ops.connectors:*' },
+  { action: ACTIONS.OpsConnectorsWrite, scope: 'ops.connectors:*' },
+  { action: ACTIONS.OpsCommandsRun, scope: 'ops.connectors:*' },
   { action: ACTIONS.InstanceConfigRead, scope: '' },
   { action: ACTIONS.InstanceConfigWrite, scope: '' },
 ];

--- a/packages/common/src/rbac/scope.ts
+++ b/packages/common/src/rbac/scope.ts
@@ -39,6 +39,7 @@ export const SCOPE_KINDS = [
   'approvals',
   'chat',
   'agents.config',
+  'ops.connectors',
 ] as const;
 
 export type ScopeKind = (typeof SCOPE_KINDS)[number];

--- a/packages/data-layer/src/db/schema-applier.test.ts
+++ b/packages/data-layer/src/db/schema-applier.test.ts
@@ -15,6 +15,7 @@ describe('applySchema()', () => {
       'folder', 'dashboard_acl', 'preferences', 'quota', 'audit_log',
       'instance_llm_config', 'instance_datasources',
       'notification_channels', 'instance_settings',
+      'ops_connectors',
     ];
 
     const rows = db.all<{ name: string }>(sql`SELECT name FROM sqlite_master WHERE type='table'`);

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -737,3 +737,29 @@ CREATE TABLE IF NOT EXISTS mute_timings (
   created_at     TEXT NOT NULL,
   updated_at     TEXT NOT NULL
 );
+
+-- ============================================================================
+-- Ops connectors (Kubernetes etc.)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS ops_connectors (
+  id                      TEXT PRIMARY KEY,
+  org_id                  TEXT NOT NULL,
+  type                    TEXT NOT NULL CHECK (type = 'kubernetes'),
+  name                    TEXT NOT NULL,
+  environment             TEXT NULL,
+  config_json             TEXT NOT NULL,
+  secret_ref              TEXT NULL,
+  encrypted_secret        TEXT NULL,
+  allowed_namespaces_json TEXT NOT NULL DEFAULT '[]',
+  capabilities_json       TEXT NOT NULL DEFAULT '[]',
+  status                  TEXT NOT NULL DEFAULT 'unknown',
+  last_checked_at         TEXT NULL,
+  created_at              TEXT NOT NULL,
+  updated_at              TEXT NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES org(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ops_connectors_org_name ON ops_connectors(org_id, name);
+CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_id   ON ops_connectors(org_id);
+CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_type ON ops_connectors(org_id, type);

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -27,6 +27,7 @@ import type {
   IDatasourceRepository,
   INotificationChannelRepository,
 } from '@agentic-obs/common';
+import type { IOpsConnectorRepository } from './types/ops-connector.js';
 import type {
   IGatewayInvestigationStore,
   IGatewayIncidentStore,
@@ -60,6 +61,7 @@ import { SqliteChatSessionEventRepository } from './sqlite/chat-session-event.js
 import { InstanceConfigRepository } from './sqlite/instance-config.js';
 import { DatasourceRepository } from './sqlite/datasource.js';
 import { NotificationChannelRepository } from './sqlite/notification-channel.js';
+import { OpsConnectorRepository } from './sqlite/ops-connector.js';
 
 /**
  * Core repositories (shared across all backends that support them).
@@ -102,6 +104,7 @@ export interface SqliteRepositories {
   instanceConfig: IInstanceConfigRepository;
   datasources: IDatasourceRepository;
   notificationChannels: INotificationChannelRepository;
+  opsConnectors: IOpsConnectorRepository;
 }
 
 export function createPostgresRepositories(db: DbClient): Repositories {
@@ -135,6 +138,7 @@ export function createSqliteRepositories(db: SqliteClient): SqliteRepositories {
     instanceConfig: new InstanceConfigRepository(db),
     datasources: new DatasourceRepository(db),
     notificationChannels: new NotificationChannelRepository(db),
+    opsConnectors: new OpsConnectorRepository(db),
   };
 }
 

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -41,6 +41,17 @@ export type {
   SharePermission,
 } from './types.js';
 
+export type {
+  IOpsConnectorRepository,
+  NewOpsConnector,
+  OpsConnector,
+  OpsConnectorConfig,
+  OpsConnectorPatch,
+  OpsConnectorReadOptions,
+  OpsConnectorStatus,
+  OpsConnectorType,
+} from './types/ops-connector.js';
+
 export * from './postgres/index.js';
 export * from './sqlite/index.js';
 export * from './event-wrappers/index.js';

--- a/packages/data-layer/src/repository/sqlite/index.ts
+++ b/packages/data-layer/src/repository/sqlite/index.ts
@@ -21,3 +21,4 @@ export { SqliteChatSessionEventRepository } from './chat-session-event.js';
 export { InstanceConfigRepository } from './instance-config.js';
 export { DatasourceRepository } from './datasource.js';
 export { NotificationChannelRepository } from './notification-channel.js';
+export { OpsConnectorRepository } from './ops-connector.js';

--- a/packages/data-layer/src/repository/sqlite/ops-connector.test.ts
+++ b/packages/data-layer/src/repository/sqlite/ops-connector.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { createTestDb } from '../../test-support/test-db.js';
+import { OpsConnectorRepository } from './ops-connector.js';
+
+describe('OpsConnectorRepository', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+  let db: SqliteClient;
+  let repo: OpsConnectorRepository;
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-ops-connector-repository-xxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_a', 'Org A', 'now', 'now')`);
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_b', 'Org B', 'now', 'now')`);
+    repo = new OpsConnectorRepository(db);
+  });
+
+  it('creates and lists connectors scoped by org', async () => {
+    await repo.create({
+      id: 'k8s-a',
+      orgId: 'org_a',
+      name: 'Prod',
+      config: { apiServer: 'https://k8s-a.example.com' },
+      secret: 'kubeconfig-a',
+      allowedNamespaces: ['default'],
+      capabilities: ['pods.read'],
+    });
+    await repo.create({
+      id: 'k8s-b',
+      orgId: 'org_b',
+      name: 'Prod',
+      config: { apiServer: 'https://k8s-b.example.com' },
+    });
+
+    const orgA = await repo.listByOrg('org_a', { masked: true });
+    expect(orgA).toHaveLength(1);
+    expect(orgA[0]!.id).toBe('k8s-a');
+    expect(orgA[0]!.secret).toBe('••••••ig-a');
+    expect(await repo.findByIdInOrg('org_b', 'k8s-a')).toBeNull();
+  });
+
+  it('updates and deletes by org plus id', async () => {
+    await repo.create({
+      id: 'k8s-a',
+      orgId: 'org_a',
+      name: 'Prod',
+      config: { clusterName: 'prod' },
+    });
+
+    expect(await repo.update('org_b', 'k8s-a', { name: 'Nope' })).toBeNull();
+    const updated = await repo.update('org_a', 'k8s-a', {
+      name: 'Production',
+      status: 'connected',
+      lastCheckedAt: '2026-04-26T00:00:00.000Z',
+    });
+    expect(updated!.name).toBe('Production');
+    expect(updated!.status).toBe('connected');
+
+    expect(await repo.delete('org_b', 'k8s-a')).toBe(false);
+    expect(await repo.delete('org_a', 'k8s-a')).toBe(true);
+    expect(await repo.findByIdInOrg('org_a', 'k8s-a')).toBeNull();
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/ops-connector.ts
+++ b/packages/data-layer/src/repository/sqlite/ops-connector.ts
@@ -1,0 +1,157 @@
+import { sql } from 'drizzle-orm';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import type {
+  IOpsConnectorRepository,
+  NewOpsConnector,
+  OpsConnector,
+  OpsConnectorConfig,
+  OpsConnectorPatch,
+  OpsConnectorReadOptions,
+  OpsConnectorStatus,
+} from '../types/ops-connector.js';
+import { decryptSecret, encryptSecret, maskSecret, nowIso, uid } from './instance-shared.js';
+
+interface OpsConnectorRow {
+  id: string;
+  org_id: string;
+  type: string;
+  name: string;
+  environment: string | null;
+  config_json: string;
+  secret_ref: string | null;
+  encrypted_secret: string | null;
+  allowed_namespaces_json: string;
+  capabilities_json: string;
+  status: string;
+  last_checked_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  return JSON.parse(raw) as T;
+}
+
+function rowToConnector(row: OpsConnectorRow, opts: OpsConnectorReadOptions = {}): OpsConnector {
+  const secret = decryptSecret(row.encrypted_secret);
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    type: 'kubernetes',
+    name: row.name,
+    environment: row.environment,
+    config: parseJson<OpsConnectorConfig>(row.config_json, {}),
+    secretRef: row.secret_ref,
+    secret: opts.masked ? maskSecret(secret) : secret,
+    allowedNamespaces: parseJson<string[]>(row.allowed_namespaces_json, []),
+    capabilities: parseJson<string[]>(row.capabilities_json, []),
+    status: row.status as OpsConnectorStatus,
+    lastCheckedAt: row.last_checked_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class OpsConnectorRepository implements IOpsConnectorRepository {
+  constructor(private readonly db: SqliteClient) {}
+
+  async listByOrg(
+    orgId: string,
+    opts: OpsConnectorReadOptions = {},
+  ): Promise<OpsConnector[]> {
+    const rows = this.db.all<OpsConnectorRow>(sql`
+      SELECT * FROM ops_connectors
+      WHERE org_id = ${orgId}
+      ORDER BY name
+    `);
+    return rows.map((row) => rowToConnector(row, opts));
+  }
+
+  async findByIdInOrg(
+    orgId: string,
+    id: string,
+    opts: OpsConnectorReadOptions = {},
+  ): Promise<OpsConnector | null> {
+    const rows = this.db.all<OpsConnectorRow>(sql`
+      SELECT * FROM ops_connectors
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    return rows[0] ? rowToConnector(rows[0], opts) : null;
+  }
+
+  async create(input: NewOpsConnector): Promise<OpsConnector> {
+    const id = input.id ?? `k8s-${uid()}`;
+    const now = nowIso();
+    this.db.run(sql`
+      INSERT INTO ops_connectors (
+        id, org_id, type, name, environment, config_json, secret_ref,
+        encrypted_secret, allowed_namespaces_json, capabilities_json,
+        status, last_checked_at, created_at, updated_at
+      ) VALUES (
+        ${id},
+        ${input.orgId},
+        ${input.type ?? 'kubernetes'},
+        ${input.name},
+        ${input.environment ?? null},
+        ${JSON.stringify(input.config ?? {})},
+        ${input.secretRef ?? null},
+        ${encryptSecret(input.secret ?? null)},
+        ${JSON.stringify(input.allowedNamespaces ?? [])},
+        ${JSON.stringify(input.capabilities ?? [])},
+        ${input.status ?? 'unknown'},
+        ${input.lastCheckedAt ?? null},
+        ${now},
+        ${now}
+      )
+    `);
+    const saved = await this.findByIdInOrg(input.orgId, id);
+    if (!saved) throw new Error(`[OpsConnectorRepository] create: row ${id} not found after insert`);
+    return saved;
+  }
+
+  async update(
+    orgId: string,
+    id: string,
+    patch: OpsConnectorPatch,
+  ): Promise<OpsConnector | null> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return null;
+
+    const merged = {
+      name: patch.name ?? existing.name,
+      environment: patch.environment !== undefined ? patch.environment : existing.environment,
+      config: patch.config ?? existing.config,
+      secretRef: patch.secretRef !== undefined ? patch.secretRef : existing.secretRef,
+      secret: patch.secret !== undefined ? patch.secret : existing.secret,
+      allowedNamespaces: patch.allowedNamespaces ?? existing.allowedNamespaces,
+      capabilities: patch.capabilities ?? existing.capabilities,
+      status: patch.status ?? existing.status,
+      lastCheckedAt: patch.lastCheckedAt !== undefined ? patch.lastCheckedAt : existing.lastCheckedAt,
+    };
+
+    this.db.run(sql`
+      UPDATE ops_connectors SET
+        name = ${merged.name},
+        environment = ${merged.environment},
+        config_json = ${JSON.stringify(merged.config)},
+        secret_ref = ${merged.secretRef},
+        encrypted_secret = ${encryptSecret(merged.secret ?? null)},
+        allowed_namespaces_json = ${JSON.stringify(merged.allowedNamespaces)},
+        capabilities_json = ${JSON.stringify(merged.capabilities)},
+        status = ${merged.status},
+        last_checked_at = ${merged.lastCheckedAt},
+        updated_at = ${nowIso()}
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+
+    return this.findByIdInOrg(orgId, id);
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return false;
+    this.db.run(sql`DELETE FROM ops_connectors WHERE org_id = ${orgId} AND id = ${id}`);
+    return true;
+  }
+}

--- a/packages/data-layer/src/repository/types/ops-connector.ts
+++ b/packages/data-layer/src/repository/types/ops-connector.ts
@@ -1,0 +1,74 @@
+export type OpsConnectorType = 'kubernetes';
+
+export type OpsConnectorStatus = 'unknown' | 'connected' | 'degraded' | 'error';
+
+export interface OpsConnectorConfig {
+  clusterName?: string;
+  apiServer?: string;
+  context?: string;
+  [key: string]: unknown;
+}
+
+export interface OpsConnector {
+  id: string;
+  orgId: string;
+  type: OpsConnectorType;
+  name: string;
+  environment: string | null;
+  config: OpsConnectorConfig;
+  secretRef: string | null;
+  secret: string | null;
+  allowedNamespaces: string[];
+  capabilities: string[];
+  status: OpsConnectorStatus;
+  lastCheckedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NewOpsConnector {
+  id?: string;
+  orgId: string;
+  type?: OpsConnectorType;
+  name: string;
+  environment?: string | null;
+  config?: OpsConnectorConfig;
+  secretRef?: string | null;
+  secret?: string | null;
+  allowedNamespaces?: string[];
+  capabilities?: string[];
+  status?: OpsConnectorStatus;
+  lastCheckedAt?: string | null;
+}
+
+export interface OpsConnectorPatch {
+  name?: string;
+  environment?: string | null;
+  config?: OpsConnectorConfig;
+  secretRef?: string | null;
+  secret?: string | null;
+  allowedNamespaces?: string[];
+  capabilities?: string[];
+  status?: OpsConnectorStatus;
+  lastCheckedAt?: string | null;
+}
+
+export interface OpsConnectorReadOptions {
+  masked?: boolean;
+}
+
+export interface IOpsConnectorRepository {
+  listByOrg(orgId: string, opts?: OpsConnectorReadOptions): Promise<OpsConnector[]>;
+  findByIdInOrg(
+    orgId: string,
+    id: string,
+    opts?: OpsConnectorReadOptions,
+  ): Promise<OpsConnector | null>;
+  create(input: NewOpsConnector): Promise<OpsConnector>;
+  update(
+    orgId: string,
+    id: string,
+    patch: OpsConnectorPatch,
+  ): Promise<OpsConnector | null>;
+  delete(orgId: string, id: string): Promise<boolean>;
+}

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -12,3 +12,11 @@ export {
   type UserPermissions,
 } from './auth-api.js';
 export { adminApi } from './admin-api.js';
+export {
+  opsApi,
+  parseNamespaceList,
+  buildOpsConnectorInput,
+  type OpsCapability,
+  type OpsConnector,
+  type OpsConnectorInput,
+} from './ops-api.js';

--- a/packages/web/src/api/ops-api.test.ts
+++ b/packages/web/src/api/ops-api.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpsConnectorInput, parseNamespaceList } from './ops-api.js';
+
+describe('ops-api helpers', () => {
+  it('parses namespace lists from commas and newlines', () => {
+    expect(parseNamespaceList('default, api\npayments\n\n ops ')).toEqual([
+      'default',
+      'api',
+      'payments',
+      'ops',
+    ]);
+  });
+
+  it('builds a connector payload without inventing defaults beyond checked capabilities', () => {
+    expect(buildOpsConnectorInput({
+      name: ' Prod Cluster ',
+      environment: ' prod ',
+      apiServer: ' https://k8s.example.com ',
+      clusterName: '',
+      context: '',
+      namespaces: 'default,api',
+      kubeconfig: ' kubeconfig-yaml ',
+      token: '',
+      capabilities: {
+        read: true,
+        propose: true,
+        execute_approved: false,
+      },
+    })).toEqual({
+      name: 'Prod Cluster',
+      environment: 'prod',
+      config: {
+        apiServer: 'https://k8s.example.com',
+        clusterName: undefined,
+        context: undefined,
+        credentialType: 'kubeconfig',
+      },
+      allowedNamespaces: ['default', 'api'],
+      secret: 'kubeconfig-yaml',
+      capabilities: ['read', 'propose'],
+    });
+  });
+});

--- a/packages/web/src/api/ops-api.ts
+++ b/packages/web/src/api/ops-api.ts
@@ -1,0 +1,101 @@
+import { apiClient } from './rest-api.js';
+
+export type OpsCapability = 'read' | 'propose' | 'execute_approved';
+
+export interface OpsConnector {
+  id: string;
+  name: string;
+  environment?: string | null;
+  config?: {
+    apiServer?: string;
+    clusterName?: string;
+    context?: string;
+    credentialType?: 'kubeconfig' | 'token';
+  };
+  allowedNamespaces: string[];
+  capabilities: OpsCapability[];
+  status?: 'unknown' | 'connected' | 'degraded' | 'error';
+  lastCheckedAt?: string | null;
+}
+
+export interface OpsConnectorTestResult {
+  status: 'connected' | 'degraded' | 'error';
+  message: string;
+  checks?: Record<string, string>;
+}
+
+export interface OpsConnectorInput {
+  name: string;
+  environment?: string | null;
+  config: {
+    apiServer?: string;
+    clusterName?: string;
+    context?: string;
+    credentialType?: 'kubeconfig' | 'token';
+  };
+  allowedNamespaces: string[];
+  secret?: string | null;
+  capabilities: OpsCapability[];
+}
+
+export function parseNamespaceList(value: string): string[] {
+  return value
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildOpsConnectorInput(value: {
+  name: string;
+  environment: string;
+  apiServer: string;
+  clusterName: string;
+  context: string;
+  namespaces: string;
+  kubeconfig: string;
+  token: string;
+  capabilities: Record<OpsCapability, boolean>;
+}): OpsConnectorInput {
+  const secret = value.kubeconfig.trim() || value.token.trim() || null;
+  return {
+    name: value.name.trim(),
+    environment: value.environment.trim() || null,
+    config: {
+      apiServer: value.apiServer.trim() || undefined,
+      clusterName: value.clusterName.trim() || undefined,
+      context: value.context.trim() || undefined,
+      credentialType: value.kubeconfig.trim() ? 'kubeconfig' : (value.token.trim() ? 'token' : undefined),
+    },
+    allowedNamespaces: parseNamespaceList(value.namespaces),
+    secret,
+    capabilities: (Object.keys(value.capabilities) as OpsCapability[])
+      .filter((capability) => value.capabilities[capability]),
+  };
+}
+
+export const opsApi = {
+  async listConnectors(): Promise<OpsConnector[]> {
+    const res = await apiClient.get<{ connectors?: OpsConnector[] } | OpsConnector[]>('/ops/connectors');
+    if (res.error) throw new Error(res.error.message ?? 'Failed to load Ops connectors');
+    if (Array.isArray(res.data)) return res.data;
+    return res.data?.connectors ?? [];
+  },
+
+  async createConnector(input: OpsConnectorInput): Promise<OpsConnector> {
+    const res = await apiClient.post<{ connector?: OpsConnector } | OpsConnector>('/ops/connectors', input);
+    if (res.error) throw new Error(res.error.message ?? 'Failed to create Ops connector');
+    if ('connector' in res.data && res.data.connector) return res.data.connector;
+    return res.data as OpsConnector;
+  },
+
+  async testConnector(id: string): Promise<OpsConnectorTestResult> {
+    const res = await apiClient.post<OpsConnectorTestResult>(`/ops/connectors/${encodeURIComponent(id)}/test`, {});
+    if (res.error) throw new Error(res.error.message ?? 'Failed to test Ops connector');
+    return res.data;
+  },
+
+  async deleteConnector(id: string): Promise<void> {
+    const res = await apiClient.delete<{ ok: boolean }>(`/ops/connectors/${encodeURIComponent(id)}`);
+    if (res.error) throw new Error(res.error.message ?? 'Failed to delete Ops connector');
+  },
+};

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { apiClient } from '../api/client.js';
+import { buildOpsConnectorInput, opsApi, type OpsCapability, type OpsConnector } from '../api/ops-api.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import { datasourceUrlPlaceholder, llmBaseUrlPlaceholder } from '../constants/placeholders.js';
 import { DATASOURCE_TYPES, datasourceInfo } from '../constants/datasource-types.js';
@@ -42,7 +43,7 @@ interface DsFormState {
 
 interface TestResult { ok: boolean; message: string; version?: string; }
 
-type SettingsTab = 'datasources' | 'llm' | 'notifications' | 'danger';
+type SettingsTab = 'datasources' | 'ops' | 'llm' | 'notifications' | 'danger';
 
 // ─── Constants ───
 
@@ -60,6 +61,10 @@ const TABS: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
   {
     id: 'datasources', label: 'Data Sources',
     icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><ellipse cx="12" cy="6" rx="8" ry="3" /><path d="M4 6v6c0 1.657 3.582 3 8 3s8-1.343 8-3V6" /><path d="M4 12v6c0 1.657 3.582 3 8 3s8-1.343 8-3v-6" /></svg>,
+  },
+  {
+    id: 'ops', label: 'Ops Integrations',
+    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M7 7v10a2 2 0 002 2h6a2 2 0 002-2V7M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2M9 12h6M9 15h4" /></svg>,
   },
   {
     id: 'llm', label: 'LLM Provider',
@@ -368,6 +373,242 @@ function EditFormWrapper({ initial, onSave, onCancel, onDelete, readOnly = false
   return <DatasourceForm value={form} onChange={setForm} onSave={() => void handleSave()} onCancel={onCancel} onDelete={onDelete} saving={saving} isNew={false} readOnly={readOnly} />;
 }
 
+// ─── Ops Integrations Tab ───
+
+const OPS_CAPABILITIES: { id: OpsCapability; label: string }[] = [
+  { id: 'read', label: 'Read' },
+  { id: 'propose', label: 'Propose' },
+  { id: 'execute_approved', label: 'Execute approved' },
+];
+
+function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
+  const [connectors, setConnectors] = useState<OpsConnector[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [testMessages, setTestMessages] = useState<Record<string, string>>({});
+  const [form, setForm] = useState({
+    name: '',
+    environment: 'prod',
+    apiServer: '',
+    clusterName: '',
+    context: '',
+    namespaces: '',
+    kubeconfig: '',
+    token: '',
+    capabilities: { read: true, propose: true, execute_approved: false } as Record<OpsCapability, boolean>,
+  });
+
+  const loadConnectors = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      setConnectors(await opsApi.listConnectors());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Ops connectors');
+      setConnectors([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadConnectors(); }, [loadConnectors]);
+
+  const updateForm = (patch: Partial<typeof form>) => setForm((prev) => ({ ...prev, ...patch }));
+
+  const handleCreate = async () => {
+    setSaving(true); setError(null);
+    try {
+      const connector = await opsApi.createConnector(buildOpsConnectorInput(form));
+      setConnectors((prev) => [...prev, connector]);
+      setShowForm(false);
+      setForm({
+        name: '',
+        environment: 'prod',
+        apiServer: '',
+        clusterName: '',
+        context: '',
+        namespaces: '',
+        kubeconfig: '',
+        token: '',
+        capabilities: { read: true, propose: true, execute_approved: false },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create Ops connector');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async (id: string) => {
+    setTestingId(id); setError(null);
+    try {
+      const result = await opsApi.testConnector(id);
+      setTestMessages((prev) => ({ ...prev, [id]: result.message }));
+      await loadConnectors();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to test Ops connector');
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setError(null);
+    try {
+      await opsApi.deleteConnector(id);
+      setConnectors((prev) => prev.filter((connector) => connector.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete Ops connector');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <span className="inline-block w-6 h-6 border-2 border-[var(--color-outline-variant)] border-t-[var(--color-primary)] rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-[var(--color-on-surface-variant)]">
+            {connectors.length > 0
+              ? `${connectors.length} connector${connectors.length === 1 ? '' : 's'} configured`
+              : 'Not connected'}
+          </p>
+          <p className="text-xs text-[var(--color-outline)] mt-0.5">
+            Cluster tools stay unavailable until a connector is configured.
+          </p>
+        </div>
+        {!showForm && canWrite && (
+          <button type="button" onClick={() => setShowForm(true)} className={btnPrimary}>
+            Connect
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-[#EF4444]/25 bg-[#EF4444]/10 px-3 py-2 text-sm text-[#EF4444]">
+          {error}
+        </div>
+      )}
+
+      {showForm && canWrite && (
+        <div className="space-y-3 p-4 bg-[var(--color-surface-highest)] rounded-xl border border-[var(--color-outline-variant)]">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Field label="Name">
+              <input type="text" value={form.name} onChange={(e) => updateForm({ name: e.target.value })} placeholder="Production Kubernetes" className={inputCls} />
+            </Field>
+            <Field label="Environment">
+              <input type="text" value={form.environment} onChange={(e) => updateForm({ environment: e.target.value })} placeholder="prod" className={inputCls} />
+            </Field>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <Field label="API Server">
+              <input type="url" value={form.apiServer} onChange={(e) => updateForm({ apiServer: e.target.value })} placeholder="https://kubernetes.example.com" className={inputCls} />
+            </Field>
+            <Field label="Cluster">
+              <input type="text" value={form.clusterName} onChange={(e) => updateForm({ clusterName: e.target.value })} placeholder="prod-east" className={inputCls} />
+            </Field>
+            <Field label="Context">
+              <input type="text" value={form.context} onChange={(e) => updateForm({ context: e.target.value })} placeholder="prod-admin" className={inputCls} />
+            </Field>
+          </div>
+          <Field label="Namespaces" hint="Comma or newline separated. Leave blank to require explicit command namespaces.">
+            <textarea value={form.namespaces} onChange={(e) => updateForm({ namespaces: e.target.value })} rows={2} placeholder="default, api, payments" className={inputCls + ' resize-y'} />
+          </Field>
+          <Field label="Kubeconfig">
+            <textarea value={form.kubeconfig} onChange={(e) => updateForm({ kubeconfig: e.target.value })} rows={5} placeholder="Paste kubeconfig" className={inputCls + ' resize-y font-mono text-xs'} />
+          </Field>
+          <Field label="Token">
+            <input type="password" value={form.token} onChange={(e) => updateForm({ token: e.target.value })} placeholder="Service account token" className={inputCls} />
+          </Field>
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-on-surface)] mb-2">Capabilities</label>
+            <div className="flex flex-wrap gap-3">
+              {OPS_CAPABILITIES.map((capability) => (
+                <label key={capability.id} className="flex items-center gap-2 text-sm text-[var(--color-on-surface-variant)]">
+                  <input
+                    type="checkbox"
+                    checked={form.capabilities[capability.id]}
+                    onChange={(e) => updateForm({ capabilities: { ...form.capabilities, [capability.id]: e.target.checked } })}
+                    className="w-3.5 h-3.5 rounded accent-[var(--color-primary)]"
+                  />
+                  {capability.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--color-outline-variant)]/30">
+            <button type="button" onClick={() => setShowForm(false)} className="px-2.5 py-1.5 rounded-lg text-xs text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-high)] transition-colors">Cancel</button>
+            <button type="button" onClick={() => void handleCreate()} disabled={saving || !form.name.trim() || (!form.apiServer.trim() && !form.clusterName.trim() && !form.context.trim())} className={btnPrimary + ' !py-1.5 !px-3 !text-xs'}>
+              {saving ? 'Connecting...' : 'Save connector'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {connectors.length === 0 && !showForm && (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div className="w-12 h-12 rounded-xl bg-[var(--color-surface-high)] flex items-center justify-center mb-3">
+            <svg className="w-6 h-6 text-[var(--color-outline)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M7 7v10a2 2 0 002 2h6a2 2 0 002-2V7M9 12h6M9 15h4" />
+            </svg>
+          </div>
+          <p className="text-sm text-[var(--color-on-surface-variant)] mb-1">No Ops integrations connected</p>
+          <p className="text-xs text-[var(--color-outline)]">Kubernetes cluster tools will show not connected until a connector is added.</p>
+        </div>
+      )}
+
+      {connectors.map((connector) => (
+        <div key={connector.id} className="rounded-xl border border-[var(--color-outline-variant)] px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-lg bg-[var(--color-primary)]/10 text-[var(--color-primary)] flex items-center justify-center shrink-0">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M7 7v10a2 2 0 002 2h6a2 2 0 002-2V7M9 12h6M9 15h4" /></svg>
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-[var(--color-on-surface)]">{connector.name}</span>
+                <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${connector.status === 'connected' ? 'bg-[#22C55E]/10 text-[#22C55E] border-[#22C55E]/20' : 'bg-[var(--color-on-surface-variant)]/10 text-[var(--color-on-surface-variant)] border-[var(--color-outline-variant)]'}`}>
+                  {connector.status === 'connected' ? 'Connected' : 'Not connected'}
+                </span>
+                {connector.environment && <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${ENV_STYLES[connector.environment] ?? ENV_STYLES.custom}`}>{connector.environment}</span>}
+              </div>
+              <p className="mt-1 text-xs text-[var(--color-outline)] font-mono">{connector.id}</p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {(connector.allowedNamespaces ?? []).map((namespace) => (
+                  <span key={namespace} className="px-1.5 py-0.5 rounded bg-[var(--color-surface-high)] text-[10px] text-[var(--color-on-surface-variant)]">{namespace}</span>
+                ))}
+                {(connector.capabilities ?? []).map((capability) => (
+                  <span key={capability} className="px-1.5 py-0.5 rounded bg-[var(--color-primary)]/10 text-[var(--color-primary)] text-[10px]">{capability}</span>
+                ))}
+              </div>
+              {testMessages[connector.id] && (
+                <p className="mt-2 text-xs text-[var(--color-on-surface-variant)]">{testMessages[connector.id]}</p>
+              )}
+              {canWrite && (
+                <div className="mt-3 flex items-center gap-2">
+                  <button type="button" onClick={() => void handleTest(connector.id)} disabled={testingId === connector.id} className={btnSecondary + ' !py-1.5 !px-3 !text-xs'}>
+                    {testingId === connector.id ? 'Testing...' : 'Test'}
+                  </button>
+                  <button type="button" onClick={() => void handleDelete(connector.id)} className="px-3 py-1.5 rounded-lg text-xs text-[#EF4444] hover:bg-[#EF4444]/10 transition-colors">
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // ─── LLM Tab ───
 
 function LlmTab({ canWrite }: { canWrite: boolean }) {
@@ -659,6 +900,11 @@ export default function Settings() {
   // ADMIN_ONLY_PERMISSIONS in roles-def.ts). Matches the backend enforcement
   // in routes/system.ts + routes/setup.ts reset endpoint.
   const canAdminWrite = !!user && (user.isServerAdmin || hasPermission('instance.config:write'));
+  const canOpsWrite = !!user && (
+    user.isServerAdmin ||
+    hasPermission('ops.connectors:write') ||
+    hasPermission('instance.config:write')
+  );
 
   return (
     <div className="h-full flex">
@@ -692,6 +938,7 @@ export default function Settings() {
           </h2>
           <p className="text-sm text-[var(--color-on-surface-variant)] mb-6">
             {tab === 'datasources' && 'Connect to Prometheus, Loki, Elasticsearch and other data sources.'}
+            {tab === 'ops' && 'Connect Kubernetes and operational command integrations.'}
             {tab === 'llm' && 'Configure the AI model used for investigations and analysis.'}
             {tab === 'notifications' && 'Set up alert delivery channels.'}
             {tab === 'danger' && 'Irreversible actions for your OpenObs instance.'}
@@ -700,6 +947,7 @@ export default function Settings() {
           {tab === 'datasources' && (
             <DataSourcesTab canCreate={canCreateDs} canWrite={canWriteDs} canDelete={canDeleteDs} />
           )}
+          {tab === 'ops' && <OpsIntegrationsTab canWrite={canOpsWrite} />}
           {tab === 'llm' && <LlmTab canWrite={canAdminWrite} />}
           {tab === 'notifications' && <NotificationsTab canWrite={canAdminWrite} />}
           {tab === 'danger' && <DangerTab canReset={canAdminWrite} />}


### PR DESCRIPTION
## Summary
- add org-scoped Ops/Kubernetes connector persistence and API surface
- add Settings UX for configuring, testing, and deleting Kubernetes connectors
- add agent ops.run_command tool with RBAC, audit, safe read-only kubectl execution, deny rules, and existing approvals workflow for mutating commands

## Validation
- npm.cmd --workspace @agentic-obs/common run typecheck
- npm.cmd --workspace @agentic-obs/agent-core run typecheck
- npm.cmd --workspace @agentic-obs/api-gateway run typecheck
- npm.cmd --workspace @agentic-obs/web run typecheck
- npx.cmd vitest run packages/common/src/rbac/actions.test.ts packages/common/src/rbac/roles-def.test.ts packages/data-layer/src/db/schema-applier.test.ts packages/data-layer/src/repository/sqlite/ops-connector.test.ts
- npx.cmd vitest run packages/api-gateway/src/services/ops-command-runner-service.test.ts packages/api-gateway/src/routes/ops-connectors.test.ts
- npx.cmd vitest run packages/agent-core/src/agent/handlers/__tests__/ops.test.ts packages/agent-core/src/agent/tool-permissions.test.ts packages/agent-core/src/agent/orchestrator-prompt.test.ts packages/web/src/api/ops-api.test.ts
- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kubernetes ops connector management to configure and test cluster connections
  * Added `ops.run_command` agent action for executing Kubernetes commands with three intent levels: read, propose, and execute_approved
  * Added Ops Integrations tab in Settings to create, test, and manage connectors
  * Added new RBAC permissions for ops connector administration and command execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->