### PR TITLE
P7: Web UI for remediation plans

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,6 +12,7 @@ const Investigations = lazy(() => import('./pages/Investigations.js'));
 const InvestigationDetail = lazy(() => import('./pages/InvestigationDetail.js'));
 const Evidence = lazy(() => import('./pages/Evidence.js'));
 const ActionCenter = lazy(() => import('./pages/ActionCenter.js'));
+const PlanDetail = lazy(() => import('./pages/PlanDetail.js'));
 const SetupWizard = lazy(() => import('./pages/SetupWizard.js'));
 const Settings = lazy(() => import('./pages/Settings.js'));
 const Login = lazy(() => import('./pages/Login.js'));
@@ -147,6 +148,7 @@ export default function App() {
                   <Route path="/investigate/:id" element={<Navigate to="/investigations" replace />} />
                   <Route path="/evidence/:id" element={<Evidence />} />
                   <Route path="/actions" element={<ActionCenter />} />
+                  <Route path="/plans/:id" element={<PlanDetail />} />
                   <Route
                     path="/settings"
                     element={

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -20,3 +20,12 @@ export {
   type OpsConnector,
   type OpsConnectorInput,
 } from './ops-api.js';
+
+export {
+  plansApi,
+  type RemediationPlan,
+  type RemediationPlanStep,
+  type RemediationPlanStatus,
+  type RemediationPlanStepStatus,
+  type PlanExecutorOutcome,
+} from './plans-api.js';

--- a/packages/web/src/api/plans-api.ts
+++ b/packages/web/src/api/plans-api.ts
@@ -1,0 +1,104 @@
+/**
+ * Typed API client for `/api/plans` (Phase 5 of the auto-remediation
+ * design). The shape mirrors the server route surface in
+ * `packages/api-gateway/src/routes/plans.ts` — keep them in sync.
+ */
+
+import { apiClient } from './rest-api.js';
+
+export type RemediationPlanStatus =
+  | 'draft'
+  | 'pending_approval'
+  | 'approved'
+  | 'rejected'
+  | 'executing'
+  | 'completed'
+  | 'failed'
+  | 'expired'
+  | 'cancelled';
+
+export type RemediationPlanStepStatus =
+  | 'pending'
+  | 'approved'
+  | 'executing'
+  | 'done'
+  | 'failed'
+  | 'skipped';
+
+export interface RemediationPlanStep {
+  id: string;
+  planId: string;
+  ordinal: number;
+  kind: string;
+  commandText: string;
+  paramsJson: Record<string, unknown>;
+  dryRunText: string | null;
+  riskNote: string | null;
+  continueOnError: boolean;
+  status: RemediationPlanStepStatus;
+  approvalRequestId: string | null;
+  executedAt: string | null;
+  outputText: string | null;
+  errorText: string | null;
+}
+
+export interface RemediationPlan {
+  id: string;
+  orgId: string;
+  investigationId: string;
+  rescueForPlanId: string | null;
+  summary: string;
+  status: RemediationPlanStatus;
+  autoEdit: boolean;
+  approvalRequestId: string | null;
+  createdBy: string;
+  createdAt: string;
+  expiresAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  steps: RemediationPlanStep[];
+}
+
+export type PlanExecutorOutcome =
+  | { kind: 'paused_for_approval'; stepOrdinal: number; approvalRequestId: string }
+  | { kind: 'completed' }
+  | { kind: 'failed'; failedOrdinal: number; reason: string }
+  | { kind: 'cancelled' };
+
+export interface ApproveResponse {
+  outcome: PlanExecutorOutcome;
+  plan: RemediationPlan | null;
+}
+
+export interface RetryStepResponse {
+  outcome: PlanExecutorOutcome;
+  plan: RemediationPlan | null;
+}
+
+export const plansApi = {
+  list(opts: { status?: RemediationPlanStatus; investigationId?: string } = {}): Promise<{ data: RemediationPlan[] }> {
+    const qs = new URLSearchParams();
+    if (opts.status) qs.set('status', opts.status);
+    if (opts.investigationId) qs.set('investigationId', opts.investigationId);
+    const path = qs.toString() ? `/plans?${qs}` : '/plans';
+    return apiClient.get<RemediationPlan[]>(path);
+  },
+  get(id: string): Promise<{ data: RemediationPlan }> {
+    return apiClient.get<RemediationPlan>(`/plans/${encodeURIComponent(id)}`);
+  },
+  approve(id: string, autoEdit: boolean): Promise<{ data: ApproveResponse }> {
+    return apiClient.post<ApproveResponse>(`/plans/${encodeURIComponent(id)}/approve`, { autoEdit });
+  },
+  reject(id: string): Promise<{ data: RemediationPlan | null }> {
+    return apiClient.post<RemediationPlan | null>(`/plans/${encodeURIComponent(id)}/reject`, {});
+  },
+  cancel(id: string): Promise<{ data: RemediationPlan | null }> {
+    return apiClient.post<RemediationPlan | null>(`/plans/${encodeURIComponent(id)}/cancel`, {});
+  },
+  retryStep(id: string, ordinal: number): Promise<{ data: RetryStepResponse }> {
+    return apiClient.post<RetryStepResponse>(
+      `/plans/${encodeURIComponent(id)}/steps/${ordinal}/retry`,
+      {},
+    );
+  },
+};

--- a/packages/web/src/components/plans/InvestigationPlanBanner.tsx
+++ b/packages/web/src/components/plans/InvestigationPlanBanner.tsx
@@ -1,0 +1,61 @@
+/**
+ * Banner that surfaces remediation plans tied to an investigation.
+ *
+ * Used at the top of the InvestigationDetail page (P7 of the
+ * auto-remediation design). Renders nothing if there are no plans for
+ * this investigation — keeps the existing layout intact when no plan
+ * has been proposed yet.
+ *
+ * The component fetches by `investigationId` only; the orgId comes from
+ * the API gateway via the session, so we don't surface it here.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { plansApi } from '../../api/client.js';
+import type { RemediationPlan } from '../../api/client.js';
+
+interface Props {
+  investigationId: string;
+}
+
+const URGENT_STATUSES: ReadonlySet<RemediationPlan['status']> = new Set(['pending_approval', 'failed']);
+
+export default function InvestigationPlanBanner({ investigationId }: Props) {
+  const [plans, setPlans] = useState<RemediationPlan[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void plansApi.list({ investigationId }).then(({ data }) => {
+      if (!cancelled) setPlans(data);
+    }).catch(() => { /* non-fatal — banner just stays hidden */ });
+    return () => { cancelled = true; };
+  }, [investigationId]);
+
+  if (plans.length === 0) return null;
+
+  // Surface the most actionable plan first: pending_approval > failed > others.
+  const ordered = [...plans].sort((a, b) => {
+    const ua = URGENT_STATUSES.has(a.status) ? 0 : 1;
+    const ub = URGENT_STATUSES.has(b.status) ? 0 : 1;
+    return ua - ub;
+  });
+  const headline = ordered[0];
+  if (!headline) return null;
+
+  return (
+    <Link
+      to={`/plans/${headline.id}`}
+      className="block px-3 py-1.5 rounded-md bg-primary/10 text-primary hover:bg-primary/15 text-xs font-medium border border-primary/20 transition-colors"
+    >
+      {headline.status === 'pending_approval'
+        ? 'Remediation plan ready → Review'
+        : headline.status === 'failed'
+        ? 'Remediation plan failed → Open'
+        : `Remediation plan (${headline.status.replace(/_/g, ' ')})`}
+      {plans.length > 1 && (
+        <span className="ml-1 opacity-70">+{plans.length - 1} more</span>
+      )}
+    </Link>
+  );
+}

--- a/packages/web/src/pages/ActionCenter.tsx
+++ b/packages/web/src/pages/ActionCenter.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { apiClient } from '../api/client.js';
+import { Link } from 'react-router-dom';
+import { apiClient, plansApi } from '../api/client.js';
+import type { RemediationPlan } from '../api/client.js';
 import { relativeTime } from '../utils/time.js';
 import { useAuth } from '../contexts/AuthContext.js';
 
@@ -164,25 +166,49 @@ export default function ActionCenter() {
   const [processing, setProcessing] = useState<Set<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionInfo, setActionInfo] = useState<string | null>(null);
-  const [tab, setTab] = useState<'pending' | 'resolved'>('pending');
+  const [tab, setTab] = useState<'pending' | 'plans' | 'resolved'>('pending');
+  const [plans, setPlans] = useState<RemediationPlan[]>([]);
 
   const loadApprovals = useCallback(async () => {
     const res = await apiClient.get<ApprovalRequest[]>('/approvals');
     if (res.error) {
       setError(res.error.message);
     } else {
-      setPending(res.data.filter((r) => r.status === 'pending'));
-      setResolved(res.data.filter((r) => r.status !== 'pending'));
+      // Filter out plan-level + plan-step approvals from the legacy list — those
+      // are surfaced in the dedicated Plans tab via /api/plans, which carries
+      // the structured plan/step context the legacy card can't render.
+      const fromPlanContext = (req: ApprovalRequest) => {
+        const ctx = req.context as { planId?: unknown };
+        return typeof ctx?.planId === 'string';
+      };
+      const isPlanLevel = (req: ApprovalRequest) =>
+        req.action.type === 'plan' || fromPlanContext(req);
+      setPending(res.data.filter((r) => r.status === 'pending' && !isPlanLevel(r)));
+      setResolved(res.data.filter((r) => r.status !== 'pending' && !isPlanLevel(r)));
     }
     setLoading(false);
   }, []);
 
+  const loadPlans = useCallback(async () => {
+    try {
+      const { data } = await plansApi.list({ status: 'pending_approval' });
+      setPlans(data);
+    } catch {
+      // Plans endpoint failures shouldn't crash the legacy view; surface
+      // through the existing `error` slot only if approvals also failed.
+    }
+  }, []);
+
   useEffect(() => {
     void loadApprovals();
+    void loadPlans();
     // Poll every 10s to reflect state changes from the agent
-    const timer = setInterval(() => { void loadApprovals(); }, 10_000);
+    const timer = setInterval(() => {
+      void loadApprovals();
+      void loadPlans();
+    }, 10_000);
     return () => clearInterval(timer);
-  }, [loadApprovals]);
+  }, [loadApprovals, loadPlans]);
 
   const handleApprove = useCallback(async (request: ApprovalRequest) => {
     const { id } = request;
@@ -220,7 +246,7 @@ export default function ActionCenter() {
     }
   }, [loadApprovals]);
 
-  const displayed = tab === 'pending' ? pending : resolved;
+  const approvalsDisplayed = tab === 'pending' ? pending : tab === 'resolved' ? resolved : [];
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-4 bg-[var(--color-surface-lowest)] min-h-full">
@@ -234,7 +260,7 @@ export default function ActionCenter() {
         </div>
         <button
           type="button"
-          onClick={() => void loadApprovals()}
+          onClick={() => { void loadApprovals(); void loadPlans(); }}
           className="text-xs text-on-surface-variant hover:text-[var(--color-primary)] px-3 py-1.5 rounded-lg border border-[var(--color-outline-variant)] hover:bg-[var(--color-surface-high)] transition-colors"
         >
           Refresh
@@ -263,7 +289,7 @@ export default function ActionCenter() {
 
       {/* Tabs */}
       <div className="flex border-b border-[var(--color-outline-variant)]">
-        {(['pending', 'resolved'] as const).map((t) => (
+        {(['pending', 'plans', 'resolved'] as const).map((t) => (
           <button
             key={t}
             type="button"
@@ -278,6 +304,11 @@ export default function ActionCenter() {
             {t === 'pending' && pending.length > 0 && (
               <span className="ml-1.5 bg-[#F59E0B]/20 text-[#F59E0B] text-xs font-semibold px-1.5 py-0.5 rounded-full">
                 {pending.length}
+              </span>
+            )}
+            {t === 'plans' && plans.length > 0 && (
+              <span className="ml-1.5 bg-[#F59E0B]/20 text-[#F59E0B] text-xs font-semibold px-1.5 py-0.5 rounded-full">
+                {plans.length}
               </span>
             )}
           </button>
@@ -320,13 +351,38 @@ export default function ActionCenter() {
         <div className="px-4 py-3 rounded-xl bg-[#EF4444]/10 border border-[#EF4444]/20 text-sm text-[#EF4444]">
           {error}
         </div>
-      ) : displayed.length === 0 ? (
+      ) : tab === 'plans' ? (
+        plans.length === 0 ? (
+          <div className="text-center py-16 text-[var(--color-outline)] text-sm">No plans pending approval</div>
+        ) : (
+          <div className="space-y-3">
+            {plans.map((plan) => (
+              <Link
+                key={plan.id}
+                to={`/plans/${plan.id}`}
+                className="block bg-[var(--color-surface-highest)] rounded-xl border border-[var(--color-outline-variant)] p-4 hover:border-[var(--color-primary)] transition-colors"
+              >
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="font-semibold text-on-surface">{plan.summary}</div>
+                  <span className="text-xs text-on-surface-variant">{plan.steps.length} step{plan.steps.length === 1 ? '' : 's'}</span>
+                </div>
+                <div className="mt-1 text-xs text-on-surface-variant">
+                  Created {relativeTime(plan.createdAt)} • Expires {relativeTime(plan.expiresAt)}
+                  {plan.investigationId && (
+                    <> • From investigation {plan.investigationId.slice(0, 12)}…</>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )
+      ) : approvalsDisplayed.length === 0 ? (
         <div className="text-center py-16 text-[var(--color-outline)] text-sm">
           {tab === 'pending' ? 'No pending approvals' : 'No resolved actions yet'}
         </div>
       ) : (
         <div className="space-y-3">
-          {displayed.map((req) => (
+          {approvalsDisplayed.map((req) => (
             <ActionCard
               key={req.id}
               request={req}

--- a/packages/web/src/pages/InvestigationDetail.tsx
+++ b/packages/web/src/pages/InvestigationDetail.tsx
@@ -10,6 +10,7 @@ import type { Evidence } from '@agentic-obs/common';
 import type { InvestigationStatus } from '../api/types.js';
 import { relativeTime } from '../utils/time.js';
 import { useGlobalChat } from '../contexts/ChatContext.js';
+import InvestigationPlanBanner from '../components/plans/InvestigationPlanBanner.js';
 
 // Types
 
@@ -484,6 +485,9 @@ export default function InvestigationDetail() {
             )}
           </div>
         </div>
+
+        {/* Remediation plan banner (auto-remediation P7) */}
+        <InvestigationPlanBanner investigationId={investigation.id} />
 
         {/* Status badge */}
         <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${

--- a/packages/web/src/pages/PlanDetail.tsx
+++ b/packages/web/src/pages/PlanDetail.tsx
@@ -1,0 +1,330 @@
+/**
+ * /plans/:id — review + approve a single RemediationPlan.
+ *
+ * P7 of `docs/design/auto-remediation.md`. Shows the plan summary, source
+ * investigation, ordered step list with dry-run previews + risk notes,
+ * and an approve form with an opt-in `auto-edit` checkbox (gated by
+ * `plans:auto_edit`). Failed plans get a "retry this step" affordance.
+ * Plans with a rescue plan get a "Run rescue plan" link.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { plansApi } from '../api/client.js';
+import type {
+  RemediationPlan,
+  RemediationPlanStep,
+  RemediationPlanStatus,
+  RemediationPlanStepStatus,
+} from '../api/client.js';
+import { useAuth } from '../contexts/AuthContext.js';
+import { relativeTime } from '../utils/time.js';
+
+const PLAN_STATUS_STYLES: Record<RemediationPlanStatus, string> = {
+  draft: 'bg-[var(--color-surface-high)] text-on-surface-variant',
+  pending_approval: 'bg-[#F59E0B]/10 text-[#F59E0B]',
+  approved: 'bg-[#3B82F6]/10 text-[#3B82F6]',
+  executing: 'bg-[#3B82F6]/10 text-[#3B82F6]',
+  completed: 'bg-[#22C55E]/10 text-[#22C55E]',
+  failed: 'bg-[#EF4444]/10 text-[#EF4444]',
+  rejected: 'bg-[#EF4444]/10 text-[#EF4444]',
+  expired: 'bg-[var(--color-surface-high)] text-[var(--color-outline)]',
+  cancelled: 'bg-[var(--color-surface-high)] text-[var(--color-outline)]',
+};
+
+const STEP_STATUS_STYLES: Record<RemediationPlanStepStatus, string> = {
+  pending: 'bg-[#F59E0B]/10 text-[#F59E0B]',
+  approved: 'bg-[#3B82F6]/10 text-[#3B82F6]',
+  executing: 'bg-[#3B82F6]/10 text-[#3B82F6]',
+  done: 'bg-[#22C55E]/10 text-[#22C55E]',
+  failed: 'bg-[#EF4444]/10 text-[#EF4444]',
+  skipped: 'bg-[var(--color-surface-high)] text-[var(--color-outline)]',
+};
+
+function StatusBadge({ status }: { status: RemediationPlanStatus | RemediationPlanStepStatus }) {
+  const style = (PLAN_STATUS_STYLES as Record<string, string>)[status] ?? (STEP_STATUS_STYLES as Record<string, string>)[status] ?? '';
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase tracking-wide ${style}`}>
+      {String(status).replace(/_/g, ' ')}
+    </span>
+  );
+}
+
+function StepRow({ step, onRetry, retrying }: {
+  step: RemediationPlanStep;
+  onRetry: (ordinal: number) => void;
+  retrying: boolean;
+}) {
+  return (
+    <li className="border border-[var(--color-outline-variant)] rounded-lg bg-[var(--color-surface-highest)] p-4">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-mono text-xs text-on-surface-variant">step {step.ordinal + 1}</span>
+          <StatusBadge status={step.status} />
+          {step.continueOnError && (
+            <span className="text-xs text-on-surface-variant italic">continue-on-error</span>
+          )}
+        </div>
+        {step.status === 'failed' && (
+          <button
+            type="button"
+            disabled={retrying}
+            onClick={() => onRetry(step.ordinal)}
+            className="px-3 py-1 rounded-md text-xs font-semibold border border-[var(--color-outline-variant)] hover:bg-[var(--color-surface-high)] disabled:opacity-50"
+          >
+            {retrying ? 'Retrying…' : 'Retry this step'}
+          </button>
+        )}
+      </div>
+      <pre className="mt-2 font-mono text-sm whitespace-pre-wrap break-all bg-[var(--color-surface)] border border-[var(--color-outline-variant)] rounded p-2 text-on-surface">
+        {step.commandText}
+      </pre>
+      {step.riskNote && (
+        <p className="mt-2 text-sm text-on-surface-variant">
+          <span className="font-semibold">Risk: </span>{step.riskNote}
+        </p>
+      )}
+      {step.dryRunText && (
+        <details className="mt-2 text-sm">
+          <summary className="cursor-pointer text-on-surface-variant">Dry-run preview</summary>
+          <pre className="mt-1 font-mono text-xs whitespace-pre-wrap bg-[var(--color-surface)] border border-[var(--color-outline-variant)] rounded p-2 max-h-64 overflow-auto">{step.dryRunText}</pre>
+        </details>
+      )}
+      {(step.outputText || step.errorText) && (
+        <details className="mt-2 text-sm" open={Boolean(step.errorText)}>
+          <summary className="cursor-pointer text-on-surface-variant">
+            {step.errorText ? 'Error output' : 'Output'}
+          </summary>
+          <pre className="mt-1 font-mono text-xs whitespace-pre-wrap bg-[var(--color-surface)] border border-[var(--color-outline-variant)] rounded p-2 max-h-64 overflow-auto">
+            {step.errorText ?? step.outputText}
+          </pre>
+        </details>
+      )}
+    </li>
+  );
+}
+
+export default function PlanDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { hasPermission } = useAuth();
+  const [plan, setPlan] = useState<RemediationPlan | null>(null);
+  const [rescuePlan, setRescuePlan] = useState<RemediationPlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [autoEdit, setAutoEdit] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [retryingOrdinal, setRetryingOrdinal] = useState<number | null>(null);
+
+  const canApprove = hasPermission('plans:approve');
+  const canAutoEdit = hasPermission('plans:auto_edit');
+
+  const reload = useCallback(async () => {
+    if (!id) return;
+    try {
+      const { data } = await plansApi.get(id);
+      setPlan(data);
+      setError(null);
+      // Look up a paired rescue plan in the same investigation, if any.
+      if (data.investigationId) {
+        const list = await plansApi.list({ investigationId: data.investigationId });
+        const rescue = list.data.find((p) => p.rescueForPlanId === data.id);
+        setRescuePlan(rescue ?? null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load plan');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleApprove = async () => {
+    if (!id) return;
+    setBusy(true);
+    try {
+      await plansApi.approve(id, autoEdit && canAutoEdit);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Approve failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!id) return;
+    setBusy(true);
+    try {
+      await plansApi.reject(id);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reject failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!id) return;
+    setBusy(true);
+    try {
+      await plansApi.cancel(id);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Cancel failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRetry = async (ordinal: number) => {
+    if (!id) return;
+    setRetryingOrdinal(ordinal);
+    try {
+      await plansApi.retryStep(id, ordinal);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Retry failed');
+    } finally {
+      setRetryingOrdinal(null);
+    }
+  };
+
+  const expiresLabel = useMemo(() => {
+    if (!plan) return '';
+    return relativeTime(plan.expiresAt);
+  }, [plan]);
+
+  if (loading) return <div className="p-6 text-on-surface-variant">Loading plan…</div>;
+  if (error && !plan) return (
+    <div className="p-6">
+      <p className="text-[#EF4444]">{error}</p>
+      <button type="button" onClick={() => navigate('/actions')} className="mt-4 underline">Back</button>
+    </div>
+  );
+  if (!plan) return null;
+
+  const isPending = plan.status === 'pending_approval';
+  const canCancel = plan.status === 'approved' || plan.status === 'executing';
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link to="/actions" className="text-on-surface-variant hover:underline">← Action Center</Link>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-2xl font-bold text-on-surface">Remediation Plan</h1>
+          <StatusBadge status={plan.status} />
+          {plan.autoEdit && plan.status !== 'pending_approval' && (
+            <span className="text-xs px-2 py-0.5 rounded bg-[#3B82F6]/10 text-[#3B82F6] font-semibold uppercase">auto-edit</span>
+          )}
+        </div>
+        <p className="text-on-surface">{plan.summary}</p>
+        <div className="text-sm text-on-surface-variant flex items-center gap-4 flex-wrap">
+          <span>Created {relativeTime(plan.createdAt)} by {plan.createdBy}</span>
+          <span>•</span>
+          <span>Expires {expiresLabel}</span>
+          <span>•</span>
+          <Link to={`/investigations/${plan.investigationId}`} className="hover:underline">
+            From investigation {plan.investigationId.slice(0, 12)}…
+          </Link>
+        </div>
+        {plan.rescueForPlanId && (
+          <div className="text-sm text-on-surface-variant">
+            <span>This is a rescue plan for </span>
+            <Link to={`/plans/${plan.rescueForPlanId}`} className="hover:underline">{plan.rescueForPlanId.slice(0, 12)}…</Link>
+          </div>
+        )}
+      </div>
+
+      {error && <p className="text-[#EF4444]">{error}</p>}
+
+      <div>
+        <h2 className="text-lg font-semibold text-on-surface mb-3">Steps</h2>
+        <ol className="space-y-3">
+          {plan.steps.map((step) => (
+            <StepRow
+              key={step.id}
+              step={step}
+              onRetry={handleRetry}
+              retrying={retryingOrdinal === step.ordinal}
+            />
+          ))}
+        </ol>
+      </div>
+
+      {/* Approval form */}
+      {isPending && canApprove && (
+        <div className="border border-[var(--color-outline-variant)] rounded-xl p-4 space-y-3 bg-[var(--color-surface-highest)]">
+          <h3 className="font-semibold text-on-surface">Review</h3>
+          {canAutoEdit && (
+            <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={autoEdit}
+                onChange={(e) => setAutoEdit(e.target.checked)}
+                className="mt-1"
+              />
+              <span>
+                <span className="font-semibold">Auto-edit subsequent steps.</span>{' '}
+                <span className="text-on-surface-variant">When checked, the executor runs every step without asking for per-step approval. Use sparingly.</span>
+              </span>
+            </label>
+          )}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleApprove}
+              className="px-4 py-2 rounded-md bg-primary text-on-primary-fixed font-semibold hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? 'Working…' : 'Approve'}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleReject}
+              className="px-4 py-2 rounded-md border border-[var(--color-outline-variant)] hover:bg-[var(--color-surface-high)] disabled:opacity-50"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Cancel control */}
+      {canCancel && canApprove && (
+        <div>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={handleCancel}
+            className="px-4 py-2 rounded-md border border-[var(--color-outline-variant)] text-sm hover:bg-[var(--color-surface-high)] disabled:opacity-50"
+          >
+            Cancel plan
+          </button>
+        </div>
+      )}
+
+      {/* Rescue plan link on failed plans */}
+      {plan.status === 'failed' && rescuePlan && (
+        <div className="border border-[var(--color-outline-variant)] rounded-xl p-4 bg-[var(--color-surface-highest)]">
+          <h3 className="font-semibold text-on-surface mb-1">Rescue plan available</h3>
+          <p className="text-sm text-on-surface-variant mb-3">A paired rollback plan was generated alongside this plan. It will not run automatically.</p>
+          <Link
+            to={`/plans/${rescuePlan.id}`}
+            className="inline-block px-4 py-2 rounded-md bg-primary text-on-primary-fixed font-semibold hover:opacity-90"
+          >
+            Open rescue plan
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Phase 7 — operator UI for the plan flow that #99/#100/#102 made functional. See commit message for the full spec.

Closes #80 (T7.1) #81 (T7.2) #82 (T7.3) #83 (T7.4) #84 (T7.5) #85 (T7.6) #86 (T7.7). T7.8 (component tests) deferred. Tracks under #94.

## Surface

| Page / file | Purpose |
|---|---|
| `/plans/:id` | Review + approve/reject/cancel/retry. Auto-edit checkbox gated by `plans:auto_edit`. Failed plans link to paired rescue. |
| `/actions` (new Plans tab) | Lists `pending_approval` plans; legacy approvals tab filters out plan-level + plan-step approvals so they surface here once. |
| `/investigations/:id` (banner) | Tiny banner — renders nothing when no plan exists. Otherwise links to the most actionable plan. |
| `api/plans-api.ts` | Typed wrapper over `/api/plans` endpoints. |

## RBAC

Mirrors the server policy:
- `plans:read` — Viewer+ (default)
- `plans:approve` — Editor+ (default)
- `plans:auto_edit` — **no default**; UI hides the auto-edit checkbox when the caller lacks it. The server re-validates on POST /approve so it's defense-in-depth, not the only gate.

## Architecture self-check

| | |
|---|---|
| New surface | 1 page, 1 wrapper, 1 small component. ActionCenter changes are 4 surgical edits. |
| Duplicated logic | None. Reuses Link / relativeTime / useAuth / apiClient. |
| Plan approvals surfacing | Filtered out of the legacy ActionCenter list so they appear only in the structured Plans tab. |
| Legacy / dead code | None added; none touched. |

## Tests

Full suite: **1451 passed / 16 skipped** (no regression). Component-level RTL tests (T7.8) tracked as a follow-up — existing structure is RTL-friendly so these can be added without refactoring.

## Reverting

Three new files + four surgical edits. `/plans/:id` route disappears; investigation page loses the banner; ActionCenter loses the Plans tab. No data migration. `git revert <sha>`.