### PR TITLE
Execute approved Ops commands

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -153,6 +153,8 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   }));
   app.use('/api/approvals', createApprovalRouter({
     approvals: eventApprovalStore,
+    approvalRequests: repos.approvals,
+    opsConnectors: repos.opsConnectors,
     ac: accessControl,
   }));
   app.use('/api/notifications', createNotificationsRouter({

--- a/packages/api-gateway/src/routes/approval.ts
+++ b/packages/api-gateway/src/routes/approval.ts
@@ -2,11 +2,12 @@ import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import type { ApiError } from '@agentic-obs/common';
 import { ac, ACTIONS } from '@agentic-obs/common';
-import type { IGatewayApprovalStore } from '@agentic-obs/data-layer';
+import type { IApprovalRequestRepository, IGatewayApprovalStore, IOpsConnectorRepository } from '@agentic-obs/data-layer';
 import { authMiddleware } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import { OpsCommandRunnerService } from '../services/ops-command-runner-service.js';
 
 /**
  * Stamp the caller's org role onto the approval record for audit. We keep the
@@ -22,6 +23,8 @@ function legacyOrgRole(role: string | undefined): string {
 
 export interface ApprovalRouterDeps {
   approvals: IGatewayApprovalStore;
+  approvalRequests?: IApprovalRequestRepository;
+  opsConnectors?: IOpsConnectorRepository;
   /**
    * RBAC surface. `AccessControlSurface` is used (not the concrete service)
    * because this router is mounted outside the async auth IIFE in server.ts
@@ -178,6 +181,43 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         }
 
         res.json(updated);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  // POST /api/approvals/:id/execute - execute an already-approved operation.
+  // This is intentionally narrow today: only `ops.run_command` approval
+  // records are executable here, so Kubernetes fixes reuse the existing
+  // approvals table instead of inventing a parallel Ops approval system.
+  router.post(
+    '/:id/execute',
+    authMiddleware,
+    requirePermission((req) =>
+      ac.eval(ACTIONS.ApprovalsApprove, `approvals:uid:${req.params['id'] ?? ''}`),
+    ),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const auth = authReq.auth;
+        if (!auth) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+          return;
+        }
+        if (!deps.approvalRequests || !deps.opsConnectors) {
+          res.status(503).json({
+            error: { code: 'NOT_CONFIGURED', message: 'approval execution is not configured' },
+          });
+          return;
+        }
+        const runner = new OpsCommandRunnerService({
+          connectors: deps.opsConnectors,
+          approvals: deps.approvalRequests,
+        }, auth.orgId);
+        const result = await runner.executeApprovedApproval(req.params['id'] ?? '', auth);
+        const status = result.decision === 'executed' ? 200 : 400;
+        res.status(status).json(result);
       } catch (err) {
         next(err);
       }

--- a/packages/api-gateway/src/services/ops-command-runner-service.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.test.ts
@@ -104,4 +104,52 @@ describe('OpsCommandRunnerService', () => {
       }),
     }));
   });
+
+  it('requires an approved existing approval record before execution', async () => {
+    approvals.findById = vi.fn(async () => ({
+      id: 'approval-1',
+      action: {
+        type: 'ops.run_command',
+        targetService: 'Production',
+        params: {
+          connectorId: 'k8s-prod',
+          command: 'kubectl rollout restart deployment/api -n default',
+        },
+      },
+      context: { requestedBy: 'u_1', reason: 'restart api' },
+      status: 'pending' as const,
+      createdAt: 'now',
+      expiresAt: 'later',
+    }));
+    const service = new OpsCommandRunnerService({ connectors, approvals }, 'org_a');
+
+    const result = await service.executeApprovedApproval('approval-1', identity());
+
+    expect(result.decision).toBe('denied');
+    expect(result.observation).toContain('is pending');
+  });
+
+  it('requires connector execute_approved capability for approved execution', async () => {
+    approvals.findById = vi.fn(async () => ({
+      id: 'approval-1',
+      action: {
+        type: 'ops.run_command',
+        targetService: 'Production',
+        params: {
+          connectorId: 'k8s-prod',
+          command: 'kubectl rollout restart deployment/api -n default',
+        },
+      },
+      context: { requestedBy: 'u_1', reason: 'restart api' },
+      status: 'approved' as const,
+      createdAt: 'now',
+      expiresAt: 'later',
+    }));
+    const service = new OpsCommandRunnerService({ connectors, approvals }, 'org_a');
+
+    const result = await service.executeApprovedApproval('approval-1', identity());
+
+    expect(result.decision).toBe('denied');
+    expect(result.observation).toContain('does not allow execute_approved');
+  });
 });

--- a/packages/api-gateway/src/services/ops-command-runner-service.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.ts
@@ -9,7 +9,7 @@ import type {
   OpsConnector,
 } from '@agentic-obs/data-layer';
 
-export type OpsCommandDecision = 'read' | 'approval_required' | 'denied';
+export type OpsCommandDecision = 'read' | 'approval_required' | 'executed' | 'denied';
 
 export interface OpsCommandRunnerServiceDeps {
   connectors: IOpsConnectorRepository;
@@ -97,14 +97,88 @@ export class OpsCommandRunnerService {
       return {
         decision: 'approval_required',
         observation:
-          'Approved Ops command execution is not wired to a kubectl runner yet. Use the existing approval record as the control point; do not execute this command directly.',
+          'Use the existing approval request execute endpoint to run approved Ops commands. Do not execute directly from chat.',
       };
     }
 
-    return this.runReadCommand(connector, params.command);
+    return this.runKubectlCommand(connector, params.command);
   }
 
-  private async runReadCommand(
+  async executeApprovedApproval(
+    approvalId: string,
+    identity: Identity,
+  ): Promise<{ observation: string; decision: OpsCommandDecision; approvalId: string }> {
+    const approval = await this.deps.approvals.findById(approvalId);
+    if (!approval) {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Approval request "${approvalId}" was not found.`,
+      };
+    }
+    if (approval.status !== 'approved') {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Approval request "${approvalId}" is ${approval.status}; only approved Ops command requests can execute.`,
+      };
+    }
+    if (approval.action.type !== 'ops.run_command') {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Approval request "${approvalId}" is for "${approval.action.type}", not ops.run_command.`,
+      };
+    }
+
+    const connectorId = typeof approval.action.params['connectorId'] === 'string'
+      ? approval.action.params['connectorId']
+      : '';
+    const command = typeof approval.action.params['command'] === 'string'
+      ? approval.action.params['command']
+      : '';
+    if (!connectorId || !command) {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Approval request "${approvalId}" is missing connectorId or command.`,
+      };
+    }
+
+    const connector = await this.deps.connectors.findByIdInOrg(this.orgId, connectorId);
+    if (!connector) {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Ops connector "${connectorId}" is not configured for this org.`,
+      };
+    }
+    if (!connector.capabilities.includes('execute_approved')) {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Ops connector "${connector.name}" does not allow execute_approved commands.`,
+      };
+    }
+
+    const policy = classifyOpsCommand(command);
+    if (policy.decision === 'denied') {
+      return {
+        approvalId,
+        decision: 'denied',
+        observation: `Denied by Ops command policy: ${policy.reason}.`,
+      };
+    }
+
+    const result = await this.runKubectlCommand(connector, command);
+    return {
+      approvalId,
+      decision: result.decision === 'denied' ? 'denied' : 'executed',
+      observation: `Approved by ${identity.userId}; ${result.observation}`,
+    };
+  }
+
+  private async runKubectlCommand(
     connector: OpsConnector,
     command: string,
   ): Promise<{ observation: string; decision: OpsCommandDecision }> {
@@ -112,14 +186,14 @@ export class OpsCommandRunnerService {
       return {
         decision: 'denied',
         observation:
-          `Read command is allowed by policy for connector "${connector.name}", but this server cannot resolve secretRef credentials yet.`,
+          `Command is allowed by policy for connector "${connector.name}", but this server cannot resolve secretRef credentials yet.`,
       };
     }
     if (!looksLikeKubeconfig(connector.secret)) {
       return {
         decision: 'denied',
         observation:
-          'Read command was not executed because only kubeconfig credentials are supported for live kubectl execution in this build.',
+          'Command was not executed because only kubeconfig credentials are supported for live kubectl execution in this build.',
       };
     }
 

--- a/packages/web/src/pages/ActionCenter.tsx
+++ b/packages/web/src/pages/ActionCenter.tsx
@@ -15,7 +15,7 @@ interface ApprovalAction {
 }
 
 interface ApprovalContext {
-  investigationId: string;
+  investigationId?: string;
   requestedBy: string;
   reason: string;
 }
@@ -69,7 +69,7 @@ const STATUS_STYLES: Record<ApprovalStatus, string> = {
 interface ActionCardProps {
   request: ApprovalRequest;
   processing: boolean;
-  onApprove: (id: string) => void;
+  onApprove: (request: ApprovalRequest) => void;
   onReject: (id: string) => void;
   canApprove: boolean;
 }
@@ -115,7 +115,9 @@ function ActionCard({ request, processing, onApprove, onReject, canApprove }: Ac
       {/* Footer row - stacks vertically on mobile */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 pt-1">
         <div className="text-xs text-[var(--color-outline)] space-x-3">
-          <span>Context: {request.context.investigationId.slice(0, 8)}…</span>
+          {request.context.investigationId && (
+            <span>Context: {request.context.investigationId.slice(0, 8)}…</span>
+          )}
           {request.expiresAt && <span>expires in {expiresIn(request.expiresAt)}</span>}
           {request.resolvedBy && <span>resolved by {request.resolvedBy}</span>}
         </div>
@@ -133,10 +135,10 @@ function ActionCard({ request, processing, onApprove, onReject, canApprove }: Ac
             <button
               type="button"
               disabled={processing}
-              onClick={() => onApprove(request.id)}
+              onClick={() => onApprove(request)}
               className="flex-1 sm:flex-none px-4 py-2.5 sm:py-1.5 rounded-lg text-sm sm:text-xs font-medium bg-[var(--color-primary)] text-[var(--color-on-primary-fixed)] hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
-              {processing ? 'Processing…' : 'Approve'}
+              {processing ? 'Processing…' : request.action.type === 'ops.run_command' ? 'Approve & Execute' : 'Approve'}
             </button>
           </div>
         )}
@@ -161,6 +163,7 @@ export default function ActionCenter() {
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState<Set<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
+  const [actionInfo, setActionInfo] = useState<string | null>(null);
   const [tab, setTab] = useState<'pending' | 'resolved'>('pending');
 
   const loadApprovals = useCallback(async () => {
@@ -181,20 +184,32 @@ export default function ActionCenter() {
     return () => clearInterval(timer);
   }, [loadApprovals]);
 
-  const handleApprove = useCallback(async (id: string) => {
+  const handleApprove = useCallback(async (request: ApprovalRequest) => {
+    const { id } = request;
     setActionError(null);
+    setActionInfo(null);
     setProcessing((prev) => new Set(prev).add(id));
     const res = await apiClient.post<ApprovalRequest>(`/approvals/${id}/approve`, {});
-    setProcessing((prev) => { const s = new Set(prev); s.delete(id); return s; });
     if (res.error) {
       setActionError(`Approve failed: ${res.error.message}`);
+      setProcessing((prev) => { const s = new Set(prev); s.delete(id); return s; });
     } else {
+      if (request.action.type === 'ops.run_command') {
+        const exec = await apiClient.post<{ observation?: string; decision?: string }>(`/approvals/${id}/execute`, {});
+        if (exec.error) {
+          setActionError(`Execute failed: ${exec.error.message}`);
+        } else {
+          setActionInfo(exec.data.observation ?? 'Approved command executed.');
+        }
+      }
+      setProcessing((prev) => { const s = new Set(prev); s.delete(id); return s; });
       await loadApprovals();
     }
   }, [loadApprovals]);
 
   const handleReject = useCallback(async (id: string) => {
     setActionError(null);
+    setActionInfo(null);
     setProcessing((prev) => new Set(prev).add(id));
     const res = await apiClient.post<ApprovalRequest>(`/approvals/${id}/reject`, {});
     setProcessing((prev) => { const s = new Set(prev); s.delete(id); return s; });
@@ -283,6 +298,19 @@ export default function ActionCenter() {
         </div>
       )}
 
+      {actionInfo && (
+        <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-[#22C55E]/10 border border-[#22C55E]/20 text-sm text-[#22C55E]">
+          <span>{actionInfo}</span>
+          <button
+            type="button"
+            onClick={() => setActionInfo(null)}
+            className="ml-3 text-[#22C55E]/70 hover:text-[#22C55E] font-semibold"
+          >
+            x
+          </button>
+        </div>
+      )}
+
       {/* Content */}
       {loading ? (
         <div className="flex items-center justify-center py-16">
@@ -303,7 +331,7 @@ export default function ActionCenter() {
               key={req.id}
               request={req}
               processing={processing.has(req.id)}
-              onApprove={(id) => { void handleApprove(id); }}
+              onApprove={(request) => { void handleApprove(request); }}
               onReject={(id) => { void handleReject(id); }}
               canApprove={canApprove}
             />


### PR DESCRIPTION
## Summary
- add an approval execute endpoint for existing approved ops.run_command records
- keep Ops execution tied to the existing approvals workflow instead of creating a parallel approval system
- update Action Center to approve and execute Ops commands in one explicit flow
- require connector execute_approved capability before running approved commands

## Validation
- npm.cmd --workspace @agentic-obs/api-gateway run typecheck
- npm.cmd --workspace @agentic-obs/web run typecheck
- npx.cmd vitest run packages/api-gateway/src/services/ops-command-runner-service.test.ts
- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to execute already-approved operations directly from the action center via a new execute endpoint.
  * Updated approval workflow with "Approve & Execute" button for operational command actions.
  * New execution endpoint includes validation for connector capabilities and approval status.

* **Tests**
  * Added unit tests for approved operation execution scenarios, including pending approval and missing capability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->