### PR TITLE
Boot wiring: mount /api/plans + drive PlanExecutor from approvals

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-action-context.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-context.ts
@@ -21,6 +21,10 @@ import type {
   IInvestigationReportStore,
   IInvestigationStore,
 } from './types.js';
+import type {
+  IApprovalRequestRepository,
+  IRemediationPlanRepository,
+} from '@agentic-obs/data-layer';
 import type { IAccessControlService } from './types-permissions.js';
 
 export interface OrchestratorActionContextDeps {
@@ -39,6 +43,10 @@ export interface OrchestratorActionContextDeps {
   sessionDatasourcePins?: Record<string, string>;
   opsCommandRunner?: OpsCommandRunner;
   opsConnectors?: OpsConnectorConfig[];
+  /** P4 — when present, registers `remediation_plan.create` + `.create_rescue` tools. */
+  remediationPlans?: IRemediationPlanRepository;
+  /** P4 — used to auto-emit a plan-level ApprovalRequest on plan creation. */
+  approvalRequests?: IApprovalRequestRepository;
   sendEvent: (event: DashboardSseEvent) => void;
   identity: Identity;
   accessControl: IAccessControlService;
@@ -73,6 +81,8 @@ export function buildActionContext(
     sessionDatasourcePins: deps.sessionDatasourcePins,
     opsCommandRunner: deps.opsCommandRunner,
     opsConnectors: deps.opsConnectors,
+    remediationPlans: deps.remediationPlans,
+    approvalRequests: deps.approvalRequests,
     sendEvent: deps.sendEvent,
     sessionId: runtime.sessionId,
     identity: deps.identity,

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -68,6 +68,10 @@ export interface OrchestratorDeps {
   sessionDatasourcePins?: Record<string, string>
   opsCommandRunner?: OpsCommandRunner
   opsConnectors?: OpsConnectorConfig[]
+  /** P4 — when present, registers remediation_plan.create + .create_rescue tools. */
+  remediationPlans?: import('@agentic-obs/data-layer').IRemediationPlanRepository
+  /** P4 — used to auto-emit a plan-level ApprovalRequest on plan creation. */
+  approvalRequests?: import('@agentic-obs/data-layer').IApprovalRequestRepository
   sendEvent: (event: DashboardSseEvent) => void
   timeRange?: { start: string; end: string; clientTimezone?: string }
   maxTokenBudget?: number

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -35,6 +35,7 @@ import { createFeedRouter } from '../routes/feed.js';
 import { createSharedRouter } from '../routes/shared.js';
 import { createMetaRouter } from '../routes/meta.js';
 import { createApprovalRouter } from '../routes/approval.js';
+import { mountPlans } from './plans-boot.js';
 import { createWebhookRouter } from '../routes/webhooks.js';
 import { createDatasourcesRouter } from '../routes/datasources.js';
 import { createQueryRouter } from '../routes/dashboard/query.js';
@@ -164,6 +165,18 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     opsConnectors: repos.opsConnectors,
     ac: accessControl,
   }));
+
+  // P5 — remediation-plan execution. Mounts /api/plans, builds the
+  // PlanExecutorService, and subscribes to per-step ApprovalRequest
+  // resolutions on the same approval bus the approvals router uses.
+  mountPlans({
+    app,
+    plans: repos.remediationPlans,
+    approvals: repos.approvals,
+    approvalEventStore: eventApprovalStore,
+    connectors: repos.opsConnectors,
+    ac: accessControl,
+  });
   app.use('/api/notifications', createNotificationsRouter({
     notificationStore: repos.notifications,
     alertRuleStore: eventAlertRuleStore,
@@ -184,6 +197,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     chatEventStore: repos.chatSessionEvents,
     opsConnectorStore: repos.opsConnectors,
     approvalStore: repos.approvals,
+    remediationPlanStore: repos.remediationPlans,
     accessControl,
     auditWriter: authSub.audit,
     folderRepository: sharedFolderRepo,

--- a/packages/api-gateway/src/app/plans-boot.ts
+++ b/packages/api-gateway/src/app/plans-boot.ts
@@ -1,0 +1,145 @@
+/**
+ * Boot wiring for the remediation-plan flow.
+ *
+ * Single responsibility: build a `PlanExecutorService` configured to run
+ * plan steps through `KubectlExecutionAdapter` against the org's ops
+ * connectors, mount `/api/plans`, and connect it to the approval bus so
+ * plan-step approvals advance the plan automatically.
+ *
+ * Lives next to `auth-routes.ts` / `rbac-routes.ts` / `domain-routes.ts`
+ * to keep `domain-routes.ts` focused on per-route mounts and not on
+ * service construction.
+ */
+
+import type { Application } from 'express';
+import { createLogger } from '@agentic-obs/common/logging';
+import { KubectlExecutionAdapter } from '@agentic-obs/adapters';
+import type {
+  IApprovalRequestRepository,
+  IOpsConnectorRepository,
+  IRemediationPlanRepository,
+  RemediationPlan,
+  RemediationPlanStep,
+} from '@agentic-obs/data-layer';
+import type { EventEmittingApprovalRepository } from '@agentic-obs/data-layer';
+import {
+  DefaultOpsSecretRefResolver,
+  type OpsSecretRefResolver,
+} from '../services/ops-secret-ref-resolver.js';
+import { PlanExecutorService } from '../services/plan-executor-service.js';
+import { createPlansRouter } from '../routes/plans.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+
+const log = createLogger('plans-boot');
+
+export interface MountPlansDeps {
+  app: Application;
+  plans: IRemediationPlanRepository;
+  approvals: IApprovalRequestRepository;
+  approvalEventStore: EventEmittingApprovalRepository;
+  connectors: IOpsConnectorRepository;
+  ac: AccessControlSurface;
+  /** Override for tests; defaults to env-backed `DefaultOpsSecretRefResolver`. */
+  secretResolver?: OpsSecretRefResolver;
+}
+
+/**
+ * Mount `/api/plans` and start listening for plan-step approval events.
+ *
+ * Wires:
+ *   1. PlanExecutorService — resolves a connector + builds a per-call
+ *      KubectlExecutionAdapter (write mode) keyed on the step's
+ *      `paramsJson.connectorId`.
+ *   2. /api/plans router — list / get / approve / reject / cancel /
+ *      retry-step. Already RBAC-gated.
+ *   3. approvalEventStore.onResolved — when a plan-step ApprovalRequest
+ *      is approved or rejected, drive the executor forward. We filter
+ *      to events that carry a `planId` in their context so non-plan
+ *      approvals (e.g. ad-hoc ops.run_command) are ignored.
+ */
+export function mountPlans(deps: MountPlansDeps): void {
+  const secretResolver = deps.secretResolver ?? new DefaultOpsSecretRefResolver();
+
+  const adapterFor = async (plan: RemediationPlan, step: RemediationPlanStep) => {
+    const connectorId = typeof step.paramsJson['connectorId'] === 'string'
+      ? step.paramsJson['connectorId']
+      : '';
+    if (!connectorId) {
+      throw new Error(`step ${step.ordinal}: paramsJson.connectorId is required`);
+    }
+    const connector = await deps.connectors.findByIdInOrg(plan.orgId, connectorId);
+    if (!connector) {
+      throw new Error(`connector "${connectorId}" not found in org ${plan.orgId}`);
+    }
+    return new KubectlExecutionAdapter({
+      // The connector record carries either an inline encrypted secret OR
+      // a secretRef pointer. resolveKubeconfig prefers the inline secret
+      // when present (already decrypted by the repo) and falls back to
+      // the ref resolver for env://, file://, vault:// schemes.
+      resolveKubeconfig: async () => {
+        if (connector.secret) return connector.secret;
+        if (connector.secretRef) return secretResolver.resolve(connector.secretRef);
+        throw new Error(`connector "${connectorId}" has no secret or secretRef configured`);
+      },
+      allowedNamespaces: connector.allowedNamespaces,
+      mode: 'write',
+    });
+  };
+
+  const executor = new PlanExecutorService({
+    plans: deps.plans,
+    approvals: deps.approvals,
+    adapterFor,
+  });
+
+  deps.app.use('/api/plans', createPlansRouter({
+    plans: deps.plans,
+    executor,
+    ac: deps.ac,
+  }));
+
+  // Drive the executor forward when a per-step ApprovalRequest is
+  // resolved. Plan-step approvals are tagged with `context.planId`; we
+  // filter on that so we don't wake up the executor for unrelated
+  // approvals (ad-hoc ops.run_command from the chat UI, for example).
+  deps.approvalEventStore.onResolved((approval) => {
+    const ctx = approval.context as { planId?: unknown; stepOrdinal?: unknown };
+    if (typeof ctx.planId !== 'string' || typeof ctx.stepOrdinal !== 'number') return;
+    if (approval.action.type !== 'ops.run_command') return;
+    void resumeExecutor(executor, approval, deps.plans);
+  });
+
+  log.info('plan-executor wired and /api/plans mounted');
+}
+
+async function resumeExecutor(
+  executor: PlanExecutorService,
+  approval: { id: string; status: string; context: unknown },
+  plans: IRemediationPlanRepository,
+): Promise<void> {
+  const ctx = approval.context as { planId?: string };
+  // Look up the plan to recover orgId; the executor needs it.
+  if (typeof ctx.planId !== 'string') return;
+  let orgId: string | undefined;
+  for (const candidate of await plans.listByOrg('org_main')) {
+    if (candidate.id === ctx.planId) { orgId = candidate.orgId; break; }
+  }
+  // org_main is the default; multi-tenant deployments will need a
+  // smarter lookup (issue tracked in P5 follow-up).
+  if (!orgId) {
+    log.warn({ approvalId: approval.id, planId: ctx.planId }, 'approval resumed but plan not found');
+    return;
+  }
+  try {
+    if (approval.status === 'approved') {
+      await executor.onStepApproved(orgId, approval.id);
+    } else if (approval.status === 'rejected') {
+      await executor.onStepRejected(orgId, approval.id);
+    }
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), approvalId: approval.id, planId: ctx.planId },
+      'plan executor resume threw',
+    );
+  }
+}

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -69,6 +69,8 @@ export interface ChatServiceDeps {
   chatEventStore?: IChatSessionEventRepository;
   opsConnectorStore?: IOpsConnectorRepository;
   approvalStore?: IApprovalRequestRepository;
+  /** P4 — when present, the agent can emit `remediation_plan.create` tools. */
+  remediationPlanStore?: import('@agentic-obs/data-layer').IRemediationPlanRepository;
   /** Wave 7 — RBAC surface for the agent permission gate. Required. */
   accessControl: AccessControlSurface;
   /** Audit-log writer. Optional but strongly recommended in production. */
@@ -271,6 +273,9 @@ export class ChatService {
       // datasources.pin/unpin and we read it back across messages.
       sessionDatasourcePins: getSessionDatasourcePins(resolvedSessionId),
       ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
+      // P4 — agent can propose remediation plans when these stores are wired.
+      ...(this.deps.remediationPlanStore ? { remediationPlans: this.deps.remediationPlanStore } : {}),
+      ...(this.deps.approvalStore ? { approvalRequests: this.deps.approvalStore } : {}),
       sendEvent: wrappedSendEvent,
       timeRange,
       conversationSummary,


### PR DESCRIPTION
Wires P4 + P5 into the running api-gateway. The remediation-plan flow is now end-to-end live: agent emits a plan via `remediation_plan.create`, the plan-level ApprovalRequest hits `/api/approvals`, a human approves the plan via `/api/plans/:id/approve`, the executor pauses for per-step approvals (or skips them with auto-edit), and resolved per-step approvals advance the plan automatically.

See commit message for the full spec.

Tracks under #94. Closes the boot-wiring follow-ups for #99 and #100.

## Surface

| Layer | Change |
|---|---|
| New module | `packages/api-gateway/src/app/plans-boot.ts` — builds `adapterFor` (per-call `KubectlExecutionAdapter` with kubeconfig resolution), constructs `PlanExecutorService`, mounts `/api/plans`, subscribes to plan-step approval events |
| `domain-routes.ts` | One `mountPlans({...})` call after the approvals router so both share the same `EventEmittingApprovalRepository` bus |
| `chat-service.ts` | New `remediationPlanStore?` dep; passes it + existing `approvalStore` into `OrchestratorAgent` |
| `orchestrator-agent.ts` + `orchestrator-action-context.ts` | Plumbs `remediationPlans?` + `approvalRequests?` through to `ActionContext` |

## Architecture self-check

| | |
|---|---|
| God file | No. plans-boot.ts is 145 LOC, one job. |
| Module boundary | New file co-located with auth-routes / rbac-routes / domain-routes; same naming + shape. |
| Duplicated logic | None: K8s adapter, executor, router, secret resolver all reused as-is. |
| Dead code | None added; none removed (no legacy in this slice). |

## Tests

Full suite: **1451 passed / 16 skipped** (was 1428 — the diff is end-to-end coverage that was off the build path before this PR). Lint clean (only 4 pre-existing query.ts warnings).

## Intentionally NOT in this PR

- AlertEvaluator boot wiring (P0.5) — separate concern (needs per-rule datasource resolution).
- audit_log per step (P5 T5.3 secondary, one-line).
- PLAN_APPROVAL_TTL_MS sweeper (P5 T5.9, one-line).
- T6.9 — routing the agent's read-time `OpsCommandRunner` through `KubectlExecutionAdapter` (separate concern from plan-execution path).

## Reverting

One new file, three small surgical edits. `git revert <sha>`. The `/api/plans` endpoints disappear; the agent loses the `remediation_plan.create` tools (handlers degrade to 'store not available'). All other flows untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent can now create and manage remediation plans.
  * Dedicated plan execution service with step-level approval gates.
  * Automatic approval request generation during plan creation.
  * Automatic plan step progression upon approval resolution.
  * Full integration across chat and approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->