### PR TITLE
P8: AutoInvestigationDispatcher (alert.fired → investigation)

### DIFF
--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  AutoInvestigationDispatcher,
+  buildAlertQuestion,
+} from './auto-investigation-dispatcher.js';
+import type { AlertFiredPayload } from './alert-evaluator-service.js';
+
+function basePayload(overrides: Partial<AlertFiredPayload> = {}): AlertFiredPayload {
+  return {
+    ruleId: 'rule-1',
+    ruleName: 'high-error-rate',
+    severity: 'high',
+    value: 0.12,
+    threshold: 0.05,
+    operator: '>',
+    labels: { team: 'web' },
+    firedAt: '2026-04-29T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('buildAlertQuestion', () => {
+  it('includes rule name, severity, condition, current value, and labels', () => {
+    const q = buildAlertQuestion(basePayload());
+    expect(q).toMatch(/Alert "high-error-rate"/);
+    expect(q).toMatch(/high/);
+    expect(q).toMatch(/value > 0.05/);
+    expect(q).toMatch(/current 0.12/);
+    expect(q).toMatch(/team=web/);
+    expect(q).toMatch(/Investigate the root cause/);
+  });
+  it('omits labels block when none are present', () => {
+    const q = buildAlertQuestion(basePayload({ labels: {} }));
+    expect(q).not.toMatch(/labels:/);
+  });
+});
+
+describe('AutoInvestigationDispatcher', () => {
+  let alertEvents: EventEmitter;
+  let now: Date;
+
+  beforeEach(() => {
+    alertEvents = new EventEmitter();
+    now = new Date('2026-04-29T00:00:00.000Z');
+  });
+
+  function mkDispatcher(spawn: ReturnType<typeof vi.fn>) {
+    return new AutoInvestigationDispatcher({
+      alertEvents,
+      runner: {
+        saTokens: { validateAndLookup: async () => null },
+        makeOrchestrator: () => ({} as never),
+      },
+      saToken: 'openobs_sa_test',
+      dedupMs: 60_000,
+      clock: () => now,
+      spawnAgent: spawn as unknown as typeof import('@agentic-obs/agent-core').runBackgroundAgent,
+    });
+  }
+
+  it('spawns one investigation per alert.fired', async () => {
+    const spawn = vi.fn().mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    d.subscribe();
+    alertEvents.emit('alert.fired', basePayload());
+    // listener is fire-and-forget; await microtasks
+    await new Promise((r) => setImmediate(r));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const args = spawn.mock.calls[0]?.[1] as { saToken: string; message: string };
+    expect(args.saToken).toBe('openobs_sa_test');
+    expect(args.message).toMatch(/high-error-rate/);
+  });
+
+  it('dedups same ruleId within the window', async () => {
+    const spawn = vi.fn().mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    await d.onAlertFired(basePayload());
+    await d.onAlertFired(basePayload());
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a second firing through after the dedup window expires', async () => {
+    const spawn = vi.fn().mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    await d.onAlertFired(basePayload());
+    now = new Date(now.getTime() + 61_000);
+    await d.onAlertFired(basePayload());
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats different ruleIds as independent', async () => {
+    const spawn = vi.fn().mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    await d.onAlertFired(basePayload({ ruleId: 'a' }));
+    await d.onAlertFired(basePayload({ ruleId: 'b' }));
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps running when one investigation throws', async () => {
+    const spawn = vi.fn()
+      .mockRejectedValueOnce(new Error('LLM down'))
+      .mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    await d.onAlertFired(basePayload({ ruleId: 'a' }));
+    await d.onAlertFired(basePayload({ ruleId: 'b' }));
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('subscribe is idempotent and unsubscribe stops further dispatches', async () => {
+    const spawn = vi.fn().mockResolvedValue('ok');
+    const d = mkDispatcher(spawn);
+    d.subscribe();
+    d.subscribe();
+    alertEvents.emit('alert.fired', basePayload());
+    await new Promise((r) => setImmediate(r));
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    d.unsubscribe();
+    alertEvents.emit('alert.fired', basePayload({ ruleId: 'rule-2' }));
+    await new Promise((r) => setImmediate(r));
+    expect(spawn).toHaveBeenCalledTimes(1); // still 1, unsubscribe worked
+  });
+});

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
@@ -1,0 +1,136 @@
+/**
+ * AutoInvestigationDispatcher — when a rule transitions into `firing`,
+ * automatically kick off an investigation that diagnoses why.
+ *
+ * Phase 8 of `docs/design/auto-remediation.md`. Subscribes to the
+ * AlertEvaluatorService's `alert.fired` event and dispatches a background
+ * orchestrator run via `runBackgroundAgent`. The agent runs as a
+ * service-account identity resolved from a configured SA token; it has
+ * no human-side capabilities (cannot approve plans, etc.).
+ *
+ * Dedup: same ruleId within the dedup window only spawns one
+ * investigation. v1 uses an in-memory LRU; multi-replica HA needs a
+ * persistent marker on the rule row — tracked as a follow-up.
+ *
+ * The dispatcher does NOT own the alert event source — it's handed an
+ * `AlertEvaluatorService` (or any EventEmitter that emits the
+ * `alert.fired` shape). Stop/start is just `subscribe()` + `unsubscribe()`,
+ * matching the lifecycle the api-gateway boot sequence expects.
+ */
+
+import type { EventEmitter } from 'node:events';
+import { createLogger } from '@agentic-obs/common/logging';
+import {
+  runBackgroundAgent,
+  type BackgroundRunnerDeps,
+} from '@agentic-obs/agent-core';
+import type { AlertFiredPayload } from './alert-evaluator-service.js';
+
+const log = createLogger('auto-investigation');
+
+/** Default dedup window if the caller doesn't supply one. */
+const DEFAULT_DEDUP_MS = 5 * 60 * 1000;
+
+export interface AutoInvestigationDispatcherOptions {
+  /** Source of `alert.fired` events. AlertEvaluatorService satisfies this. */
+  alertEvents: EventEmitter;
+  /** Service-account token resolver + orchestrator factory. */
+  runner: BackgroundRunnerDeps;
+  /** Raw SA token (`openobs_sa_...`) used to authenticate the auto-investigations. */
+  saToken: string;
+  /**
+   * Same ruleId firing within this window is deduped. Defaults to 5 minutes;
+   * pass `forDurationSec * 2 * 1000` for tighter alignment to the rule.
+   */
+  dedupMs?: number;
+  /** Override for tests. */
+  clock?: () => Date;
+  /**
+   * Override the spawned background-agent function — useful in tests so we
+   * don't have to stand up a real orchestrator. Defaults to
+   * `runBackgroundAgent`.
+   */
+  spawnAgent?: typeof runBackgroundAgent;
+}
+
+/** Compose a question string from an alert payload. */
+export function buildAlertQuestion(payload: AlertFiredPayload): string {
+  const opPretty = payload.operator;
+  const labelsBit = Object.keys(payload.labels).length > 0
+    ? ` (labels: ${Object.entries(payload.labels).map(([k, v]) => `${k}=${v}`).join(', ')})`
+    : '';
+  return [
+    `Alert "${payload.ruleName}" (${payload.severity}) is firing${labelsBit}.`,
+    `Condition: value ${opPretty} ${payload.threshold}; current ${payload.value}.`,
+    'Investigate the root cause and propose a fix if one is in scope.',
+  ].join(' ');
+}
+
+export class AutoInvestigationDispatcher {
+  private readonly listener: (payload: AlertFiredPayload) => void;
+  private readonly recent = new Map<string, number>(); // ruleId -> ms timestamp
+  private readonly dedupMs: number;
+  private readonly clock: () => Date;
+  private readonly spawnAgent: typeof runBackgroundAgent;
+  private subscribed = false;
+
+  constructor(private readonly opts: AutoInvestigationDispatcherOptions) {
+    this.dedupMs = opts.dedupMs ?? DEFAULT_DEDUP_MS;
+    this.clock = opts.clock ?? (() => new Date());
+    this.spawnAgent = opts.spawnAgent ?? runBackgroundAgent;
+    this.listener = (payload) => { void this.onAlertFired(payload); };
+  }
+
+  /** Begin listening. Idempotent — calling twice does not double-subscribe. */
+  subscribe(): void {
+    if (this.subscribed) return;
+    this.opts.alertEvents.on('alert.fired', this.listener);
+    this.subscribed = true;
+  }
+
+  unsubscribe(): void {
+    if (!this.subscribed) return;
+    this.opts.alertEvents.off('alert.fired', this.listener);
+    this.subscribed = false;
+  }
+
+  /**
+   * Handle one alert.fired event. Public for tests; production callers go
+   * through `subscribe()`.
+   */
+  async onAlertFired(payload: AlertFiredPayload): Promise<void> {
+    const now = this.clock().getTime();
+    const last = this.recent.get(payload.ruleId);
+    if (last !== undefined && now - last < this.dedupMs) {
+      log.debug({ ruleId: payload.ruleId, deltaMs: now - last }, 'auto-investigation deduped');
+      return;
+    }
+    this.recent.set(payload.ruleId, now);
+    this.gcRecent(now);
+
+    try {
+      const reply = await this.spawnAgent(this.opts.runner, {
+        saToken: this.opts.saToken,
+        message: buildAlertQuestion(payload),
+      });
+      log.info(
+        { ruleId: payload.ruleId, ruleName: payload.ruleName, replyHead: reply.slice(0, 120) },
+        'auto-investigation completed',
+      );
+    } catch (err) {
+      // Crash isolation: one failed investigation must not stop the
+      // dispatcher from handling future alerts.
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), ruleId: payload.ruleId },
+        'auto-investigation failed',
+      );
+    }
+  }
+
+  /** Drop dedup entries older than the window so the map doesn't grow unbounded. */
+  private gcRecent(now: number): void {
+    for (const [k, v] of this.recent) {
+      if (now - v >= this.dedupMs) this.recent.delete(k);
+    }
+  }
+}


### PR DESCRIPTION
Phase 8 — closes the loop from a fired alert to an automatic root-cause investigation. See commit message for the spec.

The dispatcher consumes `alert.fired` events from P0.5's AlertEvaluatorService and kicks off a service-account investigation via the existing `runBackgroundAgent`. From there the chain is unchanged: orchestrator runs, optionally calls `remediation_plan.create` (P4), the plan flows through the approval flow (P5), operator reviews (P7).

Closes #88 (T8.1), #90 (T8.3), #91 (T8.4). Tracks under #94. T8.2 (synthetic SA seed) and T8.5/T8.6 (boot wiring + e2e) deferred to a wiring PR.

## Surface

| | |
|---|---|
| New file | `packages/api-gateway/src/services/auto-investigation-dispatcher.ts` (136 LOC) |
| Class | `AutoInvestigationDispatcher` — `subscribe()`, `unsubscribe()`, `onAlertFired(payload)` |
| Helper | `buildAlertQuestion(payload)` — pure, exported, used by tests + reusable from a custom dispatcher |
| Tests | 8 cases — composition, dedup, crash isolation, subscribe idempotence |

## Dedup

In-memory LRU keyed on `ruleId` with default `dedupMs=5min`. GC happens on each event. Multi-replica HA + restart resilience explicitly NOT in v1 (would need a marker column on `alert_rule` — tracked).

## Architecture self-check

- Single file, single responsibility (subscribe + dedup + spawn).
- Reuses `runBackgroundAgent` (existing service-account agent pattern) and `AlertFiredPayload` (from P0.5). No new abstraction layers.
- Doesn't own the event source — caller passes any `EventEmitter`. Keeps the dispatcher unit-testable without booting the evaluator.
- No legacy/dead code touched.

## Tests

Full suite **1459 / 16 skipped** (was 1451). Lint clean.

## Reverting

One new file. `git revert <sha>`. Nothing else depends on it yet (boot wiring is the follow-up).