### PR TITLE
Boot-wire alert evaluator + fix latent build errors

### DIFF
--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -38,3 +38,10 @@ export {
 } from './agent/index.js';
 
 export type { Investigation, InvestigationPlan, InvestigationStatus } from '@agentic-obs/common';
+
+export {
+  runBackgroundAgent,
+  type BackgroundAgentRunInput,
+  type BackgroundRunnerDeps,
+  type ISaTokenResolver,
+} from './agent/background-runner.js';

--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -1,0 +1,113 @@
+/**
+ * Boot wiring for the alert evaluator.
+ *
+ * Phase 0.5 of `docs/design/auto-remediation.md` boot path. Stands up
+ * the periodic AlertEvaluatorService against the configured default
+ * Prometheus-compatible datasource, behind a feature flag.
+ *
+ *   ALERT_EVALUATOR_ENABLED   default 'true'
+ *
+ * v1 single-process: no leader lock, no cross-replica HA. The evaluator
+ * is fine to run in one api-gateway instance until horizontal-scale
+ * lands (tracked as a follow-up in the design doc).
+ *
+ * Wiring the AutoInvestigationDispatcher to this evaluator is a
+ * separate follow-up — that needs an orchestrator factory extracted
+ * from chat-service.
+ */
+
+import { createLogger } from '@agentic-obs/common/logging';
+import { PrometheusMetricsAdapter } from '@agentic-obs/adapters';
+import {
+  AlertEvaluatorService,
+  type MetricQueryFn,
+} from '../services/alert-evaluator-service.js';
+import {
+  resolvePrometheusDatasource,
+  type PrometheusDatasource,
+} from '../services/dashboard-service.js';
+import type { SetupConfigService } from '../services/setup-config-service.js';
+import type { IAlertRuleRepository } from '@agentic-obs/data-layer';
+
+const log = createLogger('alerts-boot');
+
+function envFlag(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultValue;
+  return raw === '1' || raw.toLowerCase() === 'true';
+}
+
+/**
+ * Build a `MetricQueryFn` that resolves a rule's PromQL against the
+ * configured default Prometheus-compatible datasource and returns the
+ * latest scalar value.
+ *
+ * `null` return = "no sample". The evaluator treats null as "leave
+ * state alone", which matches alertmanager semantics: stale =
+ * inconclusive.
+ *
+ * Datasource resolution is **per-call** so an operator can swap
+ * datasources at runtime without restarting the api-gateway. The
+ * downside is a small overhead per tick; the upside is consistency
+ * with the rest of the system (which does the same).
+ *
+ * Multi-series queries are folded to the first sample. Production
+ * alert rules are expected to aggregate to a scalar (e.g. `sum(...) by ()`).
+ */
+export function buildMetricQueryFn(setupConfig: SetupConfigService): MetricQueryFn {
+  return async (rule) => {
+    const datasources = await setupConfig.listDatasources();
+    const prom: PrometheusDatasource | undefined = resolvePrometheusDatasource(datasources);
+    if (!prom) {
+      log.debug({ ruleId: rule.id }, 'no Prometheus datasource configured; skipping evaluation');
+      return null;
+    }
+    const adapter = new PrometheusMetricsAdapter(prom.url, prom.headers);
+    try {
+      const samples = await adapter.instantQuery(rule.condition.query);
+      const first = samples[0];
+      if (!first) return null;
+      const v = Number(first.value);
+      return Number.isFinite(v) ? v : null;
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), ruleId: rule.id },
+        'metric query failed; treating as no-sample',
+      );
+      return null;
+    }
+  };
+}
+
+export interface MountAlertsDeps {
+  rules: IAlertRuleRepository;
+  setupConfig: SetupConfigService;
+}
+
+/**
+ * Start the evaluator (if enabled). Returns a `{ evaluator, stop }`
+ * handle so a graceful-shutdown caller can clean up timers, AND so the
+ * follow-up that wires AutoInvestigationDispatcher can subscribe to
+ * the evaluator's `alert.fired` events without re-instantiating it.
+ */
+export async function startAlerts(deps: MountAlertsDeps): Promise<{
+  evaluator: AlertEvaluatorService | null;
+  stop: () => void;
+}> {
+  if (!envFlag('ALERT_EVALUATOR_ENABLED', true)) {
+    log.info('alert evaluator disabled by ALERT_EVALUATOR_ENABLED=false');
+    return { evaluator: null, stop: () => undefined };
+  }
+
+  const evaluator = new AlertEvaluatorService({
+    rules: deps.rules,
+    query: buildMetricQueryFn(deps.setupConfig),
+  });
+  await evaluator.start();
+  log.info('alert evaluator started');
+
+  return {
+    evaluator,
+    stop: () => evaluator.stop(),
+  };
+}

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -37,6 +37,7 @@ import { createPersistence } from './app/persistence.js';
 import { buildAuthSubsystem, mountAuthRoutes } from './app/auth-routes.js';
 import { mountRbacRoutes } from './app/rbac-routes.js';
 import { mountDomainRoutes } from './app/domain-routes.js';
+import { startAlerts } from './app/alerts-boot.js';
 import { createShutdownHooks } from './app/lifecycle.js';
 import type { WebSocketGatewayDeps } from './websocket/gateway.js';
 
@@ -191,6 +192,15 @@ export async function createApp(): Promise<Application> {
     sharedFolderRepo,
     userRateLimiter,
     queryRateLimiter,
+  });
+
+  // Start the periodic alert evaluator (Phase 0.5 boot path). Behind
+  // ALERT_EVALUATOR_ENABLED (default true). The handle is parked on
+  // app.locals so a graceful-shutdown caller (or a future AutoInvestigation
+  // dispatcher) can reach the evaluator without rebuilding it.
+  app.locals['alertsHandle'] = await startAlerts({
+    rules: persistence.repos.alertRules,
+    setupConfig,
   });
 
   app.locals['websocketGatewayDeps'] = {

--- a/packages/api-gateway/src/services/alert-evaluator-service.ts
+++ b/packages/api-gateway/src/services/alert-evaluator-service.ts
@@ -29,8 +29,8 @@ import type {
   AlertOperator,
   AlertRule,
   AlertRuleState,
-  IAlertRuleRepository,
 } from '@agentic-obs/common';
+import type { IAlertRuleRepository } from '@agentic-obs/data-layer';
 
 const log = createLogger('alert-evaluator');
 


### PR DESCRIPTION
Wires P0.5's AlertEvaluatorService into the api-gateway boot path so configured alert rules with a Prometheus datasource actually fire. Behind `ALERT_EVALUATOR_ENABLED` (default true). Also fixes two latent `tsc --build` errors that vitest's source resolution didn't catch.

See commit message for the full spec.

## Surface

| | |
|---|---|
| New file | `packages/api-gateway/src/app/alerts-boot.ts` (113 LOC) |
| `server.ts` | +8 lines: `startAlerts(...)` after `mountDomainRoutes`, handle parked on `app.locals` for future shutdown / dispatcher hook |
| Bug fix | Re-export `runBackgroundAgent` + types from `@agentic-obs/agent-core` barrel (P8 dispatcher's import was pointing at a non-exported symbol; vitest hid it) |
| Bug fix | `AlertEvaluatorService` import `IAlertRuleRepository` from data-layer not common (both packages have the same-named interface; structurally compatible but `tsc --build` sees different namespaces) |

## Behavior

- Datasource resolution per-call. Operator can swap the default Prom datasource at runtime without restarting.
- `instantQuery` empty result -> 'no sample' -> state stands. Matches alertmanager semantics.
- Errors during query are logged + downgraded; transient Prom outage doesn't whip rules between states.
- Multi-series queries fold to first sample (production rules aggregate to scalar).
- Single-process v1, no leader lock. Multi-replica HA is explicit follow-up.

## Architecture self-check

- One new file (alerts-boot.ts), single responsibility (build query fn + start service).
- Reuses existing `resolvePrometheusDatasource` + `PrometheusMetricsAdapter`. No new abstractions.
- AutoInvestigationDispatcher wiring NOT in this PR — its orchestrator factory work is its own concern. The handle is parked on `app.locals` so the follow-up just attaches.
- The two bug fixes are unrelated to this PR's feature but blocking it (the `runBackgroundAgent` export hole would have shipped to prod if not caught).

## Tests

Full suite: **1459 passed / 16 skipped** (no change). Lint clean (only the 4 pre-existing query.ts warnings).

## Reverting

`git revert <sha>` removes `startAlerts` call. The two barrel-export fixes are independently safe to keep (they make existing code build cleanly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert evaluation is now integrated into the API Gateway and runs automatically on a scheduled basis.
  * Alert evaluation is enabled by default but can be disabled via configuration.
  * The service handles errors gracefully with appropriate fallbacks when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->