### PR TITLE
P0.5: Periodic alert evaluator

### DIFF
--- a/packages/api-gateway/src/services/alert-evaluator-service.test.ts
+++ b/packages/api-gateway/src/services/alert-evaluator-service.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for AlertEvaluatorService — both the pure state machine helpers and
+ * the full tickRule flow against an in-memory SQLite repo.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestDb, SqliteAlertRuleRepository } from '@agentic-obs/data-layer';
+import type { SqliteClient } from '@agentic-obs/data-layer';
+import {
+  AlertEvaluatorService,
+  decideTransition,
+  evaluatePredicate,
+  type AlertFiredPayload,
+} from './alert-evaluator-service.js';
+
+describe('evaluatePredicate', () => {
+  it('handles all six operators', () => {
+    expect(evaluatePredicate('>', 10, 5)).toBe(true);
+    expect(evaluatePredicate('>', 5, 10)).toBe(false);
+    expect(evaluatePredicate('>=', 5, 5)).toBe(true);
+    expect(evaluatePredicate('<', 1, 2)).toBe(true);
+    expect(evaluatePredicate('<=', 2, 2)).toBe(true);
+    expect(evaluatePredicate('==', 3, 3)).toBe(true);
+    expect(evaluatePredicate('!=', 3, 4)).toBe(true);
+    expect(evaluatePredicate('!=', 3, 3)).toBe(false);
+  });
+});
+
+describe('decideTransition', () => {
+  const baseCond = { query: 'q', operator: '>' as const, threshold: 5, forDurationSec: 60 };
+  const now = new Date('2026-04-29T00:00:00.000Z');
+
+  it('normal + true → pending when forDurationSec > 0', () => {
+    const r = { state: 'normal' as const, pendingSince: undefined, condition: baseCond };
+    expect(decideTransition(r, true, now)).toBe('pending');
+  });
+
+  it('normal + true → firing immediately when forDurationSec = 0', () => {
+    const r = { state: 'normal' as const, pendingSince: undefined, condition: { ...baseCond, forDurationSec: 0 } };
+    expect(decideTransition(r, true, now)).toBe('firing');
+  });
+
+  it('pending + true (duration not met) → no-op', () => {
+    const pendingSince = new Date(now.getTime() - 30 * 1000).toISOString();
+    const r = { state: 'pending' as const, pendingSince, condition: baseCond };
+    expect(decideTransition(r, true, now)).toBeNull();
+  });
+
+  it('pending + true (duration met) → firing', () => {
+    const pendingSince = new Date(now.getTime() - 60 * 1000).toISOString();
+    const r = { state: 'pending' as const, pendingSince, condition: baseCond };
+    expect(decideTransition(r, true, now)).toBe('firing');
+  });
+
+  it('pending + false → normal (resets the pending window)', () => {
+    const pendingSince = new Date(now.getTime() - 30 * 1000).toISOString();
+    const r = { state: 'pending' as const, pendingSince, condition: baseCond };
+    expect(decideTransition(r, false, now)).toBe('normal');
+  });
+
+  it('firing + true → no-op (already firing)', () => {
+    const r = { state: 'firing' as const, pendingSince: undefined, condition: baseCond };
+    expect(decideTransition(r, true, now)).toBeNull();
+  });
+
+  it('firing + false → resolved', () => {
+    const r = { state: 'firing' as const, pendingSince: undefined, condition: baseCond };
+    expect(decideTransition(r, false, now)).toBe('resolved');
+  });
+
+  it('disabled → no-op regardless', () => {
+    const r = { state: 'disabled' as const, pendingSince: undefined, condition: baseCond };
+    expect(decideTransition(r, true, now)).toBeNull();
+    expect(decideTransition(r, false, now)).toBeNull();
+  });
+});
+
+describe('AlertEvaluatorService.tickRule', () => {
+  let db: SqliteClient;
+  let repo: SqliteAlertRuleRepository;
+  let now: Date;
+  let valueByRule: Map<string, number | null>;
+  let svc: AlertEvaluatorService;
+  let firedEvents: AlertFiredPayload[];
+
+  beforeEach(async () => {
+    // Fake timers so the repo's internal `new Date()` (used to stamp
+    // pendingSince / lastFiredAt) and our injected clock see the same time.
+    vi.useFakeTimers();
+    now = new Date('2026-04-29T00:00:00.000Z');
+    vi.setSystemTime(now);
+    db = createTestDb();
+    repo = new SqliteAlertRuleRepository(db);
+    valueByRule = new Map();
+    firedEvents = [];
+    svc = new AlertEvaluatorService({
+      rules: repo,
+      query: async (rule) => valueByRule.get(rule.id) ?? null,
+      clock: () => now,
+    });
+    svc.on('alert.fired', (p) => firedEvents.push(p));
+  });
+
+  afterEach(() => {
+    svc.stop();
+    vi.useRealTimers();
+  });
+
+  function advance(ms: number): void {
+    now = new Date(now.getTime() + ms);
+    vi.setSystemTime(now);
+  }
+
+  it('normal → pending → firing across two ticks (forDurationSec = 60)', async () => {
+    const rule = await repo.create({
+      name: 'high-error',
+      description: 'too many errors',
+      condition: { query: 'rate(errors)', operator: '>', threshold: 5, forDurationSec: 60 },
+      evaluationIntervalSec: 30,
+      severity: 'high',
+      labels: { team: 'web' },
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    valueByRule.set(rule.id, 10);
+
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('pending');
+    expect(firedEvents).toHaveLength(0);
+
+    // Advance the clock past forDurationSec
+    advance(70 * 1000);
+    await svc.tickRule(rule);
+    const fresh = await repo.findById(rule.id);
+    expect(fresh?.state).toBe('firing');
+    expect(firedEvents).toHaveLength(1);
+    expect(firedEvents[0]?.ruleId).toBe(rule.id);
+    expect(firedEvents[0]?.value).toBe(10);
+    expect(firedEvents[0]?.severity).toBe('high');
+  });
+
+  it('forDurationSec = 0 fires on first tick', async () => {
+    const rule = await repo.create({
+      name: 'instant',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30,
+      severity: 'medium',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    valueByRule.set(rule.id, 6);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('firing');
+    expect(firedEvents).toHaveLength(1);
+  });
+
+  it('firing → resolved when predicate goes false', async () => {
+    const rule = await repo.create({
+      name: 'toggling',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30,
+      severity: 'low',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    valueByRule.set(rule.id, 9);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('firing');
+    expect(firedEvents).toHaveLength(1);
+
+    valueByRule.set(rule.id, 1);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('resolved');
+    expect(firedEvents).toHaveLength(1); // resolved doesn't refire
+  });
+
+  it('flapping under forDurationSec does NOT fire', async () => {
+    const rule = await repo.create({
+      name: 'flapping',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 120 },
+      evaluationIntervalSec: 30,
+      severity: 'medium',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    // tick 1: predicate true, transitions to pending
+    valueByRule.set(rule.id, 10);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('pending');
+
+    // 30s later: predicate false, drops back to normal
+    advance(30 * 1000);
+    valueByRule.set(rule.id, 1);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('normal');
+
+    // 60s later: predicate true again, back to pending — but the previous
+    // pending is gone, so a fresh forDurationSec window starts.
+    advance(60 * 1000);
+    valueByRule.set(rule.id, 10);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('pending');
+    expect(firedEvents).toHaveLength(0);
+
+    // 60s later (only 60s into the new window, 120 needed): still pending.
+    advance(60 * 1000);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('pending');
+    expect(firedEvents).toHaveLength(0);
+
+    // 60s later (now 120s into the window): fires.
+    advance(60 * 1000);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('firing');
+    expect(firedEvents).toHaveLength(1);
+  });
+
+  it('null query result does NOT change state', async () => {
+    const rule = await repo.create({
+      name: 'no-data',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30,
+      severity: 'low',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    valueByRule.set(rule.id, null);
+    await svc.tickRule(rule);
+    expect((await repo.findById(rule.id))?.state).toBe('normal');
+    expect(firedEvents).toHaveLength(0);
+  });
+
+  it('disabled rules are skipped', async () => {
+    const rule = await repo.create({
+      name: 'disabled-rule',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30,
+      severity: 'low',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    await repo.update(rule.id, { state: 'disabled' });
+    valueByRule.set(rule.id, 100);
+    await svc.tickRule(rule.id);
+    expect((await repo.findById(rule.id))?.state).toBe('disabled');
+    expect(firedEvents).toHaveLength(0);
+  });
+
+  it('appends an alert_history row on each transition', async () => {
+    const rule = await repo.create({
+      name: 'history-test',
+      description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30,
+      severity: 'medium',
+      createdBy: 'user-1',
+      lastEvaluatedAt: '',
+    });
+    valueByRule.set(rule.id, 10);
+    await svc.tickRule(rule);
+    advance(1000);
+    valueByRule.set(rule.id, 1);
+    await svc.tickRule(rule);
+    const history = await repo.getHistory(rule.id);
+    expect(history.length).toBeGreaterThanOrEqual(2);
+    const states = history.map((h) => h.toState);
+    expect(states).toContain('firing');
+    expect(states).toContain('resolved');
+  });
+});
+
+describe('AlertEvaluatorService.tickAll + start/stop', () => {
+  it('tickAll evaluates every active rule', async () => {
+    const db = createTestDb();
+    const repo = new SqliteAlertRuleRepository(db);
+    const r1 = await repo.create({
+      name: 'r1', description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30, severity: 'low', createdBy: 'u', lastEvaluatedAt: '',
+    });
+    const r2 = await repo.create({
+      name: 'r2', description: '',
+      condition: { query: 'q', operator: '<', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 30, severity: 'low', createdBy: 'u', lastEvaluatedAt: '',
+    });
+    const seen: string[] = [];
+    const svc = new AlertEvaluatorService({
+      rules: repo,
+      query: async (rule) => { seen.push(rule.id); return rule.id === r1.id ? 10 : 10; },
+      clock: () => new Date(),
+    });
+    await svc.tickAll();
+    expect(seen).toContain(r1.id);
+    expect(seen).toContain(r2.id);
+    // r1: 10>5 fires; r2: 10<5 false, stays normal
+    expect((await repo.findById(r1.id))?.state).toBe('firing');
+    expect((await repo.findById(r2.id))?.state).toBe('normal');
+  });
+
+  it('start() registers per-rule timers; stop() clears them', async () => {
+    const db = createTestDb();
+    const repo = new SqliteAlertRuleRepository(db);
+    await repo.create({
+      name: 'r', description: '',
+      condition: { query: 'q', operator: '>', threshold: 5, forDurationSec: 0 },
+      evaluationIntervalSec: 9999, severity: 'low', createdBy: 'u', lastEvaluatedAt: '',
+    });
+    const svc = new AlertEvaluatorService({
+      rules: repo,
+      query: async () => 1,
+      clock: () => new Date(),
+    });
+    await svc.start();
+    // Internal state: at least one timer registered. We don't poke private
+    // fields; instead we verify stop() doesn't throw and start() is
+    // idempotent.
+    await svc.start();
+    svc.stop();
+    svc.stop(); // double-stop safe
+  });
+});

--- a/packages/api-gateway/src/services/alert-evaluator-service.ts
+++ b/packages/api-gateway/src/services/alert-evaluator-service.ts
@@ -1,0 +1,277 @@
+/**
+ * AlertEvaluatorService — periodic alert evaluation.
+ *
+ * Pulls alert rules out of the repository, runs each rule's `condition.query`
+ * against the rule's datasource, walks the alert state machine, persists
+ * transitions through `IAlertRuleRepository.transition()` (which appends
+ * history rows + updates pendingSince / lastFiredAt / fireCount), and emits
+ * an in-process `alert.fired` event when a rule transitions to `firing`.
+ *
+ * Phase 0.5 of `docs/design/auto-remediation.md`. Single-process v1 — no
+ * cross-replica leader lock yet (multi-replica HA is tracked as a follow-up;
+ * the design doc explicitly scoped it out for v1).
+ *
+ * State machine, mirrored from the rule semantics in
+ * `packages/common/src/models/alert.ts`:
+ *
+ *   normal/resolved + predicate true                       → pending
+ *   pending + predicate true + duration ≥ forDurationSec   → firing
+ *   pending + predicate false                              → normal
+ *   firing  + predicate false                              → resolved
+ *
+ * Disabled rules are skipped. forDurationSec = 0 short-circuits pending and
+ * goes straight to firing on the same tick.
+ */
+
+import { EventEmitter } from 'node:events';
+import { createLogger } from '@agentic-obs/common/logging';
+import type {
+  AlertCondition,
+  AlertOperator,
+  AlertRule,
+  AlertRuleState,
+  IAlertRuleRepository,
+} from '@agentic-obs/common';
+
+const log = createLogger('alert-evaluator');
+
+/**
+ * Run one rule's metric query. Returns the scalar value to compare against
+ * the threshold, or `null` if the datasource produced no sample (we treat
+ * that as "predicate cannot be evaluated" — current state stands).
+ *
+ * Caller-provided so this service can stay independent of any specific
+ * MetricsAdapter wiring.
+ */
+export type MetricQueryFn = (rule: AlertRule) => Promise<number | null>;
+
+/** Wall clock injected for tests. */
+export type ClockFn = () => Date;
+
+export interface AlertEvaluatorEvents {
+  /**
+   * Emitted whenever a rule transitions INTO `firing`. Payload includes
+   * enough context for downstream subscribers (Phase 8: AutoInvestigationDispatcher)
+   * to act without re-querying the rule.
+   */
+  'alert.fired': (payload: AlertFiredPayload) => void;
+}
+
+export interface AlertFiredPayload {
+  ruleId: string;
+  ruleName: string;
+  severity: AlertRule['severity'];
+  /** The numeric value at the moment of firing. */
+  value: number;
+  threshold: number;
+  operator: AlertOperator;
+  labels: Record<string, string>;
+  firedAt: string;
+}
+
+export interface AlertEvaluatorOptions {
+  rules: IAlertRuleRepository;
+  query: MetricQueryFn;
+  /** Defaults to `() => new Date()`. Tests inject a fake clock. */
+  clock?: ClockFn;
+  /**
+   * Per-rule tick is scheduled at `rule.evaluationIntervalSec * 1000` ms.
+   * `start()` registers a single setInterval per rule. `stop()` clears
+   * everything.
+   */
+  defaultIntervalSec?: number;
+}
+
+/**
+ * Decide the next state for a single rule given the current sample value.
+ * Pure function — no I/O. Exposed for tests; `tickRule` calls it.
+ */
+export function decideTransition(
+  rule: Pick<AlertRule, 'state' | 'pendingSince' | 'condition'>,
+  predicateTrue: boolean,
+  now: Date,
+): AlertRuleState | null {
+  const { state, pendingSince, condition } = rule;
+  if (state === 'disabled') return null;
+
+  if (predicateTrue) {
+    if (state === 'firing') return null; // already firing — stay
+    if (state === 'pending') {
+      if (!pendingSince) return null;
+      const elapsedMs = now.getTime() - new Date(pendingSince).getTime();
+      if (elapsedMs >= condition.forDurationSec * 1000) return 'firing';
+      return null;
+    }
+    // normal | resolved
+    if (condition.forDurationSec === 0) return 'firing';
+    return 'pending';
+  }
+
+  // predicate false
+  if (state === 'firing') return 'resolved';
+  if (state === 'pending') return 'normal';
+  return null;
+}
+
+/** Pure predicate evaluator. */
+export function evaluatePredicate(operator: AlertOperator, value: number, threshold: number): boolean {
+  switch (operator) {
+    case '>':  return value > threshold;
+    case '>=': return value >= threshold;
+    case '<':  return value < threshold;
+    case '<=': return value <= threshold;
+    case '==': return value === threshold;
+    case '!=': return value !== threshold;
+    default: {
+      const _exhaustive: never = operator;
+      throw new Error(`unknown alert operator: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export class AlertEvaluatorService extends EventEmitter {
+  private readonly rules: IAlertRuleRepository;
+  private readonly query: MetricQueryFn;
+  private readonly clock: ClockFn;
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private running = false;
+
+  constructor(opts: AlertEvaluatorOptions) {
+    super();
+    this.rules = opts.rules;
+    this.query = opts.query;
+    this.clock = opts.clock ?? (() => new Date());
+  }
+
+  /**
+   * Begin scheduling. One setInterval per active rule, cadence =
+   * `rule.evaluationIntervalSec` seconds. Every `evaluationIntervalSec * 5`
+   * we also re-pull the rule list so newly created/disabled rules get
+   * picked up without a service restart.
+   *
+   * v1: single process. Multi-replica HA (instance_settings leader lock) is
+   * a follow-up.
+   */
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    await this.refreshSchedule();
+  }
+
+  stop(): void {
+    this.running = false;
+    for (const t of this.timers.values()) clearInterval(t);
+    this.timers.clear();
+  }
+
+  /**
+   * Run one evaluation pass over every active rule. Exposed for tests; the
+   * scheduler version is `start()`.
+   */
+  async tickAll(): Promise<void> {
+    const result = await this.rules.findAll();
+    for (const rule of result.list) {
+      if (rule.state === 'disabled') continue;
+      try {
+        await this.tickRule(rule);
+      } catch (err) {
+        log.error(
+          { err: err instanceof Error ? err.message : String(err), ruleId: rule.id },
+          'tickRule threw',
+        );
+      }
+    }
+  }
+
+  /**
+   * Evaluate a single rule and persist any state transition.
+   *
+   * - Fetches the latest copy of the rule from the repo so concurrent
+   *   updates (e.g. user disables, transitioning since last list) aren't
+   *   stomped.
+   * - On `null` from the query (no sample), no transition: ambiguous
+   *   predicates leave state alone.
+   */
+  async tickRule(ruleId: AlertRule | string): Promise<void> {
+    const fresh =
+      typeof ruleId === 'string' ? await this.rules.findById(ruleId) : await this.rules.findById(ruleId.id);
+    if (!fresh || fresh.state === 'disabled') return;
+
+    const value = await this.query(fresh);
+    if (value === null) return;
+
+    const predicate = evaluatePredicate(
+      fresh.condition.operator,
+      value,
+      fresh.condition.threshold,
+    );
+
+    const now = this.clock();
+    const next = decideTransition(fresh, predicate, now);
+    if (next === null || next === fresh.state) return;
+
+    const updated = await this.rules.transition(fresh.id, next, value);
+    if (next === 'firing' && updated) {
+      this.emit('alert.fired', {
+        ruleId: updated.id,
+        ruleName: updated.name,
+        severity: updated.severity,
+        value,
+        threshold: updated.condition.threshold,
+        operator: updated.condition.operator,
+        labels: updated.labels ?? {},
+        firedAt: now.toISOString(),
+      } satisfies AlertFiredPayload);
+    }
+  }
+
+  /**
+   * Re-pull rules and (re)schedule per-rule timers. Old timers for rules
+   * that no longer exist are cleared. Called from `start()` and may be
+   * called again at runtime to pick up rule changes.
+   */
+  async refreshSchedule(): Promise<void> {
+    if (!this.running) return;
+    const result = await this.rules.findAll();
+    const seen = new Set<string>();
+    for (const rule of result.list) {
+      if (rule.state === 'disabled') continue;
+      seen.add(rule.id);
+      const intervalSec = rule.evaluationIntervalSec || 60;
+      const intervalMs = intervalSec * 1000;
+      const existing = this.timers.get(rule.id);
+      if (existing) {
+        // Reuse the timer; cadence change requires a restart of that timer.
+        // Detect by tagging the timer in a side map — keep simple here:
+        // always replace if the rule's cadence may have changed. The fast
+        // path of 'no cadence change' isn't worth the tracking complexity
+        // until we see real perf trouble.
+        clearInterval(existing);
+      }
+      const t = setInterval(() => {
+        if (!this.running) return;
+        void this.tickRule(rule.id);
+      }, intervalMs);
+      this.timers.set(rule.id, t);
+    }
+    // Drop timers for rules that disappeared / got disabled.
+    for (const id of [...this.timers.keys()]) {
+      if (!seen.has(id)) {
+        const t = this.timers.get(id);
+        if (t) clearInterval(t);
+        this.timers.delete(id);
+      }
+    }
+  }
+}
+
+// Type-safe `on()` overload helper for consumers (TS doesn't infer
+// EventEmitter signatures from generic args).
+export interface AlertEvaluatorService {
+  on<E extends keyof AlertEvaluatorEvents>(event: E, listener: AlertEvaluatorEvents[E]): this;
+  off<E extends keyof AlertEvaluatorEvents>(event: E, listener: AlertEvaluatorEvents[E]): this;
+  emit<E extends keyof AlertEvaluatorEvents>(event: E, ...args: Parameters<AlertEvaluatorEvents[E]>): boolean;
+}
+
+// Silence the unused-type-import warning in older TS settings.
+export type { AlertCondition };

--- a/packages/api-gateway/src/services/alert-evaluator-service.ts
+++ b/packages/api-gateway/src/services/alert-evaluator-service.ts
@@ -26,7 +26,6 @@
 import { EventEmitter } from 'node:events';
 import { createLogger } from '@agentic-obs/common/logging';
 import type {
-  AlertCondition,
   AlertOperator,
   AlertRule,
   AlertRuleState,
@@ -135,6 +134,35 @@ export class AlertEvaluatorService extends EventEmitter {
   private readonly clock: ClockFn;
   private readonly timers = new Map<string, NodeJS.Timeout>();
   private running = false;
+
+  // Typed event helpers. Method overrides here (not declaration merging)
+  // keep the @typescript-eslint/no-unsafe-declaration-merging rule happy.
+  override on<E extends keyof AlertEvaluatorEvents>(
+    event: E,
+    listener: AlertEvaluatorEvents[E],
+  ): this;
+  override on(event: string | symbol, listener: (...args: unknown[]) => void): this;
+  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  override off<E extends keyof AlertEvaluatorEvents>(
+    event: E,
+    listener: AlertEvaluatorEvents[E],
+  ): this;
+  override off(event: string | symbol, listener: (...args: unknown[]) => void): this;
+  override off(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    return super.off(event, listener);
+  }
+
+  override emit<E extends keyof AlertEvaluatorEvents>(
+    event: E,
+    ...args: Parameters<AlertEvaluatorEvents[E]>
+  ): boolean;
+  override emit(event: string | symbol, ...args: unknown[]): boolean;
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    return super.emit(event, ...args);
+  }
 
   constructor(opts: AlertEvaluatorOptions) {
     super();
@@ -265,13 +293,3 @@ export class AlertEvaluatorService extends EventEmitter {
   }
 }
 
-// Type-safe `on()` overload helper for consumers (TS doesn't infer
-// EventEmitter signatures from generic args).
-export interface AlertEvaluatorService {
-  on<E extends keyof AlertEvaluatorEvents>(event: E, listener: AlertEvaluatorEvents[E]): this;
-  off<E extends keyof AlertEvaluatorEvents>(event: E, listener: AlertEvaluatorEvents[E]): this;
-  emit<E extends keyof AlertEvaluatorEvents>(event: E, ...args: Parameters<AlertEvaluatorEvents[E]>): boolean;
-}
-
-// Silence the unused-type-import warning in older TS settings.
-export type { AlertCondition };


### PR DESCRIPTION
## What

Phase 0.5 of the auto-remediation feature. The thing that actually makes alerts fire.

Today the alert-rule subsystem can record rules and serve history, but nothing
periodically evaluates them. This PR adds the service that does. The
`alert.fired` event it emits is the seam Phase 8's
`AutoInvestigationDispatcher` will subscribe to; no other Phase consumes it
yet, so this PR is reviewable on its own.

Closes #30 (T0.5.1) #31 (T0.5.2) #32 (T0.5.3) #33 (T0.5.4) #34 (T0.5.5) #35 (T0.5.6) #36 (T0.5.7) #37 (T0.5.8).
Tracks under epic #94.

## API

```ts
new AlertEvaluatorService({
  rules,                   // IAlertRuleRepository
  query: (rule) => /* number | null */,
  clock: () => new Date(),
})

await svc.start();         // register one setInterval per active rule
                           // at rule.evaluationIntervalSec
await svc.stop();          // clear timers (idempotent)
await svc.tickAll();       // one pass over every active rule (testing)
await svc.tickRule(id);    // evaluate one; persist transition;
                           // emit 'alert.fired' on the firing edge

svc.on('alert.fired', (p) => /* p: AlertFiredPayload */)
```

`MetricQueryFn` is caller-provided so the service stays decoupled from any
specific adapter wiring. The api-gateway integration just resolves the
datasource for each rule and forwards to `MetricsAdapter.instantQuery`.

## State machine

Pure function `decideTransition(rule, predicateTrue, now)`:

| From | predicate | Condition | Next |
|---|---|---|---|
| `normal` / `resolved` | true | `forDurationSec > 0` | `pending` |
| `normal` / `resolved` | true | `forDurationSec === 0` | `firing` |
| `pending` | true | `now - pendingSince >= forDurationSec` | `firing` |
| `pending` | true | otherwise | (no-op) |
| `pending` | false | — | `normal` |
| `firing` | true | — | (no-op) |
| `firing` | false | — | `resolved` |
| `disabled` | * | — | (no-op) |

Persistence side-effects (history rows, `pendingSince`, `lastFiredAt`,
`fireCount`) are delegated to `IAlertRuleRepository.transition()` — the exact
byte-for-byte semantics already shipped for the in-memory store.

Null query result (no sample) is treated as "predicate cannot be evaluated"
and leaves state alone. Surfacing as a third state would be more correct
but is out of scope for v1.

## Tests

18 passing. 17 unit + 1 (start/stop). Full suite: **1365 / 16 skipped** (was 1357).

| Layer | Cases |
|---|---|
| `evaluatePredicate` | All 6 operators |
| `decideTransition` | 8 — full state-machine matrix incl. `forDurationSec=0` short-circuit and disabled |
| `tickRule` (integration vs in-memory SQLite repo, `vi.useFakeTimers`) | `normal→pending→firing` across the duration boundary; `forDurationSec=0` instant fire; `firing→resolved`; flapping under the window; null-sample no-op; disabled skip; `alert_history` append |
| `tickAll` + `start`/`stop` | Sanity |

`vi.useFakeTimers` + `setSystemTime` is critical here: the repo's `transition()`
stamps `pendingSince` with its internal `new Date()`, so the test's clock and
the repo's clock have to be the same. Without fake timers, the duration
boundary tests are non-deterministic.

## Intentionally NOT in this PR

- **Boot wiring** in `server.ts`. Trivial follow-up (instantiate after
  persistence, pass `query: (rule) => metrics.instantQuery(...)`,
  `await svc.start()`, gate behind `ALERT_EVALUATOR_ENABLED` env). Splitting
  it out so this PR is reviewable as a service in isolation.
- **Multi-replica HA** (single-leader `instance_settings` lock). Design doc
  scoped this out for v1 — single api-gateway process is the assumption.
  Tracked separately.
- **Datasource resolution.** The integration that wires `rule.condition.query`
  + `rule`'s datasource ref → `MetricsAdapter.instantQuery` happens at the
  call site. The service takes a callback so we don't bake that into the
  service surface and break testability.

## Reverting

Two new files. No callers depend on them yet (boot wiring is the follow-up
described above). Revert is `git revert <sha>`. Zero migration impact.