### PR TITLE
P4: Agent tools to propose remediation plans

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/remediation-plan.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/remediation-plan.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the remediation_plan.create + .create_rescue handlers.
+ *
+ * Use the real SQLite RemediationPlan + ApprovalRequest repos so we
+ * exercise the same persistence the gateway uses.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AdapterRegistry } from '../../../adapters/index.js';
+import {
+  createTestDb,
+  SqliteRemediationPlanRepository,
+  SqliteApprovalRequestRepository,
+} from '@agentic-obs/data-layer';
+import type { SqliteClient } from '@agentic-obs/data-layer';
+import {
+  handleRemediationPlanCreate,
+  handleRemediationPlanCreateRescue,
+} from '../remediation-plan.js';
+import type { ActionContext } from '../_context.js';
+
+function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    gateway: {} as ActionContext['gateway'],
+    model: 'test',
+    store: {} as ActionContext['store'],
+    investigationReportStore: {} as ActionContext['investigationReportStore'],
+    alertRuleStore: {} as ActionContext['alertRuleStore'],
+    adapters: new AdapterRegistry(),
+    sendEvent: vi.fn(),
+    sessionId: 'session-1',
+    identity: { userId: 'u1', orgId: 'org_main', orgRole: 'Admin', isServerAdmin: false, authenticatedBy: 'session' },
+    accessControl: {
+      evaluate: async () => true,
+      filterByPermission: async (_id, rows) => rows,
+    },
+    actionExecutor: {} as ActionContext['actionExecutor'],
+    alertRuleAgent: {} as ActionContext['alertRuleAgent'],
+    emitAgentEvent: vi.fn(),
+    makeAgentEvent: ((type: string) => ({ type, agentType: 'orchestrator', timestamp: '' })) as ActionContext['makeAgentEvent'],
+    pushConversationAction: vi.fn(),
+    setNavigateTo: vi.fn(),
+    investigationSections: new Map(),
+    ...overrides,
+  } as ActionContext;
+}
+
+const STD_CONNECTOR = {
+  id: 'k8s-prod',
+  name: 'k8s-prod',
+  namespaces: ['app'],
+  capabilities: [],
+};
+
+function validStep(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: 'ops.run_command',
+    commandText: 'kubectl scale deploy/web -n app --replicas=3',
+    paramsJson: {
+      argv: ['scale', 'deploy/web', '-n', 'app', '--replicas=3'],
+      connectorId: 'k8s-prod',
+    },
+    ...overrides,
+  };
+}
+
+describe('remediation_plan.create — error cases', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  let approvalsRepo: SqliteApprovalRequestRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+    approvalsRepo = new SqliteApprovalRequestRepository(db);
+  });
+
+  it('returns Error when remediation plan store is missing', async () => {
+    const ctx = makeCtx({ approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+    });
+    expect(r).toMatch(/^Error: remediation plan store/);
+  });
+
+  it('rejects missing investigationId / summary / steps', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    expect(await handleRemediationPlanCreate(ctx, { summary: 'x', steps: [validStep()] })).toMatch(/investigationId/);
+    expect(await handleRemediationPlanCreate(ctx, { investigationId: 'inv-1', steps: [validStep()] })).toMatch(/summary/);
+    expect(await handleRemediationPlanCreate(ctx, { investigationId: 'inv-1', summary: 'x' })).toMatch(/steps/);
+    expect(await handleRemediationPlanCreate(ctx, { investigationId: 'inv-1', summary: 'x', steps: [] })).toMatch(/steps/);
+  });
+
+  it('rejects malformed step shape with a clear error referencing the step index', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep(), { kind: 'ops.run_command', commandText: 'broken' }],
+    });
+    expect(r).toMatch(/step\[1\]/);
+  });
+
+  it('rejects unknown step kind', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep({ kind: 'shell.run' })],
+    });
+    expect(r).toMatch(/not supported/);
+  });
+
+  it('rejects step whose connector is not configured', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+    });
+    expect(r).toMatch(/connectorId 'k8s-prod' is not configured/);
+  });
+
+  it('rejects step whose argv hits the permanent-deny list (kubectl exec)', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep({ paramsJson: { argv: ['exec', 'web', '-n', 'app', '--', 'sh'], connectorId: 'k8s-prod' } })],
+    });
+    expect(r).toMatch(/permanently denied/);
+  });
+
+  it('rejects step targeting a namespace outside the connector allowlist', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep({ paramsJson: { argv: ['scale', 'deploy/web', '-n', 'kube-system', '--replicas=3'], connectorId: 'k8s-prod' } })],
+    });
+    expect(r).toMatch(/permanently denied|not in the connector/);
+  });
+
+  it('does not half-persist when one step is bad', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep(), validStep({ paramsJson: { argv: ['exec', 'web', '-n', 'app'], connectorId: 'k8s-prod' } })],
+    });
+    const list = await plansRepo.listByOrg('org_main');
+    expect(list).toHaveLength(0);
+  });
+});
+
+describe('remediation_plan.create — happy path', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  let approvalsRepo: SqliteApprovalRequestRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+    approvalsRepo = new SqliteApprovalRequestRepository(db);
+  });
+
+  it('persists plan + steps + an ApprovalRequest, all linked', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const observation = await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1',
+      summary: 'Scale web',
+      steps: [
+        validStep(),
+        validStep({
+          commandText: 'kubectl rollout status deploy/web -n app',
+          paramsJson: { argv: ['rollout', 'status', 'deploy/web', '-n', 'app'], connectorId: 'k8s-prod' },
+        }),
+      ],
+    });
+    expect(observation).toMatch(/Created remediation plan/);
+    expect(observation).toMatch(/2 steps/);
+
+    const plans = await plansRepo.listByOrg('org_main');
+    expect(plans).toHaveLength(1);
+    const plan = plans[0]!;
+    expect(plan.status).toBe('pending_approval');
+    expect(plan.investigationId).toBe('inv-1');
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0]?.ordinal).toBe(0);
+    expect(plan.steps[1]?.ordinal).toBe(1);
+    expect(plan.approvalRequestId).toBeTruthy();
+
+    const approval = await approvalsRepo.findById(plan.approvalRequestId!);
+    expect(approval?.action.type).toBe('plan');
+    expect((approval?.context as { planId?: string }).planId).toBe(plan.id);
+  });
+
+  it('honors expiresInMs', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const before = Date.now();
+    await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+      expiresInMs: 60_000,
+    });
+    const plan = (await plansRepo.listByOrg('org_main'))[0]!;
+    const expiresMs = new Date(plan.expiresAt).getTime();
+    expect(expiresMs - before).toBeGreaterThanOrEqual(50_000);
+    expect(expiresMs - before).toBeLessThanOrEqual(80_000);
+  });
+
+  it('persists riskNote, dryRunText, continueOnError on individual steps', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x',
+      steps: [validStep({
+        riskNote: 'pods will restart',
+        dryRunText: '+1 replica',
+        continueOnError: true,
+      })],
+    });
+    const plan = (await plansRepo.listByOrg('org_main'))[0]!;
+    expect(plan.steps[0]?.riskNote).toBe('pods will restart');
+    expect(plan.steps[0]?.dryRunText).toBe('+1 replica');
+    expect(plan.steps[0]?.continueOnError).toBe(true);
+  });
+
+  it('persists plan even when approvalRequests is unset (no auto-approval)', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, opsConnectors: [STD_CONNECTOR] });
+    await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+    });
+    const plan = (await plansRepo.listByOrg('org_main'))[0]!;
+    expect(plan.status).toBe('pending_approval');
+    expect(plan.approvalRequestId).toBeNull();
+  });
+});
+
+describe('remediation_plan.create_rescue', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  let approvalsRepo: SqliteApprovalRequestRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+    approvalsRepo = new SqliteApprovalRequestRepository(db);
+  });
+
+  it('requires rescueForPlanId', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreateRescue(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+    });
+    expect(r).toMatch(/rescueForPlanId/);
+  });
+
+  it('rejects when parent plan does not exist', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    const r = await handleRemediationPlanCreateRescue(ctx, {
+      investigationId: 'inv-1', summary: 'x', steps: [validStep()],
+      rescueForPlanId: 'plan-missing',
+    });
+    expect(r).toMatch(/parent plan.*not found/);
+  });
+
+  it('persists rescue plan but does NOT create an ApprovalRequest', async () => {
+    const ctx = makeCtx({ remediationPlans: plansRepo, approvalRequests: approvalsRepo, opsConnectors: [STD_CONNECTOR] });
+    // 1) primary plan
+    await handleRemediationPlanCreate(ctx, {
+      investigationId: 'inv-1', summary: 'primary', steps: [validStep()],
+    });
+    const primary = (await plansRepo.listByOrg('org_main'))[0]!;
+
+    // 2) rescue
+    const observation = await handleRemediationPlanCreateRescue(ctx, {
+      investigationId: 'inv-1',
+      summary: 'rollback',
+      rescueForPlanId: primary.id,
+      steps: [validStep({
+        commandText: 'kubectl scale deploy/web -n app --replicas=1',
+        paramsJson: { argv: ['scale', 'deploy/web', '-n', 'app', '--replicas=1'], connectorId: 'k8s-prod' },
+      })],
+    });
+    expect(observation).toMatch(/Created rescue plan/);
+    expect(observation).toMatch(/operator triggers it from the UI/);
+
+    const all = await plansRepo.listByOrg('org_main');
+    expect(all).toHaveLength(2);
+    const rescue = all.find((p) => p.rescueForPlanId === primary.id)!;
+    expect(rescue.status).toBe('pending_approval');
+    expect(rescue.approvalRequestId).toBeNull();
+  });
+});

--- a/packages/agent-core/src/agent/handlers/_context.ts
+++ b/packages/agent-core/src/agent/handlers/_context.ts
@@ -28,6 +28,10 @@ import type {
 import type { ActionExecutor } from '../action-executor.js';
 import type { AlertRuleAgent } from '../alert-rule-agent.js';
 import type { IAccessControlService } from '../types-permissions.js';
+import type {
+  IApprovalRequestRepository,
+  IRemediationPlanRepository,
+} from '@agentic-obs/data-layer';
 
 /** Shared context passed to every action handler. */
 export interface ActionContext {
@@ -62,6 +66,20 @@ export interface ActionContext {
   sessionDatasourcePins?: Record<string, string>;
   opsCommandRunner?: OpsCommandRunner;
   opsConnectors?: OpsConnectorConfig[];
+  /**
+   * Remediation plan store. When present, the `remediation_plan.create`
+   * and `.create_rescue` tools are registered. Optional so test/in-memory
+   * setups can omit; the handlers return a clear "store not available"
+   * observation if the agent invokes them anyway.
+   */
+  remediationPlans?: IRemediationPlanRepository;
+  /**
+   * Approval-request store. Required for the primary
+   * `remediation_plan.create` tool to auto-emit a plan-level approval.
+   * If absent, plans persist in `pending_approval` status but no
+   * ApprovalRequest is created (the UI's plans page can still show them).
+   */
+  approvalRequests?: IApprovalRequestRepository;
   sendEvent: (event: DashboardSseEvent) => void;
   sessionId: string;
 

--- a/packages/agent-core/src/agent/handlers/index.ts
+++ b/packages/agent-core/src/agent/handlers/index.ts
@@ -59,3 +59,5 @@ export { handleWebSearch } from './web.js';
 export { handleNavigate } from './navigation.js';
 export { handleFolderCreate, handleFolderList } from './folder.js';
 export { handleOpsRunCommand } from './ops.js';
+
+export { handleRemediationPlanCreate, handleRemediationPlanCreateRescue } from './remediation-plan.js';

--- a/packages/agent-core/src/agent/handlers/remediation-plan.ts
+++ b/packages/agent-core/src/agent/handlers/remediation-plan.ts
@@ -1,0 +1,227 @@
+/**
+ * Agent tools for proposing remediation plans.
+ *
+ * Phase 4 of `docs/design/auto-remediation.md`. Two tools:
+ *
+ *   - remediation_plan.create        — primary plan (auto-creates a
+ *                                       plan-level ApprovalRequest)
+ *   - remediation_plan.create_rescue — rescue/undo plan paired with a
+ *                                       primary; no ApprovalRequest is
+ *                                       created until a human triggers it
+ *                                       from the UI after a failure.
+ *
+ * Validation: every step's argv is run through P6's `checkKubectl(...,
+ * 'write', allowedNamespaces)` allowlist BEFORE any DB write. If any
+ * step is denied, the whole plan is rejected — no half-persisted plan.
+ *
+ * Execution: NOT done here. The PlanExecutorService (P5) is the only
+ * thing that runs plan steps. This file just persists the proposal and
+ * surfaces it for approval.
+ */
+
+import { checkKubectl } from '@agentic-obs/adapters';
+import type {
+  NewRemediationPlanStep,
+  RemediationPlanStepKind,
+} from '@agentic-obs/data-layer';
+import type { ActionContext } from './_context.js';
+import { withToolEventBoundary } from './_shared.js';
+
+interface RawStepInput {
+  kind?: unknown;
+  commandText?: unknown;
+  paramsJson?: unknown;
+  dryRunText?: unknown;
+  riskNote?: unknown;
+  continueOnError?: unknown;
+}
+
+interface ValidatedStep extends NewRemediationPlanStep {
+  /** retained on the parsed step so we can validate against the connector */
+  connectorId: string;
+}
+
+/**
+ * Coerce a single raw step blob into the shape the repository expects, OR
+ * return a string explaining why we can't. Strict — agents that produce
+ * sloppy step payloads should see a clear error string they can recover
+ * from on the next turn.
+ */
+function parseStep(raw: unknown, idx: number): ValidatedStep | string {
+  if (!raw || typeof raw !== 'object') {
+    return `step[${idx}] is not an object`;
+  }
+  const r = raw as RawStepInput;
+  const kind = typeof r.kind === 'string' ? r.kind : '';
+  if (!kind) return `step[${idx}].kind is required`;
+  if (kind !== 'ops.run_command') {
+    return `step[${idx}].kind '${kind}' is not supported (only 'ops.run_command' today)`;
+  }
+  const commandText = typeof r.commandText === 'string' ? r.commandText.trim() : '';
+  if (!commandText) return `step[${idx}].commandText is required`;
+
+  if (!r.paramsJson || typeof r.paramsJson !== 'object' || Array.isArray(r.paramsJson)) {
+    return `step[${idx}].paramsJson must be an object`;
+  }
+  const params = r.paramsJson as Record<string, unknown>;
+  const argv = params['argv'];
+  const connectorId = params['connectorId'];
+  if (!Array.isArray(argv) || argv.some((a) => typeof a !== 'string') || argv.length === 0) {
+    return `step[${idx}].paramsJson.argv must be a non-empty string array (kubectl argv without 'kubectl')`;
+  }
+  if (typeof connectorId !== 'string' || !connectorId) {
+    return `step[${idx}].paramsJson.connectorId must be the id of a configured ops connector`;
+  }
+  return {
+    kind: kind as RemediationPlanStepKind,
+    commandText,
+    paramsJson: params,
+    connectorId,
+    ...(typeof r.dryRunText === 'string' ? { dryRunText: r.dryRunText } : {}),
+    ...(typeof r.riskNote === 'string' ? { riskNote: r.riskNote } : {}),
+    ...(typeof r.continueOnError === 'boolean' ? { continueOnError: r.continueOnError } : {}),
+  };
+}
+
+/**
+ * Look up the connector by id and check the step's argv against the write
+ * allowlist scoped to that connector's allowedNamespaces. Returns null on
+ * pass; a string reason on fail.
+ */
+function validateStepAgainstConnector(
+  ctx: ActionContext,
+  step: ValidatedStep,
+  idx: number,
+): string | null {
+  const connector = ctx.opsConnectors?.find((c) => c.id === step.connectorId);
+  if (!connector) {
+    return `step[${idx}].paramsJson.connectorId '${step.connectorId}' is not configured for this org`;
+  }
+  const decision = checkKubectl(
+    step.paramsJson['argv'] as string[],
+    'write',
+    connector.namespaces ?? [],
+  );
+  if (!decision.allow) {
+    return `step[${idx}] (${step.commandText}): ${decision.reason ?? 'rejected by allowlist'}`;
+  }
+  return null;
+}
+
+async function createPlanCommon(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+  rescueForPlanId: string | null,
+): Promise<string> {
+  if (!ctx.remediationPlans) {
+    return 'Error: remediation plan store is not available.';
+  }
+  const investigationId = String(args['investigationId'] ?? '');
+  const summary = String(args['summary'] ?? '').trim();
+  const stepsRaw = args['steps'];
+  if (!investigationId) return 'Error: "investigationId" is required.';
+  if (!summary) return 'Error: "summary" is required.';
+  if (!Array.isArray(stepsRaw) || stepsRaw.length === 0) {
+    return 'Error: "steps" must be a non-empty array.';
+  }
+
+  // Parse + structurally validate every step before any I/O.
+  const parsed: ValidatedStep[] = [];
+  for (let i = 0; i < stepsRaw.length; i++) {
+    const result = parseStep(stepsRaw[i], i);
+    if (typeof result === 'string') return `Error: ${result}`;
+    parsed.push(result);
+  }
+  // Allowlist-validate against the connector. We refuse the WHOLE plan if
+  // any step would be denied — half-persisted plans are worse than a clear
+  // rejection that lets the agent retry.
+  for (let i = 0; i < parsed.length; i++) {
+    const reason = validateStepAgainstConnector(ctx, parsed[i] as ValidatedStep, i);
+    if (reason) return `Error: ${reason}`;
+  }
+
+  const expiresInMs = typeof args['expiresInMs'] === 'number' ? args['expiresInMs'] : undefined;
+  const expiresAt = typeof expiresInMs === 'number'
+    ? new Date(Date.now() + expiresInMs).toISOString()
+    : undefined;
+
+  const tool = rescueForPlanId === null ? 'remediation_plan.create' : 'remediation_plan.create_rescue';
+  const displayText = rescueForPlanId === null
+    ? `Proposing remediation plan: ${summary.slice(0, 60)}`
+    : `Proposing rescue plan for ${rescueForPlanId}: ${summary.slice(0, 60)}`;
+
+  let observation = '';
+  await withToolEventBoundary(
+    ctx.sendEvent,
+    tool,
+    { investigationId, summary, stepCount: parsed.length, ...(rescueForPlanId ? { rescueForPlanId } : {}) },
+    displayText,
+    async () => {
+      const plan = await ctx.remediationPlans!.create({
+        orgId: ctx.identity.orgId,
+        investigationId,
+        rescueForPlanId,
+        summary,
+        createdBy: 'agent',
+        ...(expiresAt ? { expiresAt } : {}),
+        steps: parsed.map((p) => {
+          // Drop our `connectorId` helper field; everything else flows through.
+          const { connectorId: _connectorId, ...rest } = p;
+          void _connectorId;
+          return rest as NewRemediationPlanStep;
+        }),
+      });
+
+      // Primary plans get an auto plan-level ApprovalRequest so they show
+      // up in /api/approvals + the ActionCenter UI immediately. Rescue
+      // plans do NOT — they're invoked on demand by an operator.
+      if (rescueForPlanId === null && ctx.approvalRequests) {
+        const submitted = await ctx.approvalRequests.submit({
+          action: {
+            type: 'plan',
+            targetService: 'remediation-plan',
+            params: { planId: plan.id, summary, stepCount: plan.steps.length },
+          },
+          context: {
+            investigationId,
+            requestedBy: 'agent',
+            reason: summary,
+            // planId is also stamped here so the approval-execute path can
+            // find the plan without re-parsing action.params.
+            ...{ planId: plan.id } as Record<string, unknown>,
+          },
+        });
+        await ctx.remediationPlans!.updatePlan(ctx.identity.orgId, plan.id, {
+          approvalRequestId: submitted.id,
+        });
+      }
+
+      observation = rescueForPlanId === null
+        ? `Created remediation plan "${summary}" (id: ${plan.id}, ${plan.steps.length} step${plan.steps.length === 1 ? '' : 's'}). Awaiting approval.`
+        : `Created rescue plan "${summary}" (id: ${plan.id}, ${plan.steps.length} step${plan.steps.length === 1 ? '' : 's'}) for plan ${rescueForPlanId}. It will only run if an operator triggers it from the UI.`;
+      return observation;
+    },
+  );
+  return observation;
+}
+
+export async function handleRemediationPlanCreate(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  return createPlanCommon(ctx, args, null);
+}
+
+export async function handleRemediationPlanCreateRescue(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const rescueForPlanId = String(args['rescueForPlanId'] ?? '').trim();
+  if (!rescueForPlanId) return 'Error: "rescueForPlanId" is required for a rescue plan.';
+  // Verify the parent plan exists in the same org before creating a child.
+  if (ctx.remediationPlans) {
+    const parent = await ctx.remediationPlans.findByIdInOrg(ctx.identity.orgId, rescueForPlanId);
+    if (!parent) return `Error: parent plan "${rescueForPlanId}" not found.`;
+  }
+  return createPlanCommon(ctx, args, rescueForPlanId);
+}

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -44,4 +44,6 @@ export {
   handleFolderCreate,
   handleFolderList,
   handleOpsRunCommand,
+  handleRemediationPlanCreate,
+  handleRemediationPlanCreateRescue,
 } from './handlers/index.js';

--- a/packages/agent-core/src/agent/orchestrator-action-runner.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-runner.ts
@@ -39,6 +39,8 @@ import {
   handleFolderCreate,
   handleFolderList,
   handleOpsRunCommand,
+  handleRemediationPlanCreate,
+  handleRemediationPlanCreateRescue,
 } from './orchestrator-action-handlers.js';
 import type { ToolAuditReporter } from './orchestrator-audit-reporter.js';
 
@@ -188,6 +190,9 @@ async function dispatchAction(
     case 'changes.list_recent': return handleChangesListRecent(ctx, args);
     // Kubernetes / Ops integrations
     case 'ops.run_command': return handleOpsRunCommand(ctx, args);
+    // Remediation plans (P4)
+    case 'remediation_plan.create': return handleRemediationPlanCreate(ctx, args);
+    case 'remediation_plan.create_rescue': return handleRemediationPlanCreateRescue(ctx, args);
     // Web search
     case 'web.search': return handleWebSearch(ctx, args);
     // `tool_search` is intercepted by ReActLoop before dispatch — it

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -171,6 +171,53 @@ User: "Why is p99 latency so high?"
   13. investigation.complete(investigationId: "inv-789", summary: "p99 is driven by /api/v1/query_range alone (120ms vs <50ms others). No deploy correlation. Profile that handler and look at PromQL complexity per-tenant.")
 </example>
 
+## Proposing a Remediation Plan
+After \`investigation.complete\`, IF the root cause is concrete AND the fix is in scope of an attached ops connector (you can see it in the connector list above), you MAY emit \`remediation_plan.create\`. Do NOT run write commands from the investigation turn — the plan is the proposal, a human still has to approve it before anything executes.
+
+Do not propose a plan when:
+- the investigation didn't find a clear root cause
+- the fix would require credentials or capabilities the configured connectors don't have
+- the user is just asking a question, not asking you to fix something
+- the fix is "ask a human" (then say so in plain text)
+
+Each step is a single \`kubectl\` command. Provide:
+- \`commandText\` — what an operator would type, verbatim. Surfaced to the approver.
+- \`paramsJson.argv\` — the same command as a token array WITHOUT the leading \`kubectl\`. The executor uses this; it never invokes a shell.
+- \`paramsJson.connectorId\` — which configured connector this step targets.
+- \`riskNote\` (optional) — one line about what could go wrong ("brief drop to 2 replicas").
+- \`continueOnError\` (optional, default false) — only set true for non-critical steps (e.g. a notification).
+
+Halt-on-failure is the default. Order steps so reads / verifications come before writes; finish with a \`kubectl rollout status\` or similar verification step where it makes sense.
+
+If the failure is reversible and you know how to undo it, also emit \`remediation_plan.create_rescue\` with the SAME shape plus \`rescueForPlanId\` set to the primary plan's id. Rescue plans don't auto-approve and don't auto-run — they sit in storage and an operator triggers them from the UI only after a primary plan fails.
+
+<example>
+After investigation completes with: \`/api/v1/query_range\` is the latency hotspot, deploy/web is at 1 replica.
+  1. remediation_plan.create({
+       investigationId: "inv-789",
+       summary: "Scale web from 1 to 3 replicas to reduce per-pod load on /api/v1/query_range",
+       steps: [
+         { kind: "ops.run_command", commandText: "kubectl scale deploy/web -n app --replicas=3",
+           paramsJson: { argv: ["scale", "deploy/web", "-n", "app", "--replicas=3"], connectorId: "k8s-prod" },
+           riskNote: "Brief CPU spike on existing pods during rollout." },
+         { kind: "ops.run_command", commandText: "kubectl rollout status deploy/web -n app --timeout=120s",
+           paramsJson: { argv: ["rollout", "status", "deploy/web", "-n", "app", "--timeout=120s"], connectorId: "k8s-prod" } }
+       ]
+     })
+  2. remediation_plan.create_rescue({
+       rescueForPlanId: "<primary-plan-id-from-1>",
+       investigationId: "inv-789",
+       summary: "Scale web back to 1 replica",
+       steps: [
+         { kind: "ops.run_command", commandText: "kubectl scale deploy/web -n app --replicas=1",
+           paramsJson: { argv: ["scale", "deploy/web", "-n", "app", "--replicas=1"], connectorId: "k8s-prod" } }
+       ]
+     })
+  3. final reply (plain text): "Filed remediation plan for review. It will scale web from 1 to 3 replicas and verify rollout. A rescue plan to revert is also queued."
+</example>
+
+</example>
+
 ## Opening Existing Resources
 <example>
 User: "Open the http dashboard"

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -297,6 +297,93 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
       },
     },
   },
+  // -------------------------------------------------------------------------
+  // Remediation plans (Phase 4 of docs/design/auto-remediation.md). The agent
+  // emits these AFTER `investigation.complete` when a fix is concrete and in
+  // scope of an attached connector. The plan is the unit of approval; steps
+  // are the unit of execution. Never run write commands from the
+  // investigation turn — propose them in a plan instead.
+  // -------------------------------------------------------------------------
+  'remediation_plan.create': {
+    category: 'always-on',
+    schema: {
+      name: 'remediation_plan.create',
+      description:
+        'Propose a structured remediation plan after an investigation has identified a concrete, in-scope fix. Persists the plan in pending_approval status and creates a plan-level ApprovalRequest so a human can review the whole thing as one unit. Steps are NOT executed by this tool — execution happens after a human approves the plan.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'Id from investigation.create that motivated this plan.' },
+          summary: { type: 'string', description: 'One-line description of what the plan does. Surfaced in approval UI.' },
+          steps: {
+            type: 'array',
+            description: 'Ordered list of steps. The order is the execution order. Halt-on-failure by default.',
+            items: {
+              type: 'object',
+              properties: {
+                kind: { type: 'string', enum: ['ops.run_command'], description: 'Step kind. Today only ops.run_command (kubectl) is supported.' },
+                commandText: { type: 'string', description: 'Human-readable command, e.g. "kubectl scale deploy/web -n app --replicas=3". Surfaced verbatim to the approver.' },
+                paramsJson: {
+                  type: 'object',
+                  description: 'Structured args. For ops.run_command, must include `argv` (kubectl argv WITHOUT the leading "kubectl") and `connectorId` (the ops_connectors row to run against).',
+                  properties: {
+                    argv: { type: 'array', items: { type: 'string' }, description: 'kubectl argv tokens.' },
+                    connectorId: { type: 'string', description: 'ops connector id.' },
+                  },
+                  required: ['argv', 'connectorId'],
+                },
+                dryRunText: { type: 'string', description: 'Optional. The expected effect of this step in plain text. If you ran a related read query while investigating, summarize the predicted outcome here.' },
+                riskNote: { type: 'string', description: 'Optional. Human-readable risk note ("brief drop to 2 replicas"). Surfaced in the approval UI.' },
+                continueOnError: { type: 'boolean', description: 'If true, plan continues if this step fails. Default false (halt). Use for non-critical steps like notifications.' },
+              },
+              required: ['kind', 'commandText', 'paramsJson'],
+            },
+          },
+          expiresInMs: { type: 'number', description: 'Optional. Override the default approval window (24h) in milliseconds.' },
+        },
+        required: ['investigationId', 'summary', 'steps'],
+      },
+    },
+  },
+  'remediation_plan.create_rescue': {
+    category: 'deferred',
+    schema: {
+      name: 'remediation_plan.create_rescue',
+      description:
+        'Propose a rescue/undo plan paired with a primary plan, to be invoked manually by an operator if the primary fails. Same shape as remediation_plan.create plus rescueForPlanId. Does NOT auto-create an ApprovalRequest; rescue plans are triggered on demand from the UI.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          rescueForPlanId: { type: 'string', description: 'Id of the primary plan this rescue undoes.' },
+          investigationId: { type: 'string', description: 'Same investigation that produced the primary plan.' },
+          summary: { type: 'string', description: 'One-line description of the rollback action.' },
+          steps: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                kind: { type: 'string', enum: ['ops.run_command'] },
+                commandText: { type: 'string' },
+                paramsJson: {
+                  type: 'object',
+                  properties: {
+                    argv: { type: 'array', items: { type: 'string' } },
+                    connectorId: { type: 'string' },
+                  },
+                  required: ['argv', 'connectorId'],
+                },
+                dryRunText: { type: 'string' },
+                riskNote: { type: 'string' },
+                continueOnError: { type: 'boolean' },
+              },
+              required: ['kind', 'commandText', 'paramsJson'],
+            },
+          },
+        },
+        required: ['rescueForPlanId', 'investigationId', 'summary', 'steps'],
+      },
+    },
+  },
 
   // -------------------------------------------------------------------------
   // Dashboard lifecycle + mutation primitives


### PR DESCRIPTION
Phase 4: `remediation_plan.create` + `remediation_plan.create_rescue` agent tools. See commit message for the full spec.

Closes #53 (T4.1) #54 (T4.2) #55 (T4.3) #56 (T4.4) #57 (T4.6). T4.5 (auto-fill dryRunText by spawning kubectl --dry-run=server) deferred — see below. Tracks under #94.

## Surface

```json
{
  "investigationId": "inv-789",
  "summary": "Scale web from 1 to 3 replicas",
  "steps": [
    {
      "kind": "ops.run_command",
      "commandText": "kubectl scale deploy/web -n app --replicas=3",
      "paramsJson": {
        "argv": ["scale", "deploy/web", "-n", "app", "--replicas=3"],
        "connectorId": "k8s-prod"
      },
      "riskNote": "Brief CPU spike during rollout"
    }
  ]
}
```

## Validation

Every step runs through P6's `checkKubectl(argv, 'write', allowedNamespaces)` BEFORE any DB write. Any denial rejects the whole plan with a clear error — no half-persisted plans. Permanent-deny (exec, cp, port-forward, proxy, attach, auth can-i --as), namespace-out-of-allowlist, kube-system writes, missing --namespace on writes, bare `kubectl delete` are all caught.

## Persistence

| | Primary | Rescue |
|---|---|---|
| Persists plan + steps | ✓ | ✓ |
| Status | `pending_approval` | `pending_approval` |
| Auto-creates ApprovalRequest | ✓ (`action.type='plan'`) | ✗ — operator triggers from UI |
| `rescue_for_plan_id` set | NULL | parent plan id |

## Tests

15 new cases covering errors (missing store / args / malformed step, unknown kind, unknown connector, permanent-deny verb, namespace mismatch, no half-persist), happy path (plan+steps+approval all linked, expiresInMs, per-step optional fields), and rescue (requires parent id, rejects unknown parent, no auto-approval).

Full suite: **1428 passed / 16 skipped**. Lint clean (only 4 pre-existing warnings unrelated).

## Intentionally NOT in this PR

- **T4.5** (`dryRunText` auto-fill): would require wiring `KubectlExecutionAdapter` into the agent context. The current handler accepts agent-supplied `dryRunText` but doesn't auto-spawn kubectl. Tracked separately so this PR doesn't pull connector-resolution into the agent core.
- Boot wiring (chat-service / orchestrator-action-context need to pass `remediationPlans` and `approvalRequests` into the ActionContext). One-line addition each; left for the boot-wiring follow-up that also covers P0.5 + P5.

## Reverting

Single commit, all additive. Revert with `git revert <sha>`. Tools become unavailable; existing flows untouched.