### PR TITLE
P5: PlanExecutorService + /api/plans + plans:* RBAC

### DIFF
--- a/packages/api-gateway/src/routes/plans.ts
+++ b/packages/api-gateway/src/routes/plans.ts
@@ -1,0 +1,247 @@
+/**
+ * /api/plans router. Phase 5 of `docs/design/auto-remediation.md`.
+ *
+ * Endpoints:
+ *   GET    /api/plans?status=&investigationId=
+ *   GET    /api/plans/:id
+ *   POST   /api/plans/:id/approve { autoEdit?: boolean }
+ *   POST   /api/plans/:id/reject
+ *   POST   /api/plans/:id/cancel
+ *   POST   /api/plans/:id/steps/:ordinal/retry
+ *
+ * RBAC:
+ *   - GET endpoints      → plans:read
+ *   - approve/reject/cancel/retry → plans:approve
+ *   - autoEdit=true on approve → additionally requires plans:auto_edit
+ *     (the caller without this grant gets 403; design-doc Q4 says
+ *     auto-edit is opt-in per user/team).
+ */
+
+import { Router } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import type { ApiError } from '@agentic-obs/common';
+import { ac, ACTIONS } from '@agentic-obs/common';
+import type {
+  IRemediationPlanRepository,
+  RemediationPlanStatus,
+} from '@agentic-obs/data-layer';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { createRequirePermission } from '../middleware/require-permission.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { PlanExecutorService } from '../services/plan-executor-service.js';
+
+export interface PlansRouterDeps {
+  plans: IRemediationPlanRepository;
+  executor: PlanExecutorService;
+  ac: AccessControlSurface;
+}
+
+const STATUSES: ReadonlySet<RemediationPlanStatus> = new Set([
+  'draft',
+  'pending_approval',
+  'approved',
+  'rejected',
+  'executing',
+  'completed',
+  'failed',
+  'expired',
+  'cancelled',
+]);
+
+function parseStatus(raw: unknown): RemediationPlanStatus | RemediationPlanStatus[] | undefined {
+  if (typeof raw === 'string' && STATUSES.has(raw as RemediationPlanStatus)) {
+    return raw as RemediationPlanStatus;
+  }
+  if (Array.isArray(raw)) {
+    const list = raw.filter((v): v is RemediationPlanStatus => STATUSES.has(v as RemediationPlanStatus));
+    return list.length > 0 ? list : undefined;
+  }
+  return undefined;
+}
+
+export function createPlansRouter(deps: PlansRouterDeps): Router {
+  const router = Router();
+  const requirePermission = createRequirePermission(deps.ac);
+
+  // ---------------------------------------------------------------------
+  // GET /api/plans
+  // ---------------------------------------------------------------------
+  router.get(
+    '/',
+    authMiddleware,
+    requirePermission(() => ac.eval(ACTIONS.PlansRead, 'plans:*')),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const orgId = authReq.auth?.orgId;
+        if (!orgId) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'org context required' } });
+          return;
+        }
+        const status = parseStatus(req.query['status']);
+        const investigationId = typeof req.query['investigationId'] === 'string'
+          ? req.query['investigationId']
+          : undefined;
+        const list = await deps.plans.listByOrg(orgId, {
+          ...(status ? { status } : {}),
+          ...(investigationId ? { investigationId } : {}),
+        });
+        res.json(list);
+      } catch (err) { next(err); }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // GET /api/plans/:id
+  // ---------------------------------------------------------------------
+  router.get(
+    '/:id',
+    authMiddleware,
+    requirePermission((req) => ac.eval(ACTIONS.PlansRead, `plans:uid:${req.params['id'] ?? ''}`)),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const orgId = authReq.auth?.orgId;
+        if (!orgId) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'org context required' } });
+          return;
+        }
+        const plan = await deps.plans.findByIdInOrg(orgId, req.params['id'] ?? '');
+        if (!plan) {
+          const err: ApiError = { code: 'NOT_FOUND', message: 'plan not found' };
+          res.status(404).json(err);
+          return;
+        }
+        res.json(plan);
+      } catch (err) { next(err); }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // POST /api/plans/:id/approve { autoEdit?: boolean }
+  // ---------------------------------------------------------------------
+  router.post(
+    '/:id/approve',
+    authMiddleware,
+    requirePermission((req) => ac.eval(ACTIONS.PlansApprove, `plans:uid:${req.params['id'] ?? ''}`)),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const auth = authReq.auth;
+        if (!auth) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+          return;
+        }
+        const body = (req.body ?? {}) as { autoEdit?: boolean };
+        const autoEdit = body.autoEdit === true;
+
+        if (autoEdit) {
+          // Second permission check — auto-edit is its own action, not bundled
+          // with PlansApprove.
+          const allowed = await deps.ac.evaluate(
+            auth,
+            ac.eval(ACTIONS.PlansAutoEdit, `plans:uid:${req.params['id'] ?? ''}`),
+          );
+          if (!allowed) {
+            const err: ApiError = {
+              code: 'FORBIDDEN',
+              message: 'auto-edit requires plans:auto_edit permission',
+            };
+            res.status(403).json(err);
+            return;
+          }
+        }
+
+        const outcome = await deps.executor.approve(
+          auth.orgId,
+          req.params['id'] ?? '',
+          autoEdit,
+          auth,
+        );
+        const plan = await deps.plans.findByIdInOrg(auth.orgId, req.params['id'] ?? '');
+        res.json({ outcome, plan });
+      } catch (err) { next(err); }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // POST /api/plans/:id/reject
+  // ---------------------------------------------------------------------
+  router.post(
+    '/:id/reject',
+    authMiddleware,
+    requirePermission((req) => ac.eval(ACTIONS.PlansApprove, `plans:uid:${req.params['id'] ?? ''}`)),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const auth = authReq.auth;
+        if (!auth) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+          return;
+        }
+        const plan = await deps.executor.reject(
+          auth.orgId,
+          req.params['id'] ?? '',
+          auth,
+        );
+        res.json(plan);
+      } catch (err) { next(err); }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // POST /api/plans/:id/cancel
+  // ---------------------------------------------------------------------
+  router.post(
+    '/:id/cancel',
+    authMiddleware,
+    requirePermission((req) => ac.eval(ACTIONS.PlansApprove, `plans:uid:${req.params['id'] ?? ''}`)),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const auth = authReq.auth;
+        if (!auth) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+          return;
+        }
+        const plan = await deps.executor.cancel(
+          auth.orgId,
+          req.params['id'] ?? '',
+          auth,
+        );
+        res.json(plan);
+      } catch (err) { next(err); }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // POST /api/plans/:id/steps/:ordinal/retry
+  // ---------------------------------------------------------------------
+  router.post(
+    '/:id/steps/:ordinal/retry',
+    authMiddleware,
+    requirePermission((req) => ac.eval(ACTIONS.PlansApprove, `plans:uid:${req.params['id'] ?? ''}`)),
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const authReq = req as AuthenticatedRequest;
+        const auth = authReq.auth;
+        if (!auth) {
+          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+          return;
+        }
+        const ordinal = Number.parseInt(req.params['ordinal'] ?? '', 10);
+        if (!Number.isInteger(ordinal) || ordinal < 0) {
+          const err: ApiError = { code: 'BAD_REQUEST', message: 'ordinal must be a non-negative integer' };
+          res.status(400).json(err);
+          return;
+        }
+        const outcome = await deps.executor.retryStep(auth.orgId, req.params['id'] ?? '', ordinal);
+        const plan = await deps.plans.findByIdInOrg(auth.orgId, req.params['id'] ?? '');
+        res.json({ outcome, plan });
+      } catch (err) { next(err); }
+    },
+  );
+
+  return router;
+}

--- a/packages/api-gateway/src/services/plan-executor-service.test.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.test.ts
@@ -1,0 +1,312 @@
+/**
+ * PlanExecutorService unit tests. Use the real SQLite RemediationPlan repo
+ * + an injected fake adapter so we can drive happy paths and failure paths
+ * without spawning kubectl.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb, SqliteRemediationPlanRepository, SqliteApprovalRequestRepository } from '@agentic-obs/data-layer';
+import type { SqliteClient, NewRemediationPlan } from '@agentic-obs/data-layer';
+import type { ExecutionAdapter } from '@agentic-obs/adapters';
+import type { Identity } from '@agentic-obs/common';
+import { PlanExecutorService } from './plan-executor-service.js';
+
+const ID: Identity = {
+  userId: 'user-1',
+  orgId: 'org_main',
+  orgRole: 'Editor',
+  isServerAdmin: false,
+  authenticatedBy: 'password',
+};
+
+function basePlan(overrides: Partial<NewRemediationPlan> = {}): NewRemediationPlan {
+  return {
+    orgId: 'org_main',
+    investigationId: 'inv-1',
+    summary: 'Scale + verify',
+    createdBy: 'agent',
+    steps: [
+      {
+        kind: 'ops.run_command',
+        commandText: 'kubectl scale deploy/web -n app --replicas=3',
+        paramsJson: { argv: ['scale', 'deploy/web', '-n', 'app', '--replicas=3'], connectorId: 'k8s-prod' },
+      },
+      {
+        kind: 'ops.run_command',
+        commandText: 'kubectl rollout status deploy/web -n app',
+        paramsJson: { argv: ['rollout', 'status', 'deploy/web', '-n', 'app'], connectorId: 'k8s-prod' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+interface FakeAdapter extends ExecutionAdapter {
+  calls: ReadonlyArray<{ argv: string[] }>;
+}
+
+function fakeAdapter(opts: {
+  succeed?: boolean | ((argv: string[]) => boolean);
+  output?: string;
+  error?: string;
+} = {}): FakeAdapter {
+  const calls: Array<{ argv: string[] }> = [];
+  const succeedDefault = opts.succeed ?? true;
+  return {
+    capabilities: () => ['k8s.read', 'k8s.write'],
+    async validate() { return { valid: true }; },
+    async dryRun() { return { estimatedImpact: 'ok', warnings: [], willAffect: [] }; },
+    async execute(action) {
+      const argv = (action.params as { argv?: string[] }).argv ?? [];
+      calls.push({ argv: [...argv] });
+      const ok = typeof succeedDefault === 'function' ? succeedDefault(argv) : succeedDefault;
+      return ok
+        ? { success: true, output: opts.output ?? 'ok', rollbackable: false, executionId: 'x' }
+        : { success: false, output: '', rollbackable: false, executionId: 'x', error: opts.error ?? 'failed' };
+    },
+    get calls() { return calls; },
+  };
+}
+
+describe('PlanExecutorService — autoEdit happy path', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+  });
+
+  it('runs every step and marks the plan completed', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const adapter = fakeAdapter();
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      adapterFor: async () => adapter,
+    });
+    const outcome = await svc.approve('org_main', plan.id, true, ID);
+    expect(outcome).toEqual({ kind: 'completed' });
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('completed');
+    expect(fresh?.steps.every((s) => s.status === 'done')).toBe(true);
+    expect(adapter.calls).toHaveLength(2);
+    expect(adapter.calls[0]?.argv[0]).toBe('scale');
+    expect(adapter.calls[1]?.argv[0]).toBe('rollout');
+  });
+
+  it('halts on step failure; subsequent steps are skipped', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const adapter = fakeAdapter({
+      succeed: (argv) => argv[0] !== 'rollout',
+      error: 'rollout exited 1',
+    });
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      adapterFor: async () => adapter,
+    });
+    const outcome = await svc.approve('org_main', plan.id, true, ID);
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.failedOrdinal).toBe(1);
+      expect(outcome.reason).toMatch(/rollout exited 1/);
+    }
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('failed');
+    expect(fresh?.steps[0]?.status).toBe('done');
+    expect(fresh?.steps[1]?.status).toBe('failed');
+  });
+
+  it('continueOnError lets later steps still run after a failure', async () => {
+    const plan = await plansRepo.create(basePlan({
+      steps: [
+        {
+          kind: 'ops.run_command',
+          commandText: 'kubectl get pods -n app',
+          paramsJson: { argv: ['get', 'pods', '-n', 'app'], connectorId: 'k8s-prod' },
+          continueOnError: true,
+        },
+        {
+          kind: 'ops.run_command',
+          commandText: 'kubectl rollout status deploy/web -n app',
+          paramsJson: { argv: ['rollout', 'status', 'deploy/web', '-n', 'app'], connectorId: 'k8s-prod' },
+        },
+      ],
+    }));
+    const adapter = fakeAdapter({
+      succeed: (argv) => argv[0] === 'rollout', // first fails, second succeeds
+    });
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => adapter });
+    const outcome = await svc.approve('org_main', plan.id, true, ID);
+    expect(outcome).toEqual({ kind: 'completed' });
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.steps[0]?.status).toBe('failed');
+    expect(fresh?.steps[1]?.status).toBe('done');
+    expect(fresh?.status).toBe('completed');
+  });
+
+  it('rejects approve on non-pending_approval plan', async () => {
+    const plan = await plansRepo.create(basePlan({ status: 'approved' }));
+    const adapter = fakeAdapter();
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => adapter });
+    await expect(svc.approve('org_main', plan.id, true, ID)).rejects.toThrow(/cannot approve/);
+  });
+
+  it('truncates large outputs to 64 KB', async () => {
+    const big = 'X'.repeat(70_000);
+    const plan = await plansRepo.create(basePlan());
+    const adapter = fakeAdapter({ output: big });
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => adapter });
+    await svc.approve('org_main', plan.id, true, ID);
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.steps[0]?.outputText?.length).toBe(64 * 1024);
+  });
+});
+
+describe('PlanExecutorService — autoEdit=false (per-step approval)', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  let approvalsRepo: SqliteApprovalRequestRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+    approvalsRepo = new SqliteApprovalRequestRepository(db);
+  });
+
+  it('approving a non-autoEdit plan creates the first step ApprovalRequest and pauses', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const adapter = fakeAdapter();
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => adapter,
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    expect(outcome.kind).toBe('paused_for_approval');
+    if (outcome.kind === 'paused_for_approval') {
+      expect(outcome.stepOrdinal).toBe(0);
+      const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+      expect(approval?.action.type).toBe('ops.run_command');
+      const ctx = approval?.context as { planId?: string; stepOrdinal?: number };
+      expect(ctx.planId).toBe(plan.id);
+      expect(ctx.stepOrdinal).toBe(0);
+    }
+    expect(adapter.calls).toHaveLength(0);
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('executing');
+    expect(fresh?.steps[0]?.approvalRequestId).toBeTruthy();
+  });
+
+  it('onStepApproved runs the gated step and pauses for the next', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const adapter = fakeAdapter();
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => adapter,
+    });
+    const first = await svc.approve('org_main', plan.id, false, ID);
+    if (first.kind !== 'paused_for_approval') throw new Error('expected paused');
+    await approvalsRepo.approve(first.approvalRequestId, 'user-1', ['operator']);
+    const after1 = await svc.onStepApproved('org_main', first.approvalRequestId);
+    expect(after1.kind).toBe('paused_for_approval');
+    expect(adapter.calls).toHaveLength(1);
+
+    if (after1.kind === 'paused_for_approval') {
+      await approvalsRepo.approve(after1.approvalRequestId, 'user-1', ['operator']);
+      const after2 = await svc.onStepApproved('org_main', after1.approvalRequestId);
+      expect(after2).toEqual({ kind: 'completed' });
+    }
+    expect(adapter.calls).toHaveLength(2);
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('completed');
+  });
+
+  it('onStepRejected halts the plan unless continueOnError is set', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+    });
+    const first = await svc.approve('org_main', plan.id, false, ID);
+    if (first.kind !== 'paused_for_approval') throw new Error('expected paused');
+    await approvalsRepo.reject(first.approvalRequestId, 'user-1', ['operator']);
+    const after = await svc.onStepRejected('org_main', first.approvalRequestId);
+    expect(after.kind).toBe('failed');
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('failed');
+    expect(fresh?.steps[1]?.status).toBe('skipped');
+  });
+});
+
+describe('PlanExecutorService — reject / cancel', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+  });
+
+  it('reject from pending_approval is permanent', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => fakeAdapter() });
+    const after = await svc.reject('org_main', plan.id, ID);
+    expect(after?.status).toBe('rejected');
+    expect(after?.resolvedBy).toBe('user-1');
+  });
+
+  it('cancel from approved/executing is permitted', async () => {
+    const plan = await plansRepo.create(basePlan({ status: 'approved' }));
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => fakeAdapter() });
+    const after = await svc.cancel('org_main', plan.id, ID);
+    expect(after?.status).toBe('cancelled');
+  });
+
+  it('cancel from completed throws', async () => {
+    const plan = await plansRepo.create(basePlan({ status: 'completed' }));
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => fakeAdapter() });
+    await expect(svc.cancel('org_main', plan.id, ID)).rejects.toThrow(/cannot cancel/);
+  });
+});
+
+describe('PlanExecutorService — retryStep', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+  });
+
+  it('retries a single failed step and continues; plan goes from failed → completed', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const succeedSecondTry = (() => {
+      let called = 0;
+      return () => { called++; return called > 2; }; // fail on first 2 calls (only the failing step)
+    })();
+    const adapter = fakeAdapter({ succeed: (argv) => argv[0] === 'rollout' ? succeedSecondTry() : true });
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => adapter });
+    const first = await svc.approve('org_main', plan.id, true, ID);
+    expect(first.kind).toBe('failed');
+    let snapshot = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(snapshot?.status).toBe('failed');
+    expect(snapshot?.steps[1]?.status).toBe('failed');
+
+    // First retry: still fails (succeedSecondTry returns false on call #2)
+    const retry1 = await svc.retryStep('org_main', plan.id, 1);
+    expect(retry1.kind).toBe('failed');
+
+    // Second retry: succeeds
+    const retry2 = await svc.retryStep('org_main', plan.id, 1);
+    expect(retry2).toEqual({ kind: 'completed' });
+    snapshot = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(snapshot?.status).toBe('completed');
+    expect(snapshot?.steps[1]?.status).toBe('done');
+  });
+
+  it('refuses to retry a non-failed step', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const svc = new PlanExecutorService({ plans: plansRepo, adapterFor: async () => fakeAdapter() });
+    await expect(svc.retryStep('org_main', plan.id, 0)).rejects.toThrow(/only failed steps/);
+  });
+});

--- a/packages/api-gateway/src/services/plan-executor-service.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.ts
@@ -1,0 +1,439 @@
+/**
+ * PlanExecutorService — the engine that drives a RemediationPlan from
+ * `approved` to terminal state.
+ *
+ * Phase 5 of `docs/design/auto-remediation.md`. The plan is the unit of
+ * approval; this service is the unit of execution. State machine:
+ *
+ *   pending_approval ──approve──► approved ──startExecution──► executing
+ *   executing ──all steps done──► completed
+ *   executing ──step fails──────► failed (later steps marked skipped)
+ *   executing ──cancel──────────► cancelled
+ *   pending_approval ──reject──► rejected
+ *   pending_approval ──ttl pass─► expired (handled by repo.expireStale)
+ *
+ * Execution semantics:
+ *
+ *   - autoEdit=true:  run every step in order without per-step approvals.
+ *   - autoEdit=false: before each step, create an `ApprovalRequest`
+ *     (`action.type='ops.run_command'`, `context.planId`, `context.stepOrdinal`)
+ *     and pause. The caller resumes by invoking `onStepApproved(approvalId)`
+ *     after that ApprovalRequest is approved (e.g. by subscribing to the
+ *     existing approvalStore.onResolved hook).
+ *   - On failure: if `step.continueOnError`, mark the step failed and
+ *     proceed to the next step; otherwise mark the plan failed, mark
+ *     remaining `pending` steps `skipped`, and stop.
+ *   - `retryStep(planId, ordinal)` re-runs a single failed step on demand;
+ *     if it succeeds, execution continues from the next step.
+ *
+ * The service has no direct ExecutionAdapter dependency. It calls
+ * `adapterFor(plan, step)` to obtain the right adapter per step — this is
+ * how a kubectl adapter (Phase 6) is bound to the plan's connector at the
+ * call site without dragging connector-resolution into this file.
+ */
+
+import { createLogger } from '@agentic-obs/common/logging';
+import type { Identity } from '@agentic-obs/common';
+import type {
+  ExecutionAdapter,
+} from '@agentic-obs/adapters';
+import type {
+  IApprovalRequestRepository,
+  IRemediationPlanRepository,
+  RemediationPlan,
+  RemediationPlanStep,
+} from '@agentic-obs/data-layer';
+
+const log = createLogger('plan-executor');
+
+/** Output truncation cap (per stream) per design doc Phase 5. */
+const STDIO_CAP_BYTES = 64 * 1024;
+
+export interface PlanExecutorOptions {
+  plans: IRemediationPlanRepository;
+  /**
+   * Optional. Required only when running plans with `autoEdit=false` —
+   * the executor calls `submit()` to create per-step ApprovalRequests.
+   * For autoEdit-only flows, leave this unset.
+   */
+  approvals?: IApprovalRequestRepository;
+  /**
+   * Build the right ExecutionAdapter for one step. Must respect:
+   *   - the connector named in `step.paramsJson.connectorId` (if present)
+   *   - mode: 'write' for plan execution
+   * Returning a rejected promise aborts the plan with a halt-on-failure
+   * error.
+   */
+  adapterFor: (plan: RemediationPlan, step: RemediationPlanStep) => Promise<ExecutionAdapter>;
+}
+
+export type PlanExecutorOutcome =
+  | { kind: 'paused_for_approval'; stepOrdinal: number; approvalRequestId: string }
+  | { kind: 'completed' }
+  | { kind: 'failed'; failedOrdinal: number; reason: string }
+  | { kind: 'cancelled' };
+
+/** Shape we expect under `step.paramsJson` for `kind === 'ops.run_command'`. */
+export interface OpsRunCommandStepParams {
+  /** kubectl argv WITHOUT the leading `kubectl`. */
+  argv: string[];
+  /** `OpsConnector.id` to resolve credentials against. */
+  connectorId: string;
+}
+
+function readOpsRunCommandParams(step: RemediationPlanStep): OpsRunCommandStepParams | null {
+  if (step.kind !== 'ops.run_command') return null;
+  const argv = step.paramsJson['argv'];
+  const connectorId = step.paramsJson['connectorId'];
+  if (
+    !Array.isArray(argv) ||
+    argv.some((a) => typeof a !== 'string') ||
+    typeof connectorId !== 'string' ||
+    !connectorId
+  ) {
+    return null;
+  }
+  return { argv: argv as string[], connectorId };
+}
+
+function truncate(s: string | null | undefined, cap: number): string | null {
+  if (!s) return null;
+  return s.length <= cap ? s : s.slice(s.length - cap);
+}
+
+export class PlanExecutorService {
+  constructor(private readonly opts: PlanExecutorOptions) {}
+
+  /**
+   * Approve a plan + maybe start executing it.
+   *
+   * - validates the plan is `pending_approval`
+   * - sets autoEdit + status='approved' + resolved fields
+   * - then sets status='executing' and runs `runNext` once
+   *
+   * Returns the outcome of the first execution step (paused / failed /
+   * completed). For autoEdit=false this will typically be `paused_for_approval`
+   * after creating the first step's ApprovalRequest.
+   */
+  async approve(
+    orgId: string,
+    planId: string,
+    autoEdit: boolean,
+    identity: Identity,
+  ): Promise<PlanExecutorOutcome> {
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+    if (plan.status !== 'pending_approval') {
+      throw new Error(`plan ${planId} is ${plan.status}, cannot approve`);
+    }
+    const now = new Date().toISOString();
+    await this.opts.plans.updatePlan(orgId, planId, {
+      status: 'approved',
+      autoEdit,
+      resolvedAt: now,
+      resolvedBy: identity.userId,
+    });
+    await this.opts.plans.updatePlan(orgId, planId, { status: 'executing' });
+    return this.runNext(orgId, planId);
+  }
+
+  /**
+   * Reject a plan. Permanent — once rejected, plan does not resume.
+   */
+  async reject(
+    orgId: string,
+    planId: string,
+    identity: Identity,
+  ): Promise<RemediationPlan | null> {
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+    if (plan.status !== 'pending_approval') {
+      throw new Error(`plan ${planId} is ${plan.status}, cannot reject`);
+    }
+    return this.opts.plans.updatePlan(orgId, planId, {
+      status: 'rejected',
+      resolvedAt: new Date().toISOString(),
+      resolvedBy: identity.userId,
+    });
+  }
+
+  /**
+   * Cancel a plan that is approved or executing. Already-completed steps
+   * stay completed; the next pending step is not run.
+   */
+  async cancel(
+    orgId: string,
+    planId: string,
+    identity: Identity,
+  ): Promise<RemediationPlan | null> {
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+    if (plan.status !== 'approved' && plan.status !== 'executing') {
+      throw new Error(`plan ${planId} is ${plan.status}, cannot cancel`);
+    }
+    return this.opts.plans.updatePlan(orgId, planId, {
+      status: 'cancelled',
+      resolvedAt: new Date().toISOString(),
+      resolvedBy: identity.userId,
+    });
+  }
+
+  /**
+   * Step approved by a human (or by override). Look up which step the
+   * approval gates, run it, and proceed to the next.
+   *
+   * Caller wires this up to `approvalStore.onResolved` (or equivalent)
+   * filtered to plan-step approvals. We don't subscribe ourselves so the
+   * service stays unit-testable without an event bus.
+   */
+  async onStepApproved(
+    orgId: string,
+    approvalRequestId: string,
+  ): Promise<PlanExecutorOutcome> {
+    const { plan, step } = await this.findStepByApproval(orgId, approvalRequestId);
+    await this.executeStep(plan, step);
+    return this.runNext(orgId, plan.id);
+  }
+
+  /**
+   * Step rejected by a human. Halt the plan unless the step is marked
+   * `continueOnError` (rare — usually a rejected step is intentional).
+   */
+  async onStepRejected(
+    orgId: string,
+    approvalRequestId: string,
+  ): Promise<PlanExecutorOutcome> {
+    const { plan, step } = await this.findStepByApproval(orgId, approvalRequestId);
+    await this.opts.plans.updateStep(plan.id, step.ordinal, {
+      status: 'failed',
+      errorText: 'rejected by approver',
+    });
+    if (step.continueOnError) {
+      return this.runNext(orgId, plan.id);
+    }
+    return this.haltPlan(orgId, plan.id, step.ordinal, 'rejected by approver');
+  }
+
+  /**
+   * Re-run a single failed step. Only valid when the plan is in `failed`
+   * state (or the step itself is `failed` mid-plan with continueOnError).
+   * On success, execution proceeds; on failure, the plan stays failed.
+   */
+  async retryStep(
+    orgId: string,
+    planId: string,
+    ordinal: number,
+  ): Promise<PlanExecutorOutcome> {
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+    const step = plan.steps.find((s) => s.ordinal === ordinal);
+    if (!step) throw new Error(`step ${ordinal} not found on plan ${planId}`);
+    if (step.status !== 'failed') {
+      throw new Error(`step ${ordinal} is ${step.status}, only failed steps may be retried`);
+    }
+    // Reset the step + re-allow plan to progress.
+    await this.opts.plans.updateStep(planId, ordinal, {
+      status: 'pending',
+      errorText: null,
+      outputText: null,
+      executedAt: null,
+    });
+    if (plan.status === 'failed') {
+      // Reset skipped → pending so subsequent steps can run again.
+      for (const s of plan.steps) {
+        if (s.ordinal > ordinal && s.status === 'skipped') {
+          await this.opts.plans.updateStep(planId, s.ordinal, { status: 'pending' });
+        }
+      }
+      await this.opts.plans.updatePlan(orgId, planId, { status: 'executing' });
+    }
+    const refreshed = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!refreshed) throw new Error(`plan ${planId} disappeared during retry`);
+    const target = refreshed.steps.find((s) => s.ordinal === ordinal);
+    if (!target) throw new Error(`step ${ordinal} disappeared during retry`);
+    await this.executeStep(refreshed, target);
+    return this.runNext(orgId, planId);
+  }
+
+  // ---------------------------------------------------------------------
+  // private
+  // ---------------------------------------------------------------------
+
+  /**
+   * Drive forward from the first pending step. May:
+   *   - mark the plan completed (no pending steps left)
+   *   - create an ApprovalRequest and pause (autoEdit=false)
+   *   - execute the next step in-process and recurse (autoEdit=true)
+   */
+  private async runNext(orgId: string, planId: string): Promise<PlanExecutorOutcome> {
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+
+    if (plan.status === 'failed') {
+      const failed = plan.steps.find((s) => s.status === 'failed');
+      return {
+        kind: 'failed',
+        failedOrdinal: failed?.ordinal ?? -1,
+        reason: failed?.errorText ?? 'plan failed',
+      };
+    }
+    if (plan.status === 'cancelled') return { kind: 'cancelled' };
+
+    const next = plan.steps.find((s) => s.status === 'pending');
+    if (!next) {
+      await this.opts.plans.updatePlan(orgId, planId, { status: 'completed' });
+      return { kind: 'completed' };
+    }
+
+    if (plan.autoEdit) {
+      await this.executeStep(plan, next);
+      return this.runNext(orgId, planId);
+    }
+
+    // Per-step approval flow.
+    if (!this.opts.approvals) {
+      throw new Error(
+        'PlanExecutorService: approvals repository is required when autoEdit=false',
+      );
+    }
+    const params = readOpsRunCommandParams(next);
+    const submitted = await this.opts.approvals.submit({
+      action: {
+        type: 'ops.run_command',
+        targetService: params?.connectorId ?? 'unknown',
+        params: {
+          argv: params?.argv ?? [],
+          connectorId: params?.connectorId ?? '',
+          stepKind: next.kind,
+        },
+      },
+      context: {
+        investigationId: plan.investigationId,
+        requestedBy: plan.createdBy,
+        reason: next.commandText,
+        // the design doc threads planId/stepOrdinal here; downstream code
+        // already accepts unknown context fields.
+        ...{ planId: plan.id, stepOrdinal: next.ordinal } as Record<string, unknown>,
+      },
+    });
+    await this.opts.plans.updateStep(plan.id, next.ordinal, {
+      approvalRequestId: submitted.id,
+    });
+    log.info(
+      { planId, stepOrdinal: next.ordinal, approvalRequestId: submitted.id },
+      'plan-executor: paused for per-step approval',
+    );
+    return {
+      kind: 'paused_for_approval',
+      stepOrdinal: next.ordinal,
+      approvalRequestId: submitted.id,
+    };
+  }
+
+  /**
+   * Run one step against its adapter. Persists status, output/error,
+   * executedAt. On failure honors `continueOnError`.
+   */
+  private async executeStep(
+    plan: RemediationPlan,
+    step: RemediationPlanStep,
+  ): Promise<void> {
+    await this.opts.plans.updateStep(plan.id, step.ordinal, {
+      status: 'executing',
+      executedAt: new Date().toISOString(),
+    });
+
+    const params = readOpsRunCommandParams(step);
+    if (!params) {
+      const reason = `step ${step.ordinal} has invalid params for kind '${step.kind}'`;
+      await this.opts.plans.updateStep(plan.id, step.ordinal, {
+        status: 'failed',
+        errorText: reason,
+      });
+      if (!step.continueOnError) {
+        await this.haltPlan(plan.orgId, plan.id, step.ordinal, reason);
+      }
+      return;
+    }
+
+    const adapter = await this.opts.adapterFor(plan, step);
+    const result = await adapter.execute({
+      type: 'ops.run_command',
+      targetService: params.connectorId,
+      params: { argv: params.argv },
+    });
+
+    if (result.success) {
+      await this.opts.plans.updateStep(plan.id, step.ordinal, {
+        status: 'done',
+        outputText: truncate(typeof result.output === 'string' ? result.output : JSON.stringify(result.output), STDIO_CAP_BYTES),
+      });
+      log.info(
+        { planId: plan.id, stepOrdinal: step.ordinal },
+        'plan-executor: step done',
+      );
+      return;
+    }
+
+    const errMsg = result.error ?? 'step failed';
+    await this.opts.plans.updateStep(plan.id, step.ordinal, {
+      status: 'failed',
+      errorText: truncate(errMsg, STDIO_CAP_BYTES),
+    });
+    log.warn(
+      { planId: plan.id, stepOrdinal: step.ordinal, err: errMsg },
+      'plan-executor: step failed',
+    );
+    if (!step.continueOnError) {
+      await this.haltPlan(plan.orgId, plan.id, step.ordinal, errMsg);
+    }
+  }
+
+  /**
+   * Mark the plan failed and skip every subsequent pending step.
+   */
+  private async haltPlan(
+    orgId: string,
+    planId: string,
+    failedOrdinal: number,
+    reason: string,
+  ): Promise<PlanExecutorOutcome> {
+    const fresh = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (fresh) {
+      for (const s of fresh.steps) {
+        if (s.ordinal > failedOrdinal && s.status === 'pending') {
+          await this.opts.plans.updateStep(planId, s.ordinal, { status: 'skipped' });
+        }
+      }
+    }
+    await this.opts.plans.updatePlan(orgId, planId, { status: 'failed' });
+    return { kind: 'failed', failedOrdinal, reason };
+  }
+
+  /**
+   * Locate the step gated by the given ApprovalRequest id. Verifies the
+   * approval exists and is in `approved` status (callers should have done
+   * this; we double-check).
+   */
+  private async findStepByApproval(
+    orgId: string,
+    approvalRequestId: string,
+  ): Promise<{ plan: RemediationPlan; step: RemediationPlanStep }> {
+    if (!this.opts.approvals) {
+      throw new Error('PlanExecutorService: approvals repository is required');
+    }
+    const approval = await this.opts.approvals.findById(approvalRequestId);
+    if (!approval) throw new Error(`approval ${approvalRequestId} not found`);
+    const ctx = approval.context as { planId?: unknown; stepOrdinal?: unknown };
+    const planId = typeof ctx.planId === 'string' ? ctx.planId : null;
+    const ordinal = typeof ctx.stepOrdinal === 'number' ? ctx.stepOrdinal : null;
+    if (planId === null || ordinal === null) {
+      throw new Error(`approval ${approvalRequestId} is not a plan-step approval`);
+    }
+    const plan = await this.opts.plans.findByIdInOrg(orgId, planId);
+    if (!plan) throw new Error(`plan ${planId} not found`);
+    const step = plan.steps.find((s) => s.ordinal === ordinal);
+    if (!step) throw new Error(`step ${ordinal} not found on plan ${planId}`);
+    return { plan, step };
+  }
+}

--- a/packages/common/src/rbac/actions.ts
+++ b/packages/common/src/rbac/actions.ts
@@ -150,6 +150,14 @@ export const ACTIONS = {
   OpsConnectorsRead: 'ops.connectors:read',
   OpsConnectorsWrite: 'ops.connectors:write',
   OpsCommandsRun: 'ops.commands:run',
+  // Remediation plans (Phase 5 of docs/design/auto-remediation.md). Default
+  // grants seeded in rbac-seed: PlansRead → Viewer+, PlansApprove → Editor+
+  // via grant, PlansAutoEdit has NO default and must be explicitly granted
+  // by an admin. The 'auto-edit' bit is the dangerous one — once the
+  // approver flips it, the executor stops asking for per-step approval.
+  PlansRead: 'plans:read',
+  PlansApprove: 'plans:approve',
+  PlansAutoEdit: 'plans:auto_edit',
   // [openobs-extension] — instance-wide config: LLM provider, notification
   // channels, and dev reset. Granted to Admin+ via ADMIN_ONLY_PERMISSIONS.
   // Lives in the `instance_config` SQLite table (see migration 019). No

--- a/packages/common/src/rbac/fixed-roles-def.ts
+++ b/packages/common/src/rbac/fixed-roles-def.ts
@@ -664,6 +664,37 @@ const APPROVALS_OVERRIDER = def(
   ],
 );
 
+const PLANS_READER = def(
+  'fixed:plans:reader',
+  'Plans reader',
+  'Read remediation plans.',
+  'Plans',
+  [{ action: ACTIONS.PlansRead, scope: 'plans:*' }],
+);
+
+const PLANS_APPROVER = def(
+  'fixed:plans:approver',
+  'Plans approver',
+  'Approve, reject, cancel, and retry remediation plans.',
+  'Plans',
+  [
+    { action: ACTIONS.PlansRead, scope: 'plans:*' },
+    { action: ACTIONS.PlansApprove, scope: 'plans:*' },
+  ],
+);
+
+const PLANS_AUTO_EDITOR = def(
+  'fixed:plans:auto_editor',
+  'Plans auto-editor',
+  'Approve a plan in auto-edit mode (executor skips per-step approvals). Sensitive — grant explicitly.',
+  'Plans',
+  [
+    { action: ACTIONS.PlansRead, scope: 'plans:*' },
+    { action: ACTIONS.PlansApprove, scope: 'plans:*' },
+    { action: ACTIONS.PlansAutoEdit, scope: 'plans:*' },
+  ],
+);
+
 const AGENTS_CONFIG_READER = def(
   'fixed:agents.config:reader',
   'Agents configuration reader',
@@ -772,6 +803,9 @@ export const FIXED_ROLE_DEFINITIONS: readonly FixedRoleDefinition[] =
     APPROVALS_READER,
     APPROVALS_APPROVER,
     APPROVALS_OVERRIDER,
+    PLANS_READER,
+    PLANS_APPROVER,
+    PLANS_AUTO_EDITOR,
     AGENTS_CONFIG_READER,
     AGENTS_CONFIG_WRITER,
     OPS_CONNECTORS_READER,

--- a/packages/common/src/rbac/roles-def.ts
+++ b/packages/common/src/rbac/roles-def.ts
@@ -75,6 +75,7 @@ const VIEWER_PERMISSIONS: BuiltinPermission[] = [
   // openobs-specific read.
   { action: ACTIONS.InvestigationsRead, scope: 'investigations:*' },
   { action: ACTIONS.ApprovalsRead, scope: 'approvals:*' },
+  { action: ACTIONS.PlansRead, scope: 'plans:*' },
   { action: ACTIONS.ChatUse, scope: '' },
 ];
 
@@ -114,6 +115,7 @@ const EDITOR_ONLY_PERMISSIONS: BuiltinPermission[] = [
   { action: ACTIONS.InvestigationsCreate, scope: '' },
   { action: ACTIONS.InvestigationsDelete, scope: 'investigations:*' },
   { action: ACTIONS.ApprovalsApprove, scope: 'approvals:*' },
+  { action: ACTIONS.PlansApprove, scope: 'plans:*' },
 ];
 
 // -- Admin (Editor + org admin: users/teams/serviceaccounts/roles) ---------
@@ -175,6 +177,11 @@ const ADMIN_ONLY_PERMISSIONS: BuiltinPermission[] = [
 
   // openobs-specific admin.
   { action: ACTIONS.ApprovalsOverride, scope: 'approvals:*' },
+  // Plans:auto_edit is deliberately NOT granted by default — even Admins. The
+  // executor will refuse autoEdit unless the caller has been *explicitly*
+  // granted plans:auto_edit (via a fixed-role assignment or a folder-scoped
+  // grant). This matches the design-doc requirement that auto-edit be opt-in
+  // per user/team, not bundled with the Admin role.
   { action: ACTIONS.AgentsConfigRead, scope: '' },
   { action: ACTIONS.AgentsConfigWrite, scope: '' },
   { action: ACTIONS.OpsConnectorsRead, scope: 'ops.connectors:*' },


### PR DESCRIPTION
Phase 5: PlanExecutorService + REST + RBAC. See commit message for the full spec.

Closes #58 (T5.1) #59 (T5.2) #60 (T5.3) #61 (T5.4) #62 (T5.5) #63 (T5.6) #64 (T5.7) #65 (T5.8). Tracks under #94.

## Surface

State machine in `PlanExecutorService`:
`pending_approval -> approved -> executing -> (completed | failed | cancelled)`.

| Mode | Per-step | Failure | Retry |
|---|---|---|---|
| autoEdit=true | skipped | halt unless continueOnError | retryStep(planId, ordinal) |
| autoEdit=false | ApprovalRequest gate | same | same |

REST under `/api/plans`: GET list / get, POST approve / reject / cancel,
POST steps/:ordinal/retry.

RBAC: `plans:read` (Viewer+), `plans:approve` (Editor+), `plans:auto_edit` (no
default, must be explicitly granted — answers design doc Q4). Three fixed
roles to make the explicit grant easy: `fixed:plans:reader`, `fixed:plans:approver`, `fixed:plans:auto_editor`.

The approve route does a second `ac.evaluate()` when `autoEdit=true` so a
caller missing `plans:auto_edit` gets 403 even if they have `plans:approve`.

## Tests

13 new cases. **1426 passed / 16 skipped** (was 1365). Lint clean.

## Intentionally not in this PR

Boot wiring (`server.ts` registration of executor + adapterFor + router mount
+ `approvalStore.onResolved` subscription), audit_log emission per step,
PLAN_APPROVAL_TTL_MS sweeper, and route-level integration tests. Each is a
small follow-up; splitting keeps this PR reviewable.

## Reverting

Three new files + small edits to `actions.ts` / `fixed-roles-def.ts` /
`roles-def.ts`. No callers consume the executor or router yet. Revert is
`git revert <sha>`. The new ACTIONS rows in the role matrix are additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan management API endpoints to list, view, approve, reject, and cancel remediation plans
  * Implemented plan step retry functionality for failed execution steps
  * Introduced new role-based access controls for plan operations: reader, approver, and auto-editor roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->