### PR TITLE
P1: Loosen investigation report structure

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -134,46 +134,41 @@ User: "Alert me when error rate goes above 5%"
 </example>
 
 ## Investigation
-When the user asks "why is X high/slow/broken" or "investigate X", conduct a hypothesis-driven investigation — like a senior SRE writing an incident report.
+When the user asks "why is X high/slow/broken" or "investigate X", debug it the way you'd walk a teammate through it in Slack: lead with what you saw and the numbers, work through what you suspected and what you queried, follow the trail (including dead ends), and end with what's most likely going on.
 
-The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Write the report the way a human engineer would explain their debugging process to their team: detailed reasoning, specific numbers inline, and clear logic connecting each step.
+The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Don't pre-name sections "Hypothesis 1 / Conclusion / Next Steps". Pick headings (or no headings) that fit the case, and let the prose carry the structure.
 
-### Report Structure
-1. **Initial Assessment** (text section, 3-5 sentences) — State the symptom with specific numbers. Expected vs actual? When did it start? How severe?
-2. **For each hypothesis** — A long text section (5-10 sentences): what you're testing and why, what you queried, the results, what they mean. Attach ONE evidence panel per hypothesis to visualize the key data.
-3. **Conclusion** (text section, 5-10 sentences) — Root cause (or lack thereof) and the evidence chain that led to it.
-4. **Next Steps** (text section, REQUIRED if a problem was found) — Concrete, actionable troubleshooting steps an on-call engineer could follow immediately.
+### How to write it
+- Lead with what you saw and the numbers ("p99 jumped from ~50ms baseline to 99ms around 14:30; sustained for the last hour").
+- For each thing you suspected: state it, say what you queried, what came back, and whether that killed or supported the suspicion. Allow detours and dead ends — real debugging isn't linear.
+- Connect the dots explicitly: "Since traffic is stable AND errors are zero, the cost is in per-request work, not load."
+- End with what's most likely going on — or "I couldn't tell" if you can't. Don't force a Conclusion heading; the last paragraph IS the conclusion.
+- If the user can act on it, say what they should try next, specifically. If everything is healthy, say so cleanly and stop.
+- Specific numbers inline: not "high", but "120ms vs <50ms baseline".
+- Complete paragraphs, not bullet lists.
 
-### Writing Style
-- Complete paragraphs, not bullets. Brief a team.
-- Specific numbers inline: "Request rate averaged 0.19 req/s over the past hour with a peak of 0.25 at 14:30, well within normal range."
-- Connect dots: "Since traffic is stable AND errors are zero, we can rule out load-related causes and focus on per-handler analysis."
-- Evidence panels sparingly — 2-4 total, only for the most important data points.
-- Not every investigation finds a problem. If everything is healthy, say so.
-
-### Key Rules
-- Text sections are the MAIN CONTENT. Substantial paragraphs, not one-liners.
-- Evidence panels are SUPPORTING VISUALS, not one-per-query.
-- Gather data BEFORE writing sections.
-- MUST call investigation.complete at the end. Without it, all sections are lost. Don't end the turn with plain text before completing the investigation.
+### Mechanics
+- Use \`investigation.add_section({type: "text"})\` for prose; \`{type: "evidence"}\` to attach the chart that supports a paragraph. Section order = display order.
+- Choose your own headings (or none). Don't reach for "## Initial Assessment" / "## Hypothesis Testing" by reflex — fit the heading to what you're actually saying.
+- Interleave querying and writing. Query → write a paragraph → query more → write more → drop in the evidence panel next to the prose it supports. Don't do all the queries first and then the writing.
+- Evidence panels sparingly — 2–4 total. Each one earns its place next to the paragraph that interprets it.
+- MUST call \`investigation.complete\` at the end. Without it, sections are lost. Don't end the turn with plain text before completing.
 
 <example>
 User: "Why is p99 latency so high?"
   1. datasources.list(signalType: "metrics") → id: prom-prod
   2. investigation.create(question: "Why is p99 latency high?") → inv-789
   3. metrics.query(p99) → 99ms; metrics.query(p50) → 50ms
-  4. metrics.range_query(query: request rate, duration_minutes: 60) → stable 0.19 req/s
-  5. metrics.query(error rate) → 0 errors
-  6. metrics.query(p99 by handler) → /api/v1/query_range=120ms, others <50ms
-  7. changes.list_recent(service: "api-gateway", window_minutes: 120) → no deploys in window
-  — Now write the report with all evidence gathered —
-  8. investigation.add_section(type: "text", content: "## Initial Assessment ... 99ms vs 50ms p50 ...")
-  9. investigation.add_section(type: "evidence", content: "p99 vs p50 chart", panel: {...})
-  10. investigation.add_section(type: "text", content: "## Hypothesis Testing — Traffic, Errors, Per-handler ...")
-  11. investigation.add_section(type: "evidence", content: "per-handler breakdown", panel: {...})
-  12. investigation.add_section(type: "text", content: "## Conclusion — /api/v1/query_range hotspot ...")
-  13. investigation.add_section(type: "text", content: "## Next Steps — profiling, query complexity, caching, monitoring, verify ...")
-  14. investigation.complete(investigationId: "inv-789", summary: "p99 caused by /api/v1/query_range handler (120ms vs <50ms). Recommend profiling.")
+  4. investigation.add_section(type: "text", content: "p99 is sitting at 99ms vs ~50ms p50 — about 2× the median, sustained over the last hour. Worth chasing.")
+  5. metrics.range_query(query: request rate, duration_minutes: 60) → stable 0.19 req/s
+  6. metrics.query(error rate) → 0 errors
+  7. investigation.add_section(type: "text", content: "First thought: load. Rate is flat at 0.19 req/s with a peak of 0.25 at 14:30, well within normal range. Errors are zero. So it isn't load-driven and it isn't a fault path — the cost is in per-request work somewhere.")
+  8. metrics.query(p99 by handler) → /api/v1/query_range=120ms, others <50ms
+  9. investigation.add_section(type: "evidence", content: "p99 by handler", panel: {...})
+  10. investigation.add_section(type: "text", content: "Breaking down by handler points the finger: /api/v1/query_range sits at 120ms p99 while every other handler is under 50ms. That one handler is the entire delta.")
+  11. changes.list_recent(service: "api-gateway", window_minutes: 120) → no deploys in window
+  12. investigation.add_section(type: "text", content: "No deploys in the last 2h, so this isn't a regression from a code change — most likely an expensive query pattern or upstream slowdown specific to /query_range. To pin it down, profile a slow request, check incoming PromQL complexity for that endpoint, and see whether the slowness tracks a particular tenant or query shape.")
+  13. investigation.complete(investigationId: "inv-789", summary: "p99 is driven by /api/v1/query_range alone (120ms vs <50ms others). No deploy correlation. Profile that handler and look at PromQL complexity per-tenant.")
 </example>
 
 ## Opening Existing Resources


### PR DESCRIPTION
## What

Rewrites the Investigation section of the orchestrator system prompt
(`packages/agent-core/src/agent/orchestrator-prompt.ts`) so the agent
writes reports the way a real engineer debugs: lead with what was seen,
suspect things, query, follow the trail (including dead ends), conclude.

Closes openobs/openobs#40 (T1.1) and openobs/openobs#41 (T1.2).
Tracks under epic #94. Phase 1 of [auto-remediation design](https://github.com/openobs/openobs/blob/design/auto-remediation/docs/design/auto-remediation.md).

## Why

Reports today come out as filled-in templates (Initial Assessment /
Hypothesis Testing / Conclusion / Next Steps), every time. The cause
is in the prompt itself: those headings are hard-coded as the report
structure, and the example shows a waterfall flow (gather all data
first, then dump all sections at the end). The output reads less like
debugging notes and more like a form.

## Changes

- Drop the four hard-coded section names. New text explicitly tells
  the agent not to reach for "## Initial Assessment" / "## Hypothesis
  Testing" by reflex; pick headings (or none) that fit the case.
- Encourage interleaving querying and writing. Query → write a
  paragraph → query more → write more → drop in evidence next to the
  prose it supports. The new example demonstrates this with 13 steps
  interleaving \`investigation.add_section\` and metric queries.
- Allow detours and dead ends ("first thought: load. Rate is flat at
  0.19 req/s, errors are zero. So it isn't load-driven —") instead of
  pretending the path was straight.
- Keep mechanics rules: still must call \`investigation.complete\`,
  evidence panels still capped at 2–4, prose-not-bullets still applies.

## Surface area

- One file, prompt-only.
- API of \`investigation.add_section({type, content, panel?})\` and
  \`investigation.complete\` is **unchanged** — saved-report shape is
  unchanged on disk.
- No DB migration. No new tools. No new endpoints.

## Test results

- \`npm run typecheck\` clean.
- \`npm test --run\` — 1347 passed / 16 skipped (postgres-needs-real-DB
  ones are pre-existing skips). No test asserted on the old hard-coded
  section names, so T1.3 was a no-op grep — captured in the commit
  message and tracked-issue comment.

## What's not included

- T1.4 (manual review of 5 staging investigations): I can't run that
  from here. **Reviewer**: please run a few investigations on staging
  with this prompt and paste excerpts back into the PR — that's the
  acceptance gate.

## Reverting

Single-commit, prompt-only. Revert is `git revert <sha>`; the saved
report shape is unchanged so old + new reports interoperate fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Investigation feature now uses conversational Slack-style guidance instead of rigid templates
  * Agent can interleave querying and writing dynamically rather than gathering data first
  * Improved section and evidence formatting for more flexible investigation workflows
  * Better connection between investigation results and hypotheses during debugging sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->