### PR TITLE
Resolve Ops connector secret refs

### DIFF
--- a/packages/api-gateway/src/services/ops-command-runner-service.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.test.ts
@@ -152,4 +152,24 @@ describe('OpsCommandRunnerService', () => {
     expect(result.decision).toBe('denied');
     expect(result.observation).toContain('does not allow execute_approved');
   });
+
+  it('uses the injected secretRef resolver when connector credentials are external', async () => {
+    const service = new OpsCommandRunnerService({
+      connectors,
+      approvals,
+      secretResolver: {
+        resolve: vi.fn(async () => 'apiVersion: v1\nkind: Config\n'),
+      },
+    }, 'org_a');
+
+    const result = await service.runCommand({
+      connectorId: 'k8s-prod',
+      command: 'kubectl get pods -n default',
+      intent: 'read',
+      identity: identity(),
+      sessionId: 'session-1',
+    });
+
+    expect(result.observation).not.toContain('cannot resolve secretRef');
+  });
 });

--- a/packages/api-gateway/src/services/ops-command-runner-service.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.ts
@@ -8,12 +8,14 @@ import type {
   IOpsConnectorRepository,
   OpsConnector,
 } from '@agentic-obs/data-layer';
+import { DefaultOpsSecretRefResolver, type OpsSecretRefResolver } from './ops-secret-ref-resolver.js';
 
 export type OpsCommandDecision = 'read' | 'approval_required' | 'executed' | 'denied';
 
 export interface OpsCommandRunnerServiceDeps {
   connectors: IOpsConnectorRepository;
   approvals: IApprovalRequestRepository;
+  secretResolver?: OpsSecretRefResolver;
 }
 
 interface AgentOpsConnectorConfig {
@@ -25,7 +27,11 @@ interface AgentOpsConnectorConfig {
 }
 
 export class OpsCommandRunnerService {
-  constructor(private readonly deps: OpsCommandRunnerServiceDeps, private readonly orgId: string) {}
+  private readonly secretResolver: OpsSecretRefResolver;
+
+  constructor(private readonly deps: OpsCommandRunnerServiceDeps, private readonly orgId: string) {
+    this.secretResolver = deps.secretResolver ?? new DefaultOpsSecretRefResolver();
+  }
 
   async listConnectors(): Promise<AgentOpsConnectorConfig[]> {
     const connectors = await this.deps.connectors.listByOrg(this.orgId, { masked: true });
@@ -182,14 +188,14 @@ export class OpsCommandRunnerService {
     connector: OpsConnector,
     command: string,
   ): Promise<{ observation: string; decision: OpsCommandDecision }> {
-    if (!connector.secret) {
+    const kubeconfig = await this.resolveKubeconfig(connector);
+    if (!kubeconfig.ok) {
       return {
         decision: 'denied',
-        observation:
-          `Command is allowed by policy for connector "${connector.name}", but this server cannot resolve secretRef credentials yet.`,
+        observation: kubeconfig.error,
       };
     }
-    if (!looksLikeKubeconfig(connector.secret)) {
+    if (!looksLikeKubeconfig(kubeconfig.value)) {
       return {
         decision: 'denied',
         observation:
@@ -205,7 +211,7 @@ export class OpsCommandRunnerService {
     const tempDir = await mkdtemp(join(tmpdir(), 'openobs-kube-'));
     const kubeconfigPath = join(tempDir, 'config');
     try {
-      await writeFile(kubeconfigPath, connector.secret, { encoding: 'utf8', mode: 0o600 });
+      await writeFile(kubeconfigPath, kubeconfig.value, { encoding: 'utf8', mode: 0o600 });
       const args = tokenizeKubectlCommand(command).slice(1);
       const result = await runKubectl(args, kubeconfigPath);
       return {
@@ -214,6 +220,27 @@ export class OpsCommandRunnerService {
       };
     } finally {
       await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  private async resolveKubeconfig(
+    connector: OpsConnector,
+  ): Promise<{ ok: true; value: string } | { ok: false; error: string }> {
+    if (connector.secret) return { ok: true, value: connector.secret };
+    if (!connector.secretRef) {
+      return {
+        ok: false,
+        error: `Ops connector "${connector.id}" is not connected: no credential secret or secretRef is configured.`,
+      };
+    }
+    try {
+      const value = await this.secretResolver.resolve(connector.secretRef);
+      return { ok: true, value };
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Command was not executed because secretRef could not be resolved: ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
   }
 }

--- a/packages/api-gateway/src/services/ops-connector-service.ts
+++ b/packages/api-gateway/src/services/ops-connector-service.ts
@@ -1,4 +1,5 @@
 import type { OpsConnector, OpsConnectorConfig, OpsConnectorStatus } from '@agentic-obs/data-layer';
+import { DefaultOpsSecretRefResolver, type OpsSecretRefResolver } from './ops-secret-ref-resolver.js';
 
 export interface OpsConnectorTestResult {
   status: Exclude<OpsConnectorStatus, 'unknown'>;
@@ -15,6 +16,12 @@ export interface KubernetesConnectorRunner {
 }
 
 export class StructuralKubernetesConnectorRunner implements KubernetesConnectorRunner {
+  private readonly secretResolver: OpsSecretRefResolver;
+
+  constructor(secretResolver: OpsSecretRefResolver = new DefaultOpsSecretRefResolver()) {
+    this.secretResolver = secretResolver;
+  }
+
   async test(connector: OpsConnector): Promise<OpsConnectorTestResult> {
     const validation = validateKubernetesConnector(connector.config);
     if (validation) {
@@ -26,6 +33,17 @@ export class StructuralKubernetesConnectorRunner implements KubernetesConnectorR
     }
 
     const hasCredentials = Boolean(connector.secretRef || connector.secret);
+    if (connector.secretRef) {
+      try {
+        await this.secretResolver.resolve(connector.secretRef);
+      } catch (err) {
+        return {
+          status: 'error',
+          checks: { structure: 'ok', credentials: 'missing', runner: 'skipped' },
+          message: `Kubernetes connector structure is valid, but secretRef could not be resolved: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
     return {
       status: hasCredentials ? 'connected' : 'degraded',
       checks: {

--- a/packages/api-gateway/src/services/ops-secret-ref-resolver.test.ts
+++ b/packages/api-gateway/src/services/ops-secret-ref-resolver.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DefaultOpsSecretRefResolver, redactRef, UnsupportedSecretRefError } from './ops-secret-ref-resolver.js';
+
+const resolver = new DefaultOpsSecretRefResolver();
+const touchedEnv: string[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const key of touchedEnv.splice(0)) delete process.env[key];
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('DefaultOpsSecretRefResolver', () => {
+  it('resolves env:// refs', async () => {
+    touchedEnv.push('OPENOBS_TEST_KUBECONFIG');
+    process.env['OPENOBS_TEST_KUBECONFIG'] = 'apiVersion: v1\nkind: Config\n';
+
+    await expect(resolver.resolve('env://OPENOBS_TEST_KUBECONFIG')).resolves.toContain('kind: Config');
+  });
+
+  it('resolves file:// refs with absolute paths', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openobs-secret-ref-test-'));
+    tempDirs.push(dir);
+    const path = join(dir, 'kubeconfig.yaml');
+    await writeFile(path, 'apiVersion: v1\nkind: Config\n', 'utf8');
+
+    await expect(resolver.resolve(`file://${path}`)).resolves.toContain('apiVersion');
+  });
+
+  it('rejects unsupported providers explicitly', async () => {
+    await expect(resolver.resolve('aws-sm://k8s/prod')).rejects.toBeInstanceOf(UnsupportedSecretRefError);
+  });
+
+  it('redacts non-env refs in messages', () => {
+    expect(redactRef('env://OPENOBS_TEST_KUBECONFIG')).toBe('env://OPENOBS_TEST_KUBECONFIG');
+    expect(redactRef('file:///secret/kubeconfig')).toBe('file://***');
+    expect(redactRef('vault://k8s/prod')).toBe('vault://***');
+  });
+
+  it('resolves vault:// refs using VAULT_ADDR and VAULT_TOKEN', async () => {
+    touchedEnv.push('VAULT_ADDR', 'VAULT_TOKEN');
+    process.env['VAULT_ADDR'] = 'https://vault.example.com';
+    process.env['VAULT_TOKEN'] = 'token';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { data: { kubeconfig: 'apiVersion: v1\nkind: Config\n' } } }),
+    } as Response);
+
+    await expect(resolver.resolve('vault://secret/data/k8s/prod#kubeconfig')).resolves.toContain('kind: Config');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://vault.example.com/v1/secret/data/k8s/prod',
+      { headers: { 'X-Vault-Token': 'token' } },
+    );
+  });
+});

--- a/packages/api-gateway/src/services/ops-secret-ref-resolver.ts
+++ b/packages/api-gateway/src/services/ops-secret-ref-resolver.ts
@@ -1,0 +1,91 @@
+import { readFile } from 'node:fs/promises';
+
+export interface OpsSecretRefResolver {
+  resolve(ref: string): Promise<string>;
+}
+
+export class UnsupportedSecretRefError extends Error {
+  constructor(ref: string) {
+    super(`Unsupported Ops secretRef "${redactRef(ref)}". Supported schemes: env://VAR_NAME, file://ABSOLUTE_PATH, vault://path#field.`);
+    this.name = 'UnsupportedSecretRefError';
+  }
+}
+
+export class DefaultOpsSecretRefResolver implements OpsSecretRefResolver {
+  async resolve(ref: string): Promise<string> {
+    const trimmed = ref.trim();
+    if (!trimmed) throw new UnsupportedSecretRefError(ref);
+
+    if (trimmed.startsWith('env://')) {
+      const key = trimmed.slice('env://'.length);
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+        throw new Error(`Invalid env secretRef "${redactRef(ref)}".`);
+      }
+      const value = process.env[key];
+      if (!value) {
+        throw new Error(`Environment secretRef "${redactRef(ref)}" is not set.`);
+      }
+      return value;
+    }
+
+    if (trimmed.startsWith('file://')) {
+      const path = trimmed.slice('file://'.length);
+      if (!path || !isAbsolutePath(path)) {
+        throw new Error(`File secretRef "${redactRef(ref)}" must be an absolute path.`);
+      }
+      return readFile(path, 'utf8');
+    }
+
+    if (trimmed.startsWith('vault://')) {
+      return this.resolveVault(trimmed);
+    }
+
+    throw new UnsupportedSecretRefError(ref);
+  }
+
+  private async resolveVault(ref: string): Promise<string> {
+    const addr = process.env['VAULT_ADDR'];
+    const token = process.env['VAULT_TOKEN'];
+    if (!addr || !token) {
+      throw new Error('Vault secretRef requires VAULT_ADDR and VAULT_TOKEN.');
+    }
+
+    const parsed = new URL(ref);
+    const field = parsed.hash ? decodeURIComponent(parsed.hash.slice(1)) : 'kubeconfig';
+    const vaultPath = `${parsed.hostname}${parsed.pathname}`;
+    if (!vaultPath || vaultPath === '/') {
+      throw new Error(`Vault secretRef "${redactRef(ref)}" must include a secret path.`);
+    }
+
+    const endpoint = `${addr.replace(/\/+$/, '')}/v1/${vaultPath.replace(/^\/+/, '')}`;
+    const response = await fetch(endpoint, {
+      headers: { 'X-Vault-Token': token },
+    });
+    if (!response.ok) {
+      throw new Error(`Vault secretRef "${redactRef(ref)}" returned HTTP ${response.status}.`);
+    }
+    const body = await response.json() as { data?: Record<string, unknown> };
+    const data = body.data ?? {};
+    const nested = typeof data['data'] === 'object' && data['data'] !== null
+      ? data['data'] as Record<string, unknown>
+      : data;
+    const value = nested[field];
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`Vault secretRef "${redactRef(ref)}" did not contain string field "${field}".`);
+    }
+    return value;
+  }
+}
+
+export function redactRef(ref: string): string {
+  const trimmed = ref.trim();
+  if (trimmed.startsWith('env://')) return trimmed;
+  if (trimmed.startsWith('file://')) return 'file://***';
+  if (trimmed.startsWith('vault://')) return 'vault://***';
+  const scheme = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//)?.[1];
+  return scheme ? `${scheme}://***` : '***';
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path);
+}

--- a/packages/web/src/api/ops-api.test.ts
+++ b/packages/web/src/api/ops-api.test.ts
@@ -21,6 +21,7 @@ describe('ops-api helpers', () => {
       namespaces: 'default,api',
       kubeconfig: ' kubeconfig-yaml ',
       token: '',
+      secretRef: '',
       capabilities: {
         read: true,
         propose: true,
@@ -36,8 +37,32 @@ describe('ops-api helpers', () => {
         credentialType: 'kubeconfig',
       },
       allowedNamespaces: ['default', 'api'],
+      secretRef: null,
       secret: 'kubeconfig-yaml',
       capabilities: ['read', 'propose'],
+    });
+  });
+
+  it('prefers secretRef over pasted credentials', () => {
+    expect(buildOpsConnectorInput({
+      name: 'Prod',
+      environment: '',
+      apiServer: '',
+      clusterName: 'prod',
+      context: '',
+      namespaces: '',
+      kubeconfig: ' kubeconfig-yaml ',
+      token: '',
+      secretRef: ' env://OPENOBS_KUBECONFIG_PROD ',
+      capabilities: {
+        read: true,
+        propose: false,
+        execute_approved: false,
+      },
+    })).toMatchObject({
+      secretRef: 'env://OPENOBS_KUBECONFIG_PROD',
+      secret: null,
+      capabilities: ['read'],
     });
   });
 });

--- a/packages/web/src/api/ops-api.ts
+++ b/packages/web/src/api/ops-api.ts
@@ -34,6 +34,7 @@ export interface OpsConnectorInput {
     credentialType?: 'kubeconfig' | 'token';
   };
   allowedNamespaces: string[];
+  secretRef?: string | null;
   secret?: string | null;
   capabilities: OpsCapability[];
 }
@@ -54,9 +55,11 @@ export function buildOpsConnectorInput(value: {
   namespaces: string;
   kubeconfig: string;
   token: string;
+  secretRef: string;
   capabilities: Record<OpsCapability, boolean>;
 }): OpsConnectorInput {
   const secret = value.kubeconfig.trim() || value.token.trim() || null;
+  const secretRef = value.secretRef.trim() || null;
   return {
     name: value.name.trim(),
     environment: value.environment.trim() || null,
@@ -67,7 +70,8 @@ export function buildOpsConnectorInput(value: {
       credentialType: value.kubeconfig.trim() ? 'kubeconfig' : (value.token.trim() ? 'token' : undefined),
     },
     allowedNamespaces: parseNamespaceList(value.namespaces),
-    secret,
+    secretRef,
+    secret: secretRef ? null : secret,
     capabilities: (Object.keys(value.capabilities) as OpsCapability[])
       .filter((capability) => value.capabilities[capability]),
   };

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -398,6 +398,7 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
     namespaces: '',
     kubeconfig: '',
     token: '',
+    secretRef: '',
     capabilities: { read: true, propose: true, execute_approved: false } as Record<OpsCapability, boolean>,
   });
 
@@ -432,6 +433,7 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
         namespaces: '',
         kubeconfig: '',
         token: '',
+        secretRef: '',
         capabilities: { read: true, propose: true, execute_approved: false },
       });
     } catch (err) {
@@ -524,6 +526,9 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
           </Field>
           <Field label="Kubeconfig">
             <textarea value={form.kubeconfig} onChange={(e) => updateForm({ kubeconfig: e.target.value })} rows={5} placeholder="Paste kubeconfig" className={inputCls + ' resize-y font-mono text-xs'} />
+          </Field>
+          <Field label="Secret Ref" hint="Optional. env://VAR_NAME, file://absolute/path, or vault://path#field. When set, pasted credentials are ignored.">
+            <input type="text" value={form.secretRef} onChange={(e) => updateForm({ secretRef: e.target.value })} placeholder="env://OPENOBS_KUBECONFIG_PROD" className={inputCls} />
           </Field>
           <Field label="Token">
             <input type="password" value={form.token} onChange={(e) => updateForm({ token: e.target.value })} placeholder="Service account token" className={inputCls} />


### PR DESCRIPTION
## Summary
- add explicit Ops secretRef resolver support for env://, file://, and vault://path#field
- use resolved secretRef credentials for kubectl command execution and connector testing
- keep unsupported secret providers fail-closed with redacted error messages
- add Settings support for entering secretRef values without storing pasted kubeconfig credentials

## Validation
- npm.cmd --workspace @agentic-obs/api-gateway run typecheck
- npm.cmd --workspace @agentic-obs/web run typecheck
- npx.cmd vitest run packages/api-gateway/src/services/ops-secret-ref-resolver.test.ts packages/api-gateway/src/services/ops-command-runner-service.test.ts packages/web/src/api/ops-api.test.ts
- npm.cmd run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Secret Ref" field to connector configuration for secure credential management
  * Support for secret references via environment variables, local files, and Vault integration
  * Secret references take precedence over pasted credentials when both are provided
  * Enhanced connector health validation for secret reference resolution

* **Tests**
  * Added comprehensive test coverage for secret reference resolution and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->