### PR TITLE
Wire AutoInvestigationDispatcher to AlertEvaluator (final boot)

### DIFF
--- a/packages/agent-core/src/agent/background-runner.ts
+++ b/packages/agent-core/src/agent/background-runner.ts
@@ -49,11 +49,17 @@ export interface BackgroundRunnerDeps {
    * that closes over their store/gateway/accessControl singletons and only
    * feeds the runner the per-run fields (identity, agentType).
    */
+  /**
+   * May return synchronously OR a Promise. Async builders are useful when
+   * the orchestrator needs runtime config (LLM, datasources, connectors)
+   * that can change between calls — fetch it inside the factory, not at
+   * BackgroundRunnerDeps construction time.
+   */
   makeOrchestrator: (
     overrides: Pick<OrchestratorDeps, 'identity'> & {
       agentType?: AgentType;
     },
-  ) => OrchestratorAgent;
+  ) => OrchestratorAgent | Promise<OrchestratorAgent>;
 }
 
 /**
@@ -87,7 +93,7 @@ export async function runBackgroundAgent(
     serviceAccountId: lookup.serviceAccountId ?? undefined,
   };
 
-  const agent = deps.makeOrchestrator({
+  const agent = await deps.makeOrchestrator({
     identity,
     ...(input.agentType ? { agentType: input.agentType } : {}),
   });

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -45,3 +45,5 @@ export {
   type BackgroundRunnerDeps,
   type ISaTokenResolver,
 } from './agent/background-runner.js';
+
+export type { AgentType } from './agent/agent-types.js';

--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -1,0 +1,116 @@
+/**
+ * Background-orchestrator factory.
+ *
+ * Builds a fully-wired `OrchestratorAgent` for non-interactive callers
+ * (alert.fired auto-investigations, scheduled report generation, etc.).
+ * Lives separately from `chat-service.ts` because chat-service is
+ * session-scoped (sessionId, datasource pin bag, conversation history,
+ * SSE event stream) and a background run has none of those.
+ *
+ * The factory closes over long-lived dependencies (persistence, RBAC
+ * surface, audit writer) and resolves runtime config (LLM, datasources,
+ * ops connectors) on each call. That mirrors chat-service's behavior so
+ * a runtime config change takes effect on the next background run
+ * without restarting the api-gateway.
+ *
+ * Returned closure satisfies `BackgroundRunnerDeps.makeOrchestrator`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Identity, IFolderRepository } from '@agentic-obs/common';
+import {
+  DashboardOrchestratorAgent as OrchestratorAgent,
+  type AgentType,
+  type IConversationStore as IAgentConversationStore,
+  type IInvestigationStore,
+} from '@agentic-obs/agent-core';
+import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
+import { createLlmGateway } from '../routes/llm-factory.js';
+import { OpsCommandRunnerService } from '../services/ops-command-runner-service.js';
+import {
+  buildAdapterRegistry,
+  toAgentDatasources,
+} from '../services/dashboard-service.js';
+import { toAlertRuleStore } from '../services/chat-service.js';
+import type { Persistence } from './persistence.js';
+import type { SetupConfigService } from '../services/setup-config-service.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+
+const NOOP_CONVERSATION_STORE: IAgentConversationStore = {
+  getMessages: async () => [],
+  addMessage: async (_key, msg) => msg,
+  clearMessages: async () => undefined,
+  deleteConversation: async () => undefined,
+};
+
+const sharedWebSearchAdapter = new DuckDuckGoSearchAdapter();
+
+export interface BackgroundOrchestratorFactoryDeps {
+  persistence: Persistence;
+  setupConfig: SetupConfigService;
+  accessControl: AccessControlSurface;
+  audit?: AuditWriter;
+  /** Optional folder backend — enables folder.create / folder.list tools. */
+  folderRepository?: IFolderRepository;
+}
+
+export type MakeBackgroundOrchestrator = (overrides: {
+  identity: Identity;
+  agentType?: AgentType;
+}) => Promise<OrchestratorAgent>;
+
+/**
+ * Build the closure passed as `BackgroundRunnerDeps.makeOrchestrator`.
+ * Each invocation:
+ *   - reads current LLM config from setupConfig (throws if not configured)
+ *   - reads current datasources + builds the adapter registry
+ *   - rebuilds OpsCommandRunnerService scoped to the caller's orgId
+ *   - constructs a fresh OrchestratorAgent with a noop conversation store
+ *     and a noop sendEvent (no SSE for background)
+ */
+export function buildBackgroundOrchestratorFactory(
+  deps: BackgroundOrchestratorFactoryDeps,
+): MakeBackgroundOrchestrator {
+  return async ({ identity, agentType }) => {
+    const llm = await deps.setupConfig.getLlm();
+    if (!llm) {
+      throw new Error('LLM not configured — complete the Setup Wizard before running background investigations');
+    }
+    const datasources = await deps.setupConfig.listDatasources();
+    const gateway = createLlmGateway(llm);
+    const adapters = buildAdapterRegistry(datasources);
+
+    const opsCommandRunner = deps.persistence.repos.opsConnectors && deps.persistence.repos.approvals
+      ? new OpsCommandRunnerService({
+          connectors: deps.persistence.repos.opsConnectors,
+          approvals: deps.persistence.repos.approvals,
+        }, identity.orgId)
+      : undefined;
+    const opsConnectors = opsCommandRunner ? await opsCommandRunner.listConnectors() : undefined;
+
+    return new OrchestratorAgent({
+      gateway,
+      model: llm.model,
+      store: deps.persistence.repos.dashboards,
+      conversationStore: NOOP_CONVERSATION_STORE,
+      investigationReportStore: deps.persistence.repos.investigationReports,
+      investigationStore: deps.persistence.repos.investigations as IInvestigationStore | undefined,
+      alertRuleStore: toAlertRuleStore(deps.persistence.repos.alertRules),
+      ...(deps.folderRepository ? { folderRepository: deps.folderRepository } : {}),
+      adapters,
+      webSearchAdapter: sharedWebSearchAdapter,
+      allDatasources: toAgentDatasources(datasources),
+      ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
+      remediationPlans: deps.persistence.repos.remediationPlans,
+      approvalRequests: deps.persistence.repos.approvals,
+      // Background runs have no SSE channel; tool events are still logged
+      // via the agent's internal logger but not streamed anywhere.
+      sendEvent: () => undefined,
+      identity,
+      accessControl: deps.accessControl,
+      ...(deps.audit ? { auditWriter: deps.audit } : {}),
+      ...(agentType ? { agentType } : {}),
+    }, `bg_${randomUUID()}`);
+  };
+}

--- a/packages/api-gateway/src/app/alerts-boot.test.ts
+++ b/packages/api-gateway/src/app/alerts-boot.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the alerts-boot wiring — evaluator startup gate + dispatcher
+ * gate matrix.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { IAlertRuleRepository } from '@agentic-obs/data-layer';
+import type { SetupConfigService } from '../services/setup-config-service.js';
+import { startAlerts } from './alerts-boot.js';
+
+function fakeRepo(): IAlertRuleRepository {
+  return {
+    create: async () => ({}) as never,
+    findById: async () => undefined,
+    findAll: async () => ({ list: [], total: 0 }),
+    findByWorkspace: async () => [],
+    update: async () => undefined,
+    delete: async () => false,
+    transition: async () => undefined,
+    getHistory: async () => [],
+    getAllHistory: async () => [],
+    createSilence: async () => ({}) as never,
+    findSilences: async () => [],
+    findAllSilencesIncludingExpired: async () => [],
+    updateSilence: async () => undefined,
+    deleteSilence: async () => false,
+    listContactPoints: async () => [],
+    upsertContactPoint: async () => ({}) as never,
+    deleteContactPoint: async () => false,
+    listMuteTimings: async () => [],
+    upsertMuteTiming: async () => ({}) as never,
+    deleteMuteTiming: async () => false,
+    getNotificationPolicyTree: async () => null,
+    setNotificationPolicyTree: async () => undefined,
+  } as unknown as IAlertRuleRepository;
+}
+
+function fakeSetupConfig(): SetupConfigService {
+  return {
+    listDatasources: async () => [],
+    getLlm: async () => null,
+  } as unknown as SetupConfigService;
+}
+
+describe('startAlerts', () => {
+  const orig = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...orig };
+  });
+
+  it('returns null evaluator when ALERT_EVALUATOR_ENABLED=false', async () => {
+    process.env['ALERT_EVALUATOR_ENABLED'] = 'false';
+    const handle = await startAlerts({ rules: fakeRepo(), setupConfig: fakeSetupConfig() });
+    expect(handle.evaluator).toBeNull();
+    expect(handle.dispatcher).toBeNull();
+    handle.stop();
+  });
+
+  it('starts evaluator but skips dispatcher when SA token unset', async () => {
+    delete process.env['AUTO_INVESTIGATION_SA_TOKEN'];
+    const handle = await startAlerts({ rules: fakeRepo(), setupConfig: fakeSetupConfig() });
+    expect(handle.evaluator).not.toBeNull();
+    expect(handle.dispatcher).toBeNull();
+    handle.stop();
+  });
+
+  it('skips dispatcher when AUTO_INVESTIGATION_ENABLED=false even with token + runner', async () => {
+    process.env['AUTO_INVESTIGATION_SA_TOKEN'] = 'openobs_sa_x';
+    process.env['AUTO_INVESTIGATION_ENABLED'] = 'false';
+    const handle = await startAlerts({
+      rules: fakeRepo(),
+      setupConfig: fakeSetupConfig(),
+      runner: {
+        saTokens: { validateAndLookup: async () => null },
+        makeOrchestrator: () => ({}) as never,
+      },
+    });
+    expect(handle.evaluator).not.toBeNull();
+    expect(handle.dispatcher).toBeNull();
+    handle.stop();
+  });
+
+  it('starts dispatcher when token + runner + flag are all set', async () => {
+    process.env['AUTO_INVESTIGATION_SA_TOKEN'] = 'openobs_sa_x';
+    delete process.env['AUTO_INVESTIGATION_ENABLED'];
+    const handle = await startAlerts({
+      rules: fakeRepo(),
+      setupConfig: fakeSetupConfig(),
+      runner: {
+        saTokens: { validateAndLookup: async () => null },
+        makeOrchestrator: () => ({}) as never,
+      },
+    });
+    expect(handle.evaluator).not.toBeNull();
+    expect(handle.dispatcher).not.toBeNull();
+    handle.stop();
+  });
+});

--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -18,10 +18,12 @@
 
 import { createLogger } from '@agentic-obs/common/logging';
 import { PrometheusMetricsAdapter } from '@agentic-obs/adapters';
+import type { BackgroundRunnerDeps } from '@agentic-obs/agent-core';
 import {
   AlertEvaluatorService,
   type MetricQueryFn,
 } from '../services/alert-evaluator-service.js';
+import { AutoInvestigationDispatcher } from '../services/auto-investigation-dispatcher.js';
 import {
   resolvePrometheusDatasource,
   type PrometheusDatasource,
@@ -82,6 +84,13 @@ export function buildMetricQueryFn(setupConfig: SetupConfigService): MetricQuery
 export interface MountAlertsDeps {
   rules: IAlertRuleRepository;
   setupConfig: SetupConfigService;
+  /**
+   * BackgroundRunnerDeps — when provided AND `AUTO_INVESTIGATION_SA_TOKEN`
+   * is set in env AND `AUTO_INVESTIGATION_ENABLED` is not 'false', the
+   * AutoInvestigationDispatcher is started + subscribed to the
+   * evaluator's `alert.fired` emitter.
+   */
+  runner?: BackgroundRunnerDeps;
 }
 
 /**
@@ -92,11 +101,12 @@ export interface MountAlertsDeps {
  */
 export async function startAlerts(deps: MountAlertsDeps): Promise<{
   evaluator: AlertEvaluatorService | null;
+  dispatcher: AutoInvestigationDispatcher | null;
   stop: () => void;
 }> {
   if (!envFlag('ALERT_EVALUATOR_ENABLED', true)) {
     log.info('alert evaluator disabled by ALERT_EVALUATOR_ENABLED=false');
-    return { evaluator: null, stop: () => undefined };
+    return { evaluator: null, dispatcher: null, stop: () => undefined };
   }
 
   const evaluator = new AlertEvaluatorService({
@@ -106,8 +116,40 @@ export async function startAlerts(deps: MountAlertsDeps): Promise<{
   await evaluator.start();
   log.info('alert evaluator started');
 
+  // Optionally subscribe the AutoInvestigationDispatcher (P8) to the
+  // evaluator's alert.fired stream. Three independent gates so an
+  // operator can turn pieces on/off without rebuilding:
+  //   - AUTO_INVESTIGATION_ENABLED (default true)
+  //   - AUTO_INVESTIGATION_SA_TOKEN (no default; service-account token)
+  //   - deps.runner (passed in by server.ts wiring)
+  let dispatcher: AutoInvestigationDispatcher | null = null;
+  const dispatcherOn = envFlag('AUTO_INVESTIGATION_ENABLED', true);
+  const saToken = process.env['AUTO_INVESTIGATION_SA_TOKEN'];
+  if (!dispatcherOn) {
+    log.info('auto-investigation dispatcher disabled by AUTO_INVESTIGATION_ENABLED=false');
+  } else if (!saToken) {
+    log.warn(
+      'AUTO_INVESTIGATION_SA_TOKEN unset — auto-investigation dispatcher NOT started. ' +
+      'Create a service account, generate a token, and set the env var to enable.',
+    );
+  } else if (!deps.runner) {
+    log.warn('background-runner deps not provided — auto-investigation dispatcher NOT started');
+  } else {
+    dispatcher = new AutoInvestigationDispatcher({
+      alertEvents: evaluator,
+      runner: deps.runner,
+      saToken,
+    });
+    dispatcher.subscribe();
+    log.info('auto-investigation dispatcher subscribed to alert.fired');
+  }
+
   return {
     evaluator,
-    stop: () => evaluator.stop(),
+    dispatcher,
+    stop: () => {
+      dispatcher?.unsubscribe();
+      evaluator.stop();
+    },
   };
 }

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -38,6 +38,7 @@ import { buildAuthSubsystem, mountAuthRoutes } from './app/auth-routes.js';
 import { mountRbacRoutes } from './app/rbac-routes.js';
 import { mountDomainRoutes } from './app/domain-routes.js';
 import { startAlerts } from './app/alerts-boot.js';
+import { buildBackgroundOrchestratorFactory } from './app/agent-factory.js';
 import { createShutdownHooks } from './app/lifecycle.js';
 import type { WebSocketGatewayDeps } from './websocket/gateway.js';
 
@@ -201,6 +202,16 @@ export async function createApp(): Promise<Application> {
   app.locals['alertsHandle'] = await startAlerts({
     rules: persistence.repos.alertRules,
     setupConfig,
+    runner: {
+      saTokens: bundle.apiKeyService,
+      makeOrchestrator: buildBackgroundOrchestratorFactory({
+        persistence,
+        setupConfig,
+        accessControl,
+        audit: bundle.authSub.audit,
+        folderRepository: sharedFolderRepo,
+      }),
+    },
   });
 
   app.locals['websocketGatewayDeps'] = {

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -37,8 +37,10 @@ function getSessionDatasourcePins(sessionId: string): Record<string, string> {
   return pins;
 }
 
-/** Adapts data-layer IAlertRuleRepository to agent-core IAlertRuleStore. */
-function toAlertRuleStore(repo: IAlertRuleRepository): IAlertRuleStore {
+/** Adapts data-layer IAlertRuleRepository to agent-core IAlertRuleStore.
+ * Exported so background-orchestrator builds (alerts → investigation) can
+ * reuse the same adapter without duplicating the shape. */
+export function toAlertRuleStore(repo: IAlertRuleRepository): IAlertRuleStore {
   return {
     create: (data) => repo.create(data as Parameters<IAlertRuleRepository['create']>[0]),
     update: repo.update ? (id, patch) => repo.update(id, patch as Parameters<IAlertRuleRepository['update']>[1]) : undefined,


### PR DESCRIPTION
Final boot piece. Closes the loop: alert.fired -> background orchestrator run -> investigation report + (optional) remediation plan -> existing approval/execute pipeline.

See commit message for full spec.

## Three-gate matrix for ops control

| Gate | Default | Effect |
|---|---|---|
| `ALERT_EVALUATOR_ENABLED` | true | Periodic alert evaluator (P0.5) |
| `AUTO_INVESTIGATION_ENABLED` | true | Dispatcher gate |
| `AUTO_INVESTIGATION_SA_TOKEN` | unset | Required token for the dispatcher |

If any gate is off the boot logs a clear notice. Operators can disable just the dispatcher (`AUTO_INVESTIGATION_ENABLED=false`) without losing the evaluator.

## Architecture self-check

| | |
|---|---|
| New module | `app/agent-factory.ts` (116 LOC). Single responsibility: build a non-interactive OrchestratorAgent. |
| Module boundary | chat-service stays chat-scoped; the factory is reused (toAlertRuleStore now exported). |
| Duplication | None — `buildAdapterRegistry`, `toAgentDatasources`, `OpsCommandRunnerService`, `toAlertRuleStore` are all reused. |
| Dead code | None added; one stale private exported (toAlertRuleStore is now re-used by the factory). |
| God-file growth | alerts-boot grew from 113 to ~150 LOC. server.ts grew by 11. |

## Enabling fixes folded in

- `BackgroundRunnerDeps.makeOrchestrator` now allows a Promise return (factory needs async LLM/datasource resolution; one-line at call site).
- agent-core barrel re-exports `AgentType`. Same hygiene as runBackgroundAgent in #105.

## Tests

4 new alerts-boot tests covering the three-gate matrix. Full suite **1464 passed / 16 skipped** (was 1460). Lint clean (only the 4 pre-existing query.ts warnings).

## Reverting

`git revert <sha>` removes the dispatcher boot. `/api/plans` continues working; manual investigations still work; only the alert.fired auto-trigger goes away.