### PR TITLE
P3: RemediationPlan schema + types + repos

### DIFF
--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -763,3 +763,51 @@ CREATE TABLE IF NOT EXISTS ops_connectors (
 CREATE UNIQUE INDEX IF NOT EXISTS ux_ops_connectors_org_name ON ops_connectors(org_id, name);
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_id   ON ops_connectors(org_id);
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_type ON ops_connectors(org_id, type);
+
+-- ============================================================================
+-- Remediation plans (Phase 3 of docs/design/auto-remediation.md)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS remediation_plan (
+  id                  TEXT PRIMARY KEY,
+  org_id              TEXT NOT NULL,
+  investigation_id    TEXT NOT NULL,
+  rescue_for_plan_id  TEXT,
+  summary             TEXT NOT NULL,
+  status              TEXT NOT NULL DEFAULT 'pending_approval',
+  auto_edit           INTEGER NOT NULL DEFAULT 0,
+  approval_request_id TEXT,
+  created_by          TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  expires_at          TEXT NOT NULL,
+  resolved_at         TEXT,
+  resolved_by         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_org_status
+  ON remediation_plan(org_id, status);
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_investigation
+  ON remediation_plan(investigation_id);
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_rescue_for
+  ON remediation_plan(rescue_for_plan_id);
+
+CREATE TABLE IF NOT EXISTS remediation_plan_step (
+  id                  TEXT PRIMARY KEY,
+  plan_id             TEXT NOT NULL,
+  ordinal             INTEGER NOT NULL,
+  kind                TEXT NOT NULL,
+  command_text        TEXT NOT NULL,
+  params_json         TEXT NOT NULL DEFAULT '{}',
+  dry_run_text        TEXT,
+  risk_note           TEXT,
+  continue_on_error   INTEGER NOT NULL DEFAULT 0,
+  status              TEXT NOT NULL DEFAULT 'pending',
+  approval_request_id TEXT,
+  executed_at         TEXT,
+  output_text         TEXT,
+  error_text          TEXT,
+  UNIQUE(plan_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_step_plan
+  ON remediation_plan_step(plan_id);

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -69,6 +69,9 @@ import { PostgresInstanceConfigRepository } from './postgres/instance-config.js'
 import { PostgresDatasourceRepository } from './postgres/datasource.js';
 import { PostgresNotificationChannelRepository } from './postgres/notification-channel.js';
 import { PostgresOpsConnectorRepository } from './postgres/ops-connector.js';
+import { SqliteRemediationPlanRepository } from './sqlite/remediation-plan.js';
+import { PostgresRemediationPlanRepository } from './postgres/remediation-plan.js';
+import type { IRemediationPlanRepository } from './types/remediation-plan.js';
 
 /**
  * Extended repositories available with the SQLite backend.
@@ -100,6 +103,7 @@ export interface SqliteRepositories {
   datasources: IDatasourceRepository;
   notificationChannels: INotificationChannelRepository;
   opsConnectors: IOpsConnectorRepository;
+  remediationPlans: IRemediationPlanRepository;
 }
 
 export function createSqliteRepositories(db: SqliteClient): SqliteRepositories {
@@ -123,6 +127,7 @@ export function createSqliteRepositories(db: SqliteClient): SqliteRepositories {
     datasources: new DatasourceRepository(db),
     notificationChannels: new NotificationChannelRepository(db),
     opsConnectors: new OpsConnectorRepository(db),
+    remediationPlans: new SqliteRemediationPlanRepository(db),
   };
 }
 
@@ -147,5 +152,6 @@ export function createPostgresRepositories(db: DbClient): SqliteRepositories {
     datasources: new PostgresDatasourceRepository(db),
     notificationChannels: new PostgresNotificationChannelRepository(db),
     opsConnectors: new PostgresOpsConnectorRepository(db),
+    remediationPlans: new PostgresRemediationPlanRepository(db),
   };
 }

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -52,6 +52,20 @@ export type {
   OpsConnectorType,
 } from './types/ops-connector.js';
 
+export type {
+  IRemediationPlanRepository,
+  ListRemediationPlansOptions,
+  NewRemediationPlan,
+  NewRemediationPlanStep,
+  RemediationPlan,
+  RemediationPlanPatch,
+  RemediationPlanStatus,
+  RemediationPlanStep,
+  RemediationPlanStepKind,
+  RemediationPlanStepPatch,
+  RemediationPlanStepStatus,
+} from './types/remediation-plan.js';
+
 export * from './postgres/index.js';
 export * from './sqlite/index.js';
 export * from './event-wrappers/index.js';

--- a/packages/data-layer/src/repository/postgres/index.ts
+++ b/packages/data-layer/src/repository/postgres/index.ts
@@ -21,3 +21,5 @@ export { PostgresDatasourceRepository } from './datasource.js';
 export { PostgresNotificationChannelRepository } from './notification-channel.js';
 export { PostgresOpsConnectorRepository } from './ops-connector.js';
 export { applyPostgresSchema } from './schema-applier.js';
+
+export { PostgresRemediationPlanRepository } from './remediation-plan.js';

--- a/packages/data-layer/src/repository/postgres/remediation-plan.ts
+++ b/packages/data-layer/src/repository/postgres/remediation-plan.ts
@@ -1,0 +1,337 @@
+/**
+ * Postgres implementation of `IRemediationPlanRepository`. Mirrors the
+ * SQLite implementation row-for-row; the only differences are the boolean
+ * encoding (`true/false` vs. `1/0`) and the use of `pgAll`/`pgRun` /
+ * `withTransaction` on the Postgres `DbClient`.
+ *
+ * Phase 3 of `docs/design/auto-remediation.md`.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import type { DbClient } from '../../db/client.js';
+import { pgAll, pgRun } from './pg-helpers.js';
+import type {
+  IRemediationPlanRepository,
+  ListRemediationPlansOptions,
+  NewRemediationPlan,
+  NewRemediationPlanStep,
+  RemediationPlan,
+  RemediationPlanPatch,
+  RemediationPlanStep,
+  RemediationPlanStepPatch,
+  RemediationPlanStepStatus,
+  RemediationPlanStatus,
+} from '../types/remediation-plan.js';
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface PlanRow {
+  id: string;
+  org_id: string;
+  investigation_id: string;
+  rescue_for_plan_id: string | null;
+  summary: string;
+  status: string;
+  auto_edit: boolean;
+  approval_request_id: string | null;
+  created_by: string;
+  created_at: string;
+  expires_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+}
+
+interface StepRow {
+  id: string;
+  plan_id: string;
+  ordinal: number;
+  kind: string;
+  command_text: string;
+  params_json: string | Record<string, unknown>;
+  dry_run_text: string | null;
+  risk_note: string | null;
+  continue_on_error: boolean;
+  status: string;
+  approval_request_id: string | null;
+  executed_at: string | null;
+  output_text: string | null;
+  error_text: string | null;
+}
+
+function parseParams(raw: string | Record<string, unknown> | null | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  // node-postgres returns json/jsonb as parsed objects, but the column is TEXT
+  // here so we always get a string. Be tolerant of either.
+  if (typeof raw === 'object') return raw;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    throw new Error(`[RemediationPlanRepository] params_json parse failed: ${raw.slice(0, 64)}`);
+  }
+}
+
+function rowToStep(row: StepRow): RemediationPlanStep {
+  return {
+    id: row.id,
+    planId: row.plan_id,
+    ordinal: row.ordinal,
+    kind: row.kind,
+    commandText: row.command_text,
+    paramsJson: parseParams(row.params_json),
+    dryRunText: row.dry_run_text,
+    riskNote: row.risk_note,
+    continueOnError: Boolean(row.continue_on_error),
+    status: row.status as RemediationPlanStepStatus,
+    approvalRequestId: row.approval_request_id,
+    executedAt: row.executed_at,
+    outputText: row.output_text,
+    errorText: row.error_text,
+  };
+}
+
+function rowToPlan(row: PlanRow, steps: RemediationPlanStep[]): RemediationPlan {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    investigationId: row.investigation_id,
+    rescueForPlanId: row.rescue_for_plan_id,
+    summary: row.summary,
+    status: row.status as RemediationPlanStatus,
+    autoEdit: Boolean(row.auto_edit),
+    approvalRequestId: row.approval_request_id,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    resolvedAt: row.resolved_at,
+    resolvedBy: row.resolved_by,
+    steps,
+  };
+}
+
+export class PostgresRemediationPlanRepository implements IRemediationPlanRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async create(input: NewRemediationPlan): Promise<RemediationPlan> {
+    const id = input.id ?? `plan-${randomUUID()}`;
+    const now = new Date().toISOString();
+    const expiresAt =
+      input.expiresAt ?? new Date(Date.now() + DEFAULT_TTL_MS).toISOString();
+    const status = input.status ?? 'pending_approval';
+
+    return this.db.withTransaction(async (tx) => {
+      await tx.run(sql`
+        INSERT INTO remediation_plan (
+          id, org_id, investigation_id, rescue_for_plan_id, summary, status,
+          auto_edit, approval_request_id, created_by, created_at, expires_at,
+          resolved_at, resolved_by
+        ) VALUES (
+          ${id},
+          ${input.orgId},
+          ${input.investigationId},
+          ${input.rescueForPlanId ?? null},
+          ${input.summary},
+          ${status},
+          ${input.autoEdit ?? false},
+          ${input.approvalRequestId ?? null},
+          ${input.createdBy},
+          ${now},
+          ${expiresAt},
+          ${null},
+          ${null}
+        )
+      `);
+
+      for (let i = 0; i < input.steps.length; i++) {
+        const step = input.steps[i] as NewRemediationPlanStep;
+        const stepId = `step-${randomUUID()}`;
+        await tx.run(sql`
+          INSERT INTO remediation_plan_step (
+            id, plan_id, ordinal, kind, command_text, params_json,
+            dry_run_text, risk_note, continue_on_error, status,
+            approval_request_id, executed_at, output_text, error_text
+          ) VALUES (
+            ${stepId},
+            ${id},
+            ${i},
+            ${step.kind},
+            ${step.commandText},
+            ${JSON.stringify(step.paramsJson ?? {})},
+            ${step.dryRunText ?? null},
+            ${step.riskNote ?? null},
+            ${step.continueOnError ?? false},
+            ${'pending'},
+            ${null},
+            ${null},
+            ${null},
+            ${null}
+          )
+        `);
+      }
+
+      const planRows = await tx.all<PlanRow>(
+        sql`SELECT * FROM remediation_plan WHERE id = ${id}`,
+      );
+      const stepRows = await tx.all<StepRow>(
+        sql`SELECT * FROM remediation_plan_step WHERE plan_id = ${id} ORDER BY ordinal`,
+      );
+      const planRow = planRows[0];
+      if (!planRow) {
+        throw new Error(`[RemediationPlanRepository] create: row ${id} not found after insert`);
+      }
+      return rowToPlan(planRow, stepRows.map(rowToStep));
+    });
+  }
+
+  async findByIdInOrg(orgId: string, id: string): Promise<RemediationPlan | null> {
+    const rows = await pgAll<PlanRow>(this.db, sql`
+      SELECT * FROM remediation_plan WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    const row = rows[0];
+    if (!row) return null;
+    const stepRows = await pgAll<StepRow>(this.db, sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${id} ORDER BY ordinal
+    `);
+    return rowToPlan(row, stepRows.map(rowToStep));
+  }
+
+  async listByOrg(
+    orgId: string,
+    opts: ListRemediationPlansOptions = {},
+  ): Promise<RemediationPlan[]> {
+    const wheres: SQL[] = [sql`org_id = ${orgId}`];
+    if (opts.status) {
+      const statuses = Array.isArray(opts.status) ? opts.status : [opts.status];
+      if (statuses.length > 0) {
+        const list = sql.join(statuses.map((s) => sql`${s}`), sql`, `);
+        wheres.push(sql`status IN (${list})`);
+      }
+    }
+    if (opts.investigationId) {
+      wheres.push(sql`investigation_id = ${opts.investigationId}`);
+    }
+    if (opts.rescueForPlanId === null) {
+      wheres.push(sql`rescue_for_plan_id IS NULL`);
+    } else if (typeof opts.rescueForPlanId === 'string') {
+      wheres.push(sql`rescue_for_plan_id = ${opts.rescueForPlanId}`);
+    }
+    const whereClause = sql.join([sql`WHERE`, sql.join(wheres, sql` AND `)], sql` `);
+    const limit = opts.limit ?? 100;
+    const offset = opts.offset ?? 0;
+
+    const planRows = await pgAll<PlanRow>(this.db, sql`
+      SELECT * FROM remediation_plan
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+    if (planRows.length === 0) return [];
+
+    const planIds = planRows.map((p) => p.id);
+    const idList = sql.join(planIds.map((p) => sql`${p}`), sql`, `);
+    const stepRows = await pgAll<StepRow>(this.db, sql`
+      SELECT * FROM remediation_plan_step
+      WHERE plan_id IN (${idList})
+      ORDER BY plan_id, ordinal
+    `);
+    const stepsByPlan = new Map<string, RemediationPlanStep[]>();
+    for (const sr of stepRows) {
+      const arr = stepsByPlan.get(sr.plan_id) ?? [];
+      arr.push(rowToStep(sr));
+      stepsByPlan.set(sr.plan_id, arr);
+    }
+    return planRows.map((pr) => rowToPlan(pr, stepsByPlan.get(pr.id) ?? []));
+  }
+
+  async updatePlan(
+    orgId: string,
+    id: string,
+    patch: RemediationPlanPatch,
+  ): Promise<RemediationPlan | null> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return null;
+
+    const next = {
+      status: patch.status ?? existing.status,
+      autoEdit: patch.autoEdit !== undefined ? patch.autoEdit : existing.autoEdit,
+      approvalRequestId:
+        patch.approvalRequestId !== undefined ? patch.approvalRequestId : existing.approvalRequestId,
+      resolvedAt: patch.resolvedAt !== undefined ? patch.resolvedAt : existing.resolvedAt,
+      resolvedBy: patch.resolvedBy !== undefined ? patch.resolvedBy : existing.resolvedBy,
+    };
+
+    await pgRun(this.db, sql`
+      UPDATE remediation_plan
+      SET status = ${next.status},
+          auto_edit = ${next.autoEdit},
+          approval_request_id = ${next.approvalRequestId},
+          resolved_at = ${next.resolvedAt},
+          resolved_by = ${next.resolvedBy}
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    return this.findByIdInOrg(orgId, id);
+  }
+
+  async updateStep(
+    planId: string,
+    ordinal: number,
+    patch: RemediationPlanStepPatch,
+  ): Promise<RemediationPlanStep | null> {
+    const rows = await pgAll<StepRow>(this.db, sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `);
+    const existing = rows[0];
+    if (!existing) return null;
+
+    const next = {
+      status: patch.status ?? (existing.status as RemediationPlanStepStatus),
+      approvalRequestId:
+        patch.approvalRequestId !== undefined ? patch.approvalRequestId : existing.approval_request_id,
+      executedAt: patch.executedAt !== undefined ? patch.executedAt : existing.executed_at,
+      outputText: patch.outputText !== undefined ? patch.outputText : existing.output_text,
+      errorText: patch.errorText !== undefined ? patch.errorText : existing.error_text,
+    };
+
+    await pgRun(this.db, sql`
+      UPDATE remediation_plan_step
+      SET status = ${next.status},
+          approval_request_id = ${next.approvalRequestId},
+          executed_at = ${next.executedAt},
+          output_text = ${next.outputText},
+          error_text = ${next.errorText}
+      WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `);
+
+    const after = await pgAll<StepRow>(this.db, sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `);
+    return after[0] ? rowToStep(after[0]) : null;
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return false;
+    return this.db.withTransaction(async (tx) => {
+      await tx.run(sql`DELETE FROM remediation_plan_step WHERE plan_id = ${id}`);
+      await tx.run(sql`DELETE FROM remediation_plan WHERE org_id = ${orgId} AND id = ${id}`);
+      return true;
+    });
+  }
+
+  async expireStale(now: string): Promise<number> {
+    const stale = await pgAll<{ id: string }>(this.db, sql`
+      SELECT id FROM remediation_plan
+      WHERE status = 'pending_approval' AND expires_at <= ${now}
+    `);
+    if (stale.length === 0) return 0;
+    await pgRun(this.db, sql`
+      UPDATE remediation_plan
+      SET status = 'expired'
+      WHERE status = 'pending_approval' AND expires_at <= ${now}
+    `);
+    return stale.length;
+  }
+}

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -756,3 +756,51 @@ CREATE TABLE IF NOT EXISTS ops_connectors (
 CREATE UNIQUE INDEX IF NOT EXISTS ux_ops_connectors_org_name ON ops_connectors(org_id, name);
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_id   ON ops_connectors(org_id);
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_type ON ops_connectors(org_id, type);
+
+-- ============================================================================
+-- Remediation plans (Phase 3 of docs/design/auto-remediation.md)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS remediation_plan (
+  id                  TEXT PRIMARY KEY,
+  org_id              TEXT NOT NULL,
+  investigation_id    TEXT NOT NULL,
+  rescue_for_plan_id  TEXT,
+  summary             TEXT NOT NULL,
+  status              TEXT NOT NULL DEFAULT 'pending_approval',
+  auto_edit           BOOLEAN NOT NULL DEFAULT FALSE,
+  approval_request_id TEXT,
+  created_by          TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  expires_at          TEXT NOT NULL,
+  resolved_at         TEXT,
+  resolved_by         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_org_status
+  ON remediation_plan(org_id, status);
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_investigation
+  ON remediation_plan(investigation_id);
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_rescue_for
+  ON remediation_plan(rescue_for_plan_id);
+
+CREATE TABLE IF NOT EXISTS remediation_plan_step (
+  id                  TEXT PRIMARY KEY,
+  plan_id             TEXT NOT NULL,
+  ordinal             INTEGER NOT NULL,
+  kind                TEXT NOT NULL,
+  command_text        TEXT NOT NULL,
+  params_json         TEXT NOT NULL DEFAULT '{}',
+  dry_run_text        TEXT,
+  risk_note           TEXT,
+  continue_on_error   BOOLEAN NOT NULL DEFAULT FALSE,
+  status              TEXT NOT NULL DEFAULT 'pending',
+  approval_request_id TEXT,
+  executed_at         TEXT,
+  output_text         TEXT,
+  error_text          TEXT,
+  UNIQUE(plan_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS ix_remediation_plan_step_plan
+  ON remediation_plan_step(plan_id);

--- a/packages/data-layer/src/repository/sqlite/index.ts
+++ b/packages/data-layer/src/repository/sqlite/index.ts
@@ -22,3 +22,5 @@ export { InstanceConfigRepository } from './instance-config.js';
 export { DatasourceRepository } from './datasource.js';
 export { NotificationChannelRepository } from './notification-channel.js';
 export { OpsConnectorRepository } from './ops-connector.js';
+
+export { SqliteRemediationPlanRepository } from './remediation-plan.js';

--- a/packages/data-layer/src/repository/sqlite/remediation-plan.test.ts
+++ b/packages/data-layer/src/repository/sqlite/remediation-plan.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from '../../test-support/test-db.js';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { SqliteRemediationPlanRepository } from './remediation-plan.js';
+import type { NewRemediationPlan } from '../types/remediation-plan.js';
+
+function basePlan(overrides: Partial<NewRemediationPlan> = {}): NewRemediationPlan {
+  return {
+    orgId: 'org_main',
+    investigationId: 'inv-1',
+    summary: 'Scale web up',
+    createdBy: 'agent',
+    steps: [
+      {
+        kind: 'ops.run_command',
+        commandText: 'kubectl scale deploy web -n app --replicas=3',
+        paramsJson: { verb: 'scale', namespace: 'app' },
+        riskNote: 'mid risk',
+      },
+      {
+        kind: 'ops.run_command',
+        commandText: 'kubectl rollout status deploy/web -n app',
+        paramsJson: { verb: 'rollout', namespace: 'app' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('SqliteRemediationPlanRepository', () => {
+  let db: SqliteClient;
+  let repo: SqliteRemediationPlanRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new SqliteRemediationPlanRepository(db);
+  });
+
+  it('creates a plan with steps and assigns ordinals + defaults', async () => {
+    const plan = await repo.create(basePlan());
+    expect(plan.id).toMatch(/^plan-/);
+    expect(plan.status).toBe('pending_approval');
+    expect(plan.autoEdit).toBe(false);
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0]?.ordinal).toBe(0);
+    expect(plan.steps[1]?.ordinal).toBe(1);
+    expect(plan.steps[0]?.status).toBe('pending');
+    expect(plan.steps[0]?.continueOnError).toBe(false);
+    expect(plan.steps[0]?.paramsJson).toEqual({ verb: 'scale', namespace: 'app' });
+    expect(plan.steps[0]?.riskNote).toBe('mid risk');
+    expect(plan.expiresAt > plan.createdAt).toBe(true);
+  });
+
+  it('respects supplied id, expiresAt, autoEdit, and rescueForPlanId', async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const plan = await repo.create(
+      basePlan({
+        id: 'plan-explicit',
+        expiresAt,
+        autoEdit: true,
+        rescueForPlanId: 'plan-other',
+      }),
+    );
+    expect(plan.id).toBe('plan-explicit');
+    expect(plan.expiresAt).toBe(expiresAt);
+    expect(plan.autoEdit).toBe(true);
+    expect(plan.rescueForPlanId).toBe('plan-other');
+  });
+
+  it('findByIdInOrg returns null cross-org and null for missing ids', async () => {
+    const plan = await repo.create(basePlan({ orgId: 'org_a' }));
+    expect(await repo.findByIdInOrg('org_a', plan.id)).not.toBeNull();
+    expect(await repo.findByIdInOrg('org_b', plan.id)).toBeNull();
+    expect(await repo.findByIdInOrg('org_a', 'plan-missing')).toBeNull();
+  });
+
+  it('listByOrg filters by status, investigationId, rescueForPlanId', async () => {
+    const a = await repo.create(basePlan({ summary: 'a', investigationId: 'inv-1' }));
+    const b = await repo.create(basePlan({ summary: 'b', investigationId: 'inv-2' }));
+    await repo.updatePlan('org_main', b.id, { status: 'approved' });
+    const c = await repo.create(
+      basePlan({ summary: 'c-rescue', investigationId: 'inv-1', rescueForPlanId: a.id }),
+    );
+
+    const pending = await repo.listByOrg('org_main', { status: 'pending_approval' });
+    expect(pending.map((p) => p.id).sort()).toEqual([a.id, c.id].sort());
+
+    const byInv2 = await repo.listByOrg('org_main', { investigationId: 'inv-2' });
+    expect(byInv2.map((p) => p.id)).toEqual([b.id]);
+
+    const onlyRescues = await repo.listByOrg('org_main', { rescueForPlanId: a.id });
+    expect(onlyRescues.map((p) => p.id)).toEqual([c.id]);
+
+    const nonRescues = await repo.listByOrg('org_main', { rescueForPlanId: null });
+    expect(nonRescues.map((p) => p.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('updatePlan changes status + autoEdit + resolved fields', async () => {
+    const plan = await repo.create(basePlan());
+    const after = await repo.updatePlan('org_main', plan.id, {
+      status: 'approved',
+      autoEdit: true,
+      resolvedAt: '2026-04-29T00:00:00.000Z',
+      resolvedBy: 'user-1',
+    });
+    expect(after?.status).toBe('approved');
+    expect(after?.autoEdit).toBe(true);
+    expect(after?.resolvedAt).toBe('2026-04-29T00:00:00.000Z');
+    expect(after?.resolvedBy).toBe('user-1');
+  });
+
+  it('updatePlan cross-org returns null and writes nothing', async () => {
+    const plan = await repo.create(basePlan({ orgId: 'org_a' }));
+    const result = await repo.updatePlan('org_b', plan.id, { status: 'approved' });
+    expect(result).toBeNull();
+    const reread = await repo.findByIdInOrg('org_a', plan.id);
+    expect(reread?.status).toBe('pending_approval');
+  });
+
+  it('updateStep updates only the targeted step', async () => {
+    const plan = await repo.create(basePlan());
+    const updated = await repo.updateStep(plan.id, 1, {
+      status: 'done',
+      executedAt: '2026-04-29T00:01:00.000Z',
+      outputText: 'rollout complete',
+    });
+    expect(updated?.status).toBe('done');
+    expect(updated?.executedAt).toBe('2026-04-29T00:01:00.000Z');
+
+    const reread = await repo.findByIdInOrg('org_main', plan.id);
+    expect(reread?.steps[0]?.status).toBe('pending');
+    expect(reread?.steps[1]?.status).toBe('done');
+    expect(reread?.steps[1]?.outputText).toBe('rollout complete');
+  });
+
+  it('updateStep returns null for unknown step ordinals', async () => {
+    const plan = await repo.create(basePlan());
+    const result = await repo.updateStep(plan.id, 99, { status: 'done' });
+    expect(result).toBeNull();
+  });
+
+  it('delete removes plan and steps; cross-org delete is a no-op', async () => {
+    const plan = await repo.create(basePlan({ orgId: 'org_a' }));
+    expect(await repo.delete('org_b', plan.id)).toBe(false);
+    expect(await repo.findByIdInOrg('org_a', plan.id)).not.toBeNull();
+    expect(await repo.delete('org_a', plan.id)).toBe(true);
+    expect(await repo.findByIdInOrg('org_a', plan.id)).toBeNull();
+  });
+
+  it('expireStale flips only pending_approval rows past expires_at', async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const stale = await repo.create(basePlan({ summary: 'stale', expiresAt: past }));
+    const fresh = await repo.create(basePlan({ summary: 'fresh', expiresAt: future }));
+    const approved = await repo.create(basePlan({ summary: 'approved', expiresAt: past }));
+    await repo.updatePlan('org_main', approved.id, { status: 'approved' });
+
+    const now = new Date().toISOString();
+    expect(await repo.expireStale(now)).toBe(1);
+
+    expect((await repo.findByIdInOrg('org_main', stale.id))?.status).toBe('expired');
+    expect((await repo.findByIdInOrg('org_main', fresh.id))?.status).toBe('pending_approval');
+    expect((await repo.findByIdInOrg('org_main', approved.id))?.status).toBe('approved');
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/remediation-plan.ts
+++ b/packages/data-layer/src/repository/sqlite/remediation-plan.ts
@@ -1,0 +1,335 @@
+/**
+ * SQLite implementation of `IRemediationPlanRepository`.
+ *
+ * Phase 3 of `docs/design/auto-remediation.md`. JSON columns are stored as
+ * TEXT and parsed in code (matches the surrounding sqlite-repo pattern;
+ * keeps the schema dialect-portable).
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { nowIso, uid } from './instance-shared.js';
+import type {
+  IRemediationPlanRepository,
+  ListRemediationPlansOptions,
+  NewRemediationPlan,
+  NewRemediationPlanStep,
+  RemediationPlan,
+  RemediationPlanPatch,
+  RemediationPlanStep,
+  RemediationPlanStepPatch,
+  RemediationPlanStepStatus,
+  RemediationPlanStatus,
+} from '../types/remediation-plan.js';
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface PlanRow {
+  id: string;
+  org_id: string;
+  investigation_id: string;
+  rescue_for_plan_id: string | null;
+  summary: string;
+  status: string;
+  auto_edit: number;
+  approval_request_id: string | null;
+  created_by: string;
+  created_at: string;
+  expires_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+}
+
+interface StepRow {
+  id: string;
+  plan_id: string;
+  ordinal: number;
+  kind: string;
+  command_text: string;
+  params_json: string;
+  dry_run_text: string | null;
+  risk_note: string | null;
+  continue_on_error: number;
+  status: string;
+  approval_request_id: string | null;
+  executed_at: string | null;
+  output_text: string | null;
+  error_text: string | null;
+}
+
+function parseParams(raw: string): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    // Persisted JSON should always parse; corruption is operator-visible.
+    throw new Error(`[RemediationPlanRepository] params_json parse failed: ${raw.slice(0, 64)}`);
+  }
+}
+
+function rowToStep(row: StepRow): RemediationPlanStep {
+  return {
+    id: row.id,
+    planId: row.plan_id,
+    ordinal: row.ordinal,
+    kind: row.kind,
+    commandText: row.command_text,
+    paramsJson: parseParams(row.params_json),
+    dryRunText: row.dry_run_text,
+    riskNote: row.risk_note,
+    continueOnError: row.continue_on_error === 1,
+    status: row.status as RemediationPlanStepStatus,
+    approvalRequestId: row.approval_request_id,
+    executedAt: row.executed_at,
+    outputText: row.output_text,
+    errorText: row.error_text,
+  };
+}
+
+function rowToPlan(row: PlanRow, steps: RemediationPlanStep[]): RemediationPlan {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    investigationId: row.investigation_id,
+    rescueForPlanId: row.rescue_for_plan_id,
+    summary: row.summary,
+    status: row.status as RemediationPlanStatus,
+    autoEdit: row.auto_edit === 1,
+    approvalRequestId: row.approval_request_id,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    resolvedAt: row.resolved_at,
+    resolvedBy: row.resolved_by,
+    steps,
+  };
+}
+
+export class SqliteRemediationPlanRepository implements IRemediationPlanRepository {
+  constructor(private readonly db: SqliteClient) {}
+
+  async create(input: NewRemediationPlan): Promise<RemediationPlan> {
+    const id = input.id ?? `plan-${uid()}`;
+    const now = nowIso();
+    const expiresAt =
+      input.expiresAt ?? new Date(Date.now() + DEFAULT_TTL_MS).toISOString();
+    const status = input.status ?? 'pending_approval';
+    const autoEdit = input.autoEdit ? 1 : 0;
+
+    // Atomic plan + steps insert via the QueryClient transaction primitive.
+    return this.db.withTransaction(async (tx) => {
+      await tx.run(sql`
+        INSERT INTO remediation_plan (
+          id, org_id, investigation_id, rescue_for_plan_id, summary, status,
+          auto_edit, approval_request_id, created_by, created_at, expires_at,
+          resolved_at, resolved_by
+        ) VALUES (
+          ${id},
+          ${input.orgId},
+          ${input.investigationId},
+          ${input.rescueForPlanId ?? null},
+          ${input.summary},
+          ${status},
+          ${autoEdit},
+          ${input.approvalRequestId ?? null},
+          ${input.createdBy},
+          ${now},
+          ${expiresAt},
+          ${null},
+          ${null}
+        )
+      `);
+
+      for (let i = 0; i < input.steps.length; i++) {
+        const step = input.steps[i] as NewRemediationPlanStep;
+        const stepId = `step-${uid()}`;
+        await tx.run(sql`
+          INSERT INTO remediation_plan_step (
+            id, plan_id, ordinal, kind, command_text, params_json,
+            dry_run_text, risk_note, continue_on_error, status,
+            approval_request_id, executed_at, output_text, error_text
+          ) VALUES (
+            ${stepId},
+            ${id},
+            ${i},
+            ${step.kind},
+            ${step.commandText},
+            ${JSON.stringify(step.paramsJson ?? {})},
+            ${step.dryRunText ?? null},
+            ${step.riskNote ?? null},
+            ${step.continueOnError ? 1 : 0},
+            ${'pending'},
+            ${null},
+            ${null},
+            ${null},
+            ${null}
+          )
+        `);
+      }
+
+      const planRows = await tx.all<PlanRow>(
+        sql`SELECT * FROM remediation_plan WHERE id = ${id}`,
+      );
+      const stepRows = await tx.all<StepRow>(
+        sql`SELECT * FROM remediation_plan_step WHERE plan_id = ${id} ORDER BY ordinal`,
+      );
+      const planRow = planRows[0];
+      if (!planRow) {
+        throw new Error(`[RemediationPlanRepository] create: row ${id} not found after insert`);
+      }
+      return rowToPlan(planRow, stepRows.map(rowToStep));
+    });
+  }
+
+  async findByIdInOrg(orgId: string, id: string): Promise<RemediationPlan | null> {
+    const rows = this.db.all<PlanRow>(sql`
+      SELECT * FROM remediation_plan WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    const row = rows[0];
+    if (!row) return null;
+    const stepRows = this.db.all<StepRow>(sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${id} ORDER BY ordinal
+    `);
+    return rowToPlan(row, stepRows.map(rowToStep));
+  }
+
+  async listByOrg(
+    orgId: string,
+    opts: ListRemediationPlansOptions = {},
+  ): Promise<RemediationPlan[]> {
+    const wheres: SQL[] = [sql`org_id = ${orgId}`];
+    if (opts.status) {
+      const statuses = Array.isArray(opts.status) ? opts.status : [opts.status];
+      if (statuses.length > 0) {
+        const list = sql.join(statuses.map((s) => sql`${s}`), sql`, `);
+        wheres.push(sql`status IN (${list})`);
+      }
+    }
+    if (opts.investigationId) {
+      wheres.push(sql`investigation_id = ${opts.investigationId}`);
+    }
+    if (opts.rescueForPlanId === null) {
+      wheres.push(sql`rescue_for_plan_id IS NULL`);
+    } else if (typeof opts.rescueForPlanId === 'string') {
+      wheres.push(sql`rescue_for_plan_id = ${opts.rescueForPlanId}`);
+    }
+    const whereClause = sql.join([sql`WHERE`, sql.join(wheres, sql` AND `)], sql` `);
+    const limit = opts.limit ?? 100;
+    const offset = opts.offset ?? 0;
+
+    const planRows = this.db.all<PlanRow>(sql`
+      SELECT * FROM remediation_plan
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+    if (planRows.length === 0) return [];
+
+    // Fetch all matching steps in one query, then group.
+    const planIds = planRows.map((p) => p.id);
+    const idList = sql.join(planIds.map((p) => sql`${p}`), sql`, `);
+    const stepRows = this.db.all<StepRow>(sql`
+      SELECT * FROM remediation_plan_step
+      WHERE plan_id IN (${idList})
+      ORDER BY plan_id, ordinal
+    `);
+    const stepsByPlan = new Map<string, RemediationPlanStep[]>();
+    for (const sr of stepRows) {
+      const arr = stepsByPlan.get(sr.plan_id) ?? [];
+      arr.push(rowToStep(sr));
+      stepsByPlan.set(sr.plan_id, arr);
+    }
+    return planRows.map((pr) => rowToPlan(pr, stepsByPlan.get(pr.id) ?? []));
+  }
+
+  async updatePlan(
+    orgId: string,
+    id: string,
+    patch: RemediationPlanPatch,
+  ): Promise<RemediationPlan | null> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return null;
+
+    const next = {
+      status: patch.status ?? existing.status,
+      autoEdit: patch.autoEdit !== undefined ? patch.autoEdit : existing.autoEdit,
+      approvalRequestId:
+        patch.approvalRequestId !== undefined ? patch.approvalRequestId : existing.approvalRequestId,
+      resolvedAt: patch.resolvedAt !== undefined ? patch.resolvedAt : existing.resolvedAt,
+      resolvedBy: patch.resolvedBy !== undefined ? patch.resolvedBy : existing.resolvedBy,
+    };
+
+    this.db.run(sql`
+      UPDATE remediation_plan
+      SET status = ${next.status},
+          auto_edit = ${next.autoEdit ? 1 : 0},
+          approval_request_id = ${next.approvalRequestId},
+          resolved_at = ${next.resolvedAt},
+          resolved_by = ${next.resolvedBy}
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    return this.findByIdInOrg(orgId, id);
+  }
+
+  async updateStep(
+    planId: string,
+    ordinal: number,
+    patch: RemediationPlanStepPatch,
+  ): Promise<RemediationPlanStep | null> {
+    const existing = this.db.all<StepRow>(sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `)[0];
+    if (!existing) return null;
+
+    const next = {
+      status: patch.status ?? (existing.status as RemediationPlanStepStatus),
+      approvalRequestId:
+        patch.approvalRequestId !== undefined ? patch.approvalRequestId : existing.approval_request_id,
+      executedAt: patch.executedAt !== undefined ? patch.executedAt : existing.executed_at,
+      outputText: patch.outputText !== undefined ? patch.outputText : existing.output_text,
+      errorText: patch.errorText !== undefined ? patch.errorText : existing.error_text,
+    };
+
+    this.db.run(sql`
+      UPDATE remediation_plan_step
+      SET status = ${next.status},
+          approval_request_id = ${next.approvalRequestId},
+          executed_at = ${next.executedAt},
+          output_text = ${next.outputText},
+          error_text = ${next.errorText}
+      WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `);
+
+    const after = this.db.all<StepRow>(sql`
+      SELECT * FROM remediation_plan_step WHERE plan_id = ${planId} AND ordinal = ${ordinal}
+    `)[0];
+    return after ? rowToStep(after) : null;
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.findByIdInOrg(orgId, id);
+    if (!existing) return false;
+    return this.db.withTransaction(async (tx) => {
+      await tx.run(sql`DELETE FROM remediation_plan_step WHERE plan_id = ${id}`);
+      await tx.run(sql`DELETE FROM remediation_plan WHERE org_id = ${orgId} AND id = ${id}`);
+      return true;
+    });
+  }
+
+  async expireStale(now: string): Promise<number> {
+    const stale = this.db.all<{ id: string }>(sql`
+      SELECT id FROM remediation_plan
+      WHERE status = 'pending_approval' AND expires_at <= ${now}
+    `);
+    if (stale.length === 0) return 0;
+    this.db.run(sql`
+      UPDATE remediation_plan
+      SET status = 'expired'
+      WHERE status = 'pending_approval' AND expires_at <= ${now}
+    `);
+    return stale.length;
+  }
+}

--- a/packages/data-layer/src/repository/types/remediation-plan.ts
+++ b/packages/data-layer/src/repository/types/remediation-plan.ts
@@ -1,0 +1,163 @@
+/**
+ * RemediationPlan — persistent home for a structured fix proposed by the
+ * agent after an investigation. The unit of human approval. Steps are write
+ * actions executed in order; halt-on-failure by default.
+ *
+ * Phase 3 of `docs/design/auto-remediation.md`. Schema only — no agent tools,
+ * no executor, no API routes consume these types yet.
+ */
+
+export type RemediationPlanStatus =
+  | 'draft'
+  | 'pending_approval'
+  | 'approved'
+  | 'rejected'
+  | 'executing'
+  | 'completed'
+  | 'failed'
+  | 'expired'
+  | 'cancelled';
+
+export type RemediationPlanStepStatus =
+  | 'pending'
+  | 'approved'
+  | 'executing'
+  | 'done'
+  | 'failed'
+  | 'skipped';
+
+/**
+ * Step kinds. Today only `ops.run_command` (kubectl shell), but the column
+ * stores the discriminator so the union can grow without a migration.
+ */
+export type RemediationPlanStepKind = 'ops.run_command' | string;
+
+export interface RemediationPlanStep {
+  id: string;
+  planId: string;
+  ordinal: number;
+  kind: RemediationPlanStepKind;
+  /** Human-readable command, e.g. `kubectl scale deploy web -n app --replicas=3`. */
+  commandText: string;
+  /** Structured args for the executor; shape depends on `kind`. */
+  paramsJson: Record<string, unknown>;
+  /** Captured at plan-creation time via `ExecutionAdapter.dryRun`. */
+  dryRunText: string | null;
+  /** Free-form risk note from the agent. Surfaced in approval UI. */
+  riskNote: string | null;
+  /**
+   * If true and this step fails, the plan continues with the next step
+   * instead of halting. Default `false`.
+   */
+  continueOnError: boolean;
+  status: RemediationPlanStepStatus;
+  /** Approval request gating this step (per-step approval mode only). */
+  approvalRequestId: string | null;
+  executedAt: string | null;
+  /** Truncated to 64 KB by the executor. */
+  outputText: string | null;
+  /** Truncated to 64 KB by the executor. */
+  errorText: string | null;
+}
+
+export interface RemediationPlan {
+  id: string;
+  orgId: string;
+  investigationId: string;
+  /** Set on rescue plans; points at the primary plan they undo. NULL for primary plans. */
+  rescueForPlanId: string | null;
+  summary: string;
+  status: RemediationPlanStatus;
+  /**
+   * Set at approval time. When true the executor skips per-step approval and
+   * runs the whole plan. Scope is this plan only — does not carry across.
+   */
+  autoEdit: boolean;
+  /** Plan-level approval request (created on plan persistence). */
+  approvalRequestId: string | null;
+  /** `'agent'` for LLM-emitted plans; otherwise the userId. */
+  createdBy: string;
+  createdAt: string;
+  expiresAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  steps: RemediationPlanStep[];
+}
+
+export interface NewRemediationPlanStep {
+  kind: RemediationPlanStepKind;
+  commandText: string;
+  paramsJson: Record<string, unknown>;
+  dryRunText?: string | null;
+  riskNote?: string | null;
+  continueOnError?: boolean;
+}
+
+export interface NewRemediationPlan {
+  id?: string;
+  orgId: string;
+  investigationId: string;
+  rescueForPlanId?: string | null;
+  summary: string;
+  /** Defaults to `'pending_approval'`. */
+  status?: RemediationPlanStatus;
+  autoEdit?: boolean;
+  approvalRequestId?: string | null;
+  createdBy: string;
+  /** ISO timestamp; defaults to now + 24h or `PLAN_APPROVAL_TTL_MS`. */
+  expiresAt?: string;
+  steps: NewRemediationPlanStep[];
+}
+
+export interface RemediationPlanPatch {
+  status?: RemediationPlanStatus;
+  autoEdit?: boolean;
+  approvalRequestId?: string | null;
+  resolvedAt?: string | null;
+  resolvedBy?: string | null;
+}
+
+export interface RemediationPlanStepPatch {
+  status?: RemediationPlanStepStatus;
+  approvalRequestId?: string | null;
+  executedAt?: string | null;
+  outputText?: string | null;
+  errorText?: string | null;
+}
+
+export interface ListRemediationPlansOptions {
+  status?: RemediationPlanStatus | RemediationPlanStatus[];
+  investigationId?: string;
+  rescueForPlanId?: string | null;
+  limit?: number;
+  offset?: number;
+}
+
+export interface IRemediationPlanRepository {
+  /** Insert plan + steps atomically. Returns the persisted plan with steps populated. */
+  create(input: NewRemediationPlan): Promise<RemediationPlan>;
+
+  /** Lookup a plan + its steps. NULL if not found or not in the org. */
+  findByIdInOrg(orgId: string, id: string): Promise<RemediationPlan | null>;
+
+  listByOrg(orgId: string, opts?: ListRemediationPlansOptions): Promise<RemediationPlan[]>;
+
+  /** Update plan-level fields. Steps are not touched. */
+  updatePlan(orgId: string, id: string, patch: RemediationPlanPatch): Promise<RemediationPlan | null>;
+
+  /** Update one step by (planId, ordinal). */
+  updateStep(
+    planId: string,
+    ordinal: number,
+    patch: RemediationPlanStepPatch,
+  ): Promise<RemediationPlanStep | null>;
+
+  /** Delete a plan + its steps. Returns true iff a row was deleted. */
+  delete(orgId: string, id: string): Promise<boolean>;
+
+  /**
+   * Mark all `pending_approval` plans whose `expires_at` has passed as
+   * `expired`. Returns the number of plans transitioned. Idempotent.
+   */
+  expireStale(now: string): Promise<number>;
+}


### PR DESCRIPTION
## What

Foundation drop for Phase 3 of the auto-remediation feature: persistent home
for the plans + steps the agent will emit (Phase 4) and the executor will run
(Phase 5).

Schema only — no agent tools, no executor, no API routes consume these types
yet. Safe to merge ahead of the rest.

Closes openobs/openobs#46 (T3.1), #47 (T3.2), #48 (T3.3), #49 (T3.4), #50 (T3.5),
#51 (T3.6), #52 (T3.7). Tracks under epic #94. Phase 3 of [auto-remediation
design](https://github.com/openobs/openobs/blob/design/auto-remediation/docs/design/auto-remediation.md).

## Schema

Two tables, mirrored across SQLite and Postgres dialects:

`remediation_plan` — id, org_id, investigation_id, rescue_for_plan_id, summary,
status, auto_edit, approval_request_id, created_by, created_at, expires_at,
resolved_at, resolved_by.

`remediation_plan_step` — id, plan_id, ordinal, kind, command_text, params_json,
dry_run_text, risk_note, continue_on_error, status, approval_request_id,
executed_at, output_text, error_text. `UNIQUE(plan_id, ordinal)`.

Indexes: `(org_id, status)` and `investigation_id` and `rescue_for_plan_id` on
the plan table; `plan_id` on the step table.

## Repo surface (`IRemediationPlanRepository`)

| Method | Purpose |
|---|---|
| `create(input)` | Atomic plan + steps insert; returns the persisted plan with steps populated. |
| `findByIdInOrg(orgId, id)` | Org-scoped lookup; null on miss or cross-org. |
| `listByOrg(orgId, opts)` | Filter by `status` (single or array), `investigationId`, `rescueForPlanId` (use `null` for "primary plans only"). |
| `updatePlan(orgId, id, patch)` | Plan-level fields only; cross-org returns null and writes nothing. |
| `updateStep(planId, ordinal, patch)` | One step at a time. |
| `delete(orgId, id)` | Plan + steps; org-scoped. |
| `expireStale(now)` | Flip `pending_approval` rows past `expires_at` to `expired`. Idempotent. Returns count. |

## Implementation notes

- Both backends use raw `sql` templates (matches the auth-repo pattern PR #28
  established for cross-dialect safety) and the `withTransaction` primitive
  also added in PR #28.
- JSON columns are TEXT, parsed in code. Postgres-side handles both string and
  pre-parsed object cases (some PG drivers parse json columns automatically).
- `expires_at` defaults to `now + 24h`; will become `PLAN_APPROVAL_TTL_MS`-driven
  when Phase 5 wires the executor sweeper.
- Step UNIQUE`(plan_id, ordinal)` makes ordinal-by-ordinal updates safe.

## Tests

- 10 new SQLite tests (`packages/data-layer/.../sqlite/remediation-plan.test.ts`):
  defaults, override paths, cross-org isolation on read/update/delete, listByOrg
  filter matrix, step-level update, expireStale selectivity.
- Full suite: 1357 passed, 16 skipped (was 1347 — the 10 new tests are the diff;
  Postgres skip set unchanged).
- Typecheck clean.
- Schema-applier test (which `applySchema`s the full `sqlite-schema.sql`) passes,
  i.e. the new DDL parses and runs.

## Intentionally NOT in this PR

- Drizzle `pgTable` / `sqliteTable` type objects in `schema.ts` /
  `sqlite-schema.ts`. Repos use raw `sql` templates, so these aren't required
  for runtime; consumers wanting `db.insert(table).values()` style can add
  them later.
- Any agent tool, route, or executor wiring — that's Phases 4 and 5.
- Postgres-side unit tests beyond the existing skip-when-no-PG pattern. The PG
  repo mirrors the SQLite repo row-for-row; behavioral parity is exercised when
  a CI runner with PG is available.

## Reverting

Single-commit foundation drop. Revert is `git revert <sha>`. Tables are
`CREATE ... IF NOT EXISTS`, so a revert of the migration leaves them in any
already-bootstrapped DB; that's harmless because nothing else references them
yet. A follow-up `DROP TABLE` migration can clean them up if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remediation plan management system with support for creating, retrieving, updating, and deleting plans
  * Plans support ordered execution steps with status tracking, dry-run capability, and approval workflows
  * Ability to link plans to rescue plans for coordinated remediation efforts
  * Automatic expiration of pending plans after specified timeframes
  * Comprehensive filtering and listing by organization, investigation, and status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->