### PR TITLE
P2: Investigation auto-uses connector (read-only) + ops allowlist gate

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/ops-allowlist.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/ops-allowlist.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the P2 P6-allowlist gate inside `ops.run_command`. The runner
+ * is mocked; the assertion is on what the handler refuses BEFORE reaching it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { AdapterRegistry } from '../../../adapters/index.js';
+import { handleOpsRunCommand, parseKubectlCommandString } from '../ops.js';
+import type { ActionContext } from '../_context.js';
+
+function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    gateway: {} as ActionContext['gateway'],
+    model: 'test',
+    store: {} as ActionContext['store'],
+    investigationReportStore: {} as ActionContext['investigationReportStore'],
+    alertRuleStore: {} as ActionContext['alertRuleStore'],
+    adapters: new AdapterRegistry(),
+    sendEvent: vi.fn(),
+    sessionId: 'session-1',
+    identity: { userId: 'u1', orgId: 'org_main', orgRole: 'Admin', isServerAdmin: false, authenticatedBy: 'session' },
+    accessControl: {
+      evaluate: async () => true,
+      filterByPermission: async (_id, rows) => rows,
+    },
+    actionExecutor: {} as ActionContext['actionExecutor'],
+    alertRuleAgent: {} as ActionContext['alertRuleAgent'],
+    emitAgentEvent: vi.fn(),
+    makeAgentEvent: ((type: string) => ({ type, agentType: 'orchestrator', timestamp: '' })) as ActionContext['makeAgentEvent'],
+    pushConversationAction: vi.fn(),
+    setNavigateTo: vi.fn(),
+    investigationSections: new Map(),
+    ...overrides,
+  } as ActionContext;
+}
+
+describe('parseKubectlCommandString', () => {
+  it('drops the leading kubectl token', () => {
+    expect(parseKubectlCommandString('kubectl get pods -n app')).toEqual(['get', 'pods', '-n', 'app']);
+  });
+  it('returns empty for shell-meta containing inputs', () => {
+    expect(parseKubectlCommandString('kubectl get pods | grep web')).toEqual([]);
+    expect(parseKubectlCommandString('kubectl get pods $(echo x)')).toEqual([]);
+    expect(parseKubectlCommandString('kubectl get pods; rm -rf /')).toEqual([]);
+  });
+  it('handles double-quoted args', () => {
+    expect(parseKubectlCommandString('kubectl annotate pod web "kubernetes.io/x=y" -n app')).toEqual([
+      'annotate', 'pod', 'web', 'kubernetes.io/x=y', '-n', 'app',
+    ]);
+  });
+  it('returns empty on unterminated quotes', () => {
+    expect(parseKubectlCommandString('kubectl get pods "unterminated')).toEqual([]);
+  });
+});
+
+describe('handleOpsRunCommand allowlist gate (intent=read)', () => {
+  function mkRunner(): ActionContext['opsCommandRunner'] {
+    return {
+      runCommand: vi.fn().mockResolvedValue({ observation: 'ran', decision: 'executed' }),
+      listConnectors: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ActionContext['opsCommandRunner'];
+  }
+
+  it('rejects intent=read for a write-shaped command before reaching the runner', async () => {
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl scale deploy/web -n app --replicas=3',
+      intent: 'read',
+    });
+    expect(r).toMatch(/rejected/);
+    expect(r).toMatch(/read-allowlist/);
+    expect((runner as unknown as { runCommand: ReturnType<typeof vi.fn> }).runCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects intent=read for kubectl exec', async () => {
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl exec web -n app -- sh',
+      intent: 'read',
+    });
+    expect(r).toMatch(/permanently denied/);
+    expect((runner as unknown as { runCommand: ReturnType<typeof vi.fn> }).runCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects intent=read targeting a namespace outside the connector allowlist', async () => {
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl get pods -n kube-system',
+      intent: 'read',
+    });
+    expect(r).toMatch(/not in the connector/);
+    expect((runner as unknown as { runCommand: ReturnType<typeof vi.fn> }).runCommand).not.toHaveBeenCalled();
+  });
+
+  it('passes through intent=read for kubectl get on an allowlisted namespace', async () => {
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl get pods -n app',
+      intent: 'read',
+    });
+    expect(r).toBe('ran');
+    expect((runner as unknown as { runCommand: ReturnType<typeof vi.fn> }).runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate intent=propose; the runner / approval flow handles writes', async () => {
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl scale deploy/web -n app --replicas=3',
+      intent: 'propose',
+    });
+    expect(r).toBe('ran');
+    expect((runner as unknown as { runCommand: ReturnType<typeof vi.fn> }).runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through (no gate) when the command string contains shell metacharacters', async () => {
+    // Parse fails -> we bail to the runner; defense-in-depth is still there
+    // because the runner has its own validation. Keeps unparseable shapes
+    // from being silently allowed by us.
+    const runner = mkRunner();
+    const ctx = makeCtx({
+      opsCommandRunner: runner,
+      opsConnectors: [{ id: 'k8s-prod', name: 'k8s-prod', namespaces: ['app'], capabilities: [] }],
+    });
+    const r = await handleOpsRunCommand(ctx, {
+      connectorId: 'k8s-prod',
+      command: 'kubectl get pods | grep web',
+      intent: 'read',
+    });
+    // we don't gate when parse fails — runner is reached
+    expect(r).toBe('ran');
+  });
+});

--- a/packages/agent-core/src/agent/handlers/ops.ts
+++ b/packages/agent-core/src/agent/handlers/ops.ts
@@ -1,5 +1,60 @@
+import { checkKubectl } from '@agentic-obs/adapters';
 import type { ActionContext } from './_context.js';
 import { withToolEventBoundary } from './_shared.js';
+
+/**
+ * Best-effort argv parser for a `kubectl ...` command string.
+ *
+ * The `ops.run_command` tool accepts the command as one user-facing string,
+ * so we don't have a structured argv at the handler boundary. We split
+ * conservatively (whitespace, single+double quotes) to feed the P6
+ * allowlist; any parse failure falls through to the runner, which is
+ * still trusted to validate at its layer.
+ *
+ * Rules:
+ *   - leading "kubectl" is dropped if present
+ *   - "$(...)" / backticks / pipes / redirects are NOT supported and
+ *     produce an empty argv (caller treats that as "couldn't validate"
+ *     and lets the runner reject it).
+ */
+export function parseKubectlCommandString(command: string): string[] {
+  const trimmed = command.trim();
+  if (!trimmed) return [];
+  if (/[`$|;&><]/.test(trimmed)) return [];
+
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < trimmed.length) {
+    const ch = trimmed[i] ?? '';
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      let j = i + 1;
+      let buf = '';
+      while (j < trimmed.length && trimmed[j] !== quote) {
+        buf += trimmed[j];
+        j++;
+      }
+      if (j >= trimmed.length) return []; // unterminated quote
+      tokens.push(buf);
+      i = j + 1;
+      continue;
+    }
+    let j = i;
+    let buf = '';
+    while (j < trimmed.length && !/\s/.test(trimmed[j] ?? '')) {
+      buf += trimmed[j];
+      j++;
+    }
+    tokens.push(buf);
+    i = j;
+  }
+  if (tokens[0] === 'kubectl') tokens.shift();
+  return tokens;
+}
 
 export async function handleOpsRunCommand(
   ctx: ActionContext,
@@ -28,13 +83,34 @@ export async function handleOpsRunCommand(
       }
 
       const connectors = ctx.opsConnectors ?? await ctx.opsCommandRunner.listConnectors?.();
-      if (Array.isArray(connectors)) {
-        if (connectors.length === 0) {
+      const connectorList = Array.isArray(connectors) ? connectors : undefined;
+      if (connectorList) {
+        if (connectorList.length === 0) {
           return 'No Ops connectors are configured. Connect a Kubernetes/Ops integration before querying cluster state.';
         }
-        const selected = connectors.find((connector) => connector.id === connectorId);
+        const selected = connectorList.find((connector) => connector.id === connectorId);
         if (!selected) {
-          return `Ops connector "${connectorId}" is not configured. Choose one of: ${connectors.map((connector) => connector.id).join(', ')}.`;
+          return `Ops connector "${connectorId}" is not configured. Choose one of: ${connectorList.map((connector) => connector.id).join(', ')}.`;
+        }
+
+        // Defense-in-depth gate (P2 / T2.3 + T2.5):
+        //
+        // When the agent declares intent="read", the command argv MUST also
+        // be on the P6 read-allowlist. Without this gate, a model could
+        // smuggle a write through with intent="read" and the runner is the
+        // only line of defense — we want a second one at the handler so the
+        // shape of the command can't lie about its effect.
+        //
+        // Best-effort: a parse failure falls through and the runner takes
+        // over. A successful parse that fails the allowlist is rejected.
+        if (intent === 'read') {
+          const argv = parseKubectlCommandString(command);
+          if (argv.length > 0) {
+            const decision = checkKubectl(argv, 'read', selected.namespaces ?? []);
+            if (!decision.allow) {
+              return `ops.run_command rejected: ${decision.reason}. Use intent="propose" for writes, and only on a connector configured for the target namespace.`;
+            }
+          }
         }
       }
 

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -147,6 +147,9 @@ The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not
 - Specific numbers inline: not "high", but "120ms vs <50ms baseline".
 - Complete paragraphs, not bullet lists.
 
+### When a cluster connector is attached
+If the \`# Ops Integrations\` section above lists a connector, use \`ops.run_command\` with \`intent="read"\` to inspect cluster state for service-side symptoms — pod status, recent events, logs from suspect pods, etc. Stick to the connector's allowed namespaces. NEVER use \`intent="propose"\` or \`intent="execute_approved"\` from an investigation turn — propose fixes via \`remediation_plan.create\` after the investigation completes.
+
 ### Mechanics
 - Use \`investigation.add_section({type: "text"})\` for prose; \`{type: "evidence"}\` to attach the chart that supports a paragraph. Section order = display order.
 - Choose your own headings (or none). Don't reach for "## Initial Assessment" / "## Hypothesis Testing" by reflex — fit the heading to what you're actually saying.


### PR DESCRIPTION
Phase 2 — see commit message for the full spec.

Closes #42 (T2.1) #43 (T2.2 — implicit) #44 (T2.3) #45 (T2.4) #46 (T2.5) #47 (T2.6). Tracks under #94.

## Two changes, both surgical

1. **Prompt nudge** (3 lines added to the Investigation section of `orchestrator-prompt.ts`): when an Ops connector is listed, the agent should use `ops.run_command(intent='read')` for cluster-side context. Explicit ban on `intent='propose'/'execute_approved'` from an investigation turn — those belong to the plan flow.

2. **Defense-in-depth gate** in `handlers/ops.ts`: when `intent='read'`, parse the command string into argv and run it through P6's `checkKubectl(argv, 'read', connector.namespaces)`. Any write verb, permanent-deny verb (`exec/cp/port-forward/proxy/attach/auth can-i --as`), or out-of-allowlist namespace is refused before the runner is reached.

## Architecture self-check

| Concern | Decision |
|---|---|
| New module? | No. Parser + gate live next to the existing handler in `handlers/ops.ts`. Prompt change is one section inside the existing Investigation block. |
| Duplicated logic? | No. `parseKubectlCommandString` (string → argv) is distinct from P6's `parseKubectlArgv` (argv → structured). The allowlist itself is reused via `checkKubectl` from `@agentic-obs/adapters`. |
| Conditional tool registration (T2.2)? | Not needed. `ops.run_command` is already always-on; the prompt + handler gate are sufficient — registering it conditionally would split the tool surface and complicate downstream code. |
| Dead code? | I drafted a `connector-helpers.ts` module during development with helpers no caller needed. Deleted before commit. |
| Legacy code touched? | None. |

## Tests

10 new cases. Full suite: **1423 passed / 16 skipped**. Lint clean (only 4 pre-existing warnings in dashboard/query.ts unrelated to this PR).

## Reverting

Single commit, two files modified + one test file added. No callers depend on new exports. `git revert <sha>`.