### PR TITLE
O1: seed openobs auto-investigation service account

### DIFF
--- a/packages/api-gateway/src/app/auth-routes.ts
+++ b/packages/api-gateway/src/app/auth-routes.ts
@@ -23,6 +23,7 @@ import { createAuthSubsystem } from '../auth/auth-manager.js';
 import type { AuthSubsystem } from '../auth/auth-manager.js';
 import { migrateAuthToDbIfNeeded } from '../migrations/auth-to-db.js';
 import { seedAdminIfNeeded } from '../auth/seed-admin.js';
+import { seedAutoInvestigationSaIfNeeded } from '../auth/seed-auto-investigation-sa.js';
 import { createAuthRouter } from '../routes/auth.js';
 import { createUserRouter } from '../routes/user.js';
 import { createAdminRouter } from '../routes/admin.js';
@@ -79,6 +80,22 @@ async function runAuthMigration(
         'seed admin fallback failed',
       );
     }
+  }
+
+  // Idempotently seed the auto-investigation SA. Runs after the admin
+  // bootstrap above so the org exists. Failures here are non-fatal — the
+  // SA only matters for the alert.fired auto-trigger, and that path is
+  // separately gated by AUTO_INVESTIGATION_SA_TOKEN at boot.
+  try {
+    await seedAutoInvestigationSaIfNeeded({
+      users: authRepos.users,
+      orgUsers: authRepos.orgUsers,
+    });
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : err },
+      'auto-investigation SA seed failed; alert auto-investigations will be unavailable until fixed',
+    );
   }
 }
 

--- a/packages/api-gateway/src/auth/seed-auto-investigation-sa.test.ts
+++ b/packages/api-gateway/src/auth/seed-auto-investigation-sa.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDb,
+  UserRepository,
+  OrgUserRepository,
+  type SqliteClient,
+} from '@agentic-obs/data-layer';
+import {
+  seedAutoInvestigationSaIfNeeded,
+  AUTO_INVESTIGATION_SA_LOGIN,
+  AUTO_INVESTIGATION_SA_EMAIL,
+} from './seed-auto-investigation-sa.js';
+
+describe('seedAutoInvestigationSaIfNeeded', () => {
+  let db: SqliteClient;
+  let users: UserRepository;
+  let orgUsers: OrgUserRepository;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    users = new UserRepository(db);
+    orgUsers = new OrgUserRepository(db);
+  });
+
+  it('creates the SA user + org membership when missing', async () => {
+    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(id).not.toBeNull();
+    const user = await users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
+    expect(user).not.toBeNull();
+    expect(user!.isServiceAccount).toBe(true);
+    expect(user!.email).toBe(AUTO_INVESTIGATION_SA_EMAIL);
+    const member = await orgUsers.findMembership('org_main', user!.id);
+    expect(member?.role).toBe('Editor');
+  });
+
+  it('is idempotent: a second run is a no-op', async () => {
+    const id1 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    const id2 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(id1).toBe(id2);
+  });
+
+  it('repairs missing org membership without recreating the user', async () => {
+    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(id).not.toBeNull();
+    // Drop the org membership row directly to simulate a partial seed
+    const member = await orgUsers.findMembership('org_main', id!);
+    expect(member).not.toBeNull();
+    await orgUsers.remove('org_main', id!);
+    const after = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(after).toBe(id);
+    const repaired = await orgUsers.findMembership('org_main', id!);
+    expect(repaired?.role).toBe('Editor');
+  });
+
+  it('refuses to overwrite a non-SA user with login=openobs', async () => {
+    await users.create({
+      email: 'real@example.com',
+      name: 'Real Person',
+      login: AUTO_INVESTIGATION_SA_LOGIN,
+      orgId: 'org_main',
+      isAdmin: false,
+      emailVerified: true,
+    });
+    const result = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(result).toBeNull();
+    const user = await users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
+    expect(user!.isServiceAccount).toBe(false);
+  });
+});

--- a/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
+++ b/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
@@ -1,0 +1,97 @@
+/**
+ * Seed the `openobs` auto-investigation service account on first boot.
+ *
+ * Phase 8 / O1 of the auto-remediation design. The dispatcher
+ * (#108 / alerts-boot.ts) needs an SA token to spawn background
+ * investigations; this seed makes sure the SA user exists, ready for
+ * an admin to mint a key for it via the existing service-account UI.
+ *
+ * Idempotent: if a user with login `openobs` and `is_service_account=1`
+ * already exists, no-op. Org membership is also idempotent.
+ *
+ * Why we don't auto-mint the API key here: API keys are minted through
+ * `ApiKeyService` which performs an audit + binds the key to the
+ * caller's identity. Auto-minting at boot bypasses that and produces
+ * unattributed audit rows. The setup story is:
+ *   1. This seed creates the SA user.
+ *   2. An admin opens the service-accounts page, picks `openobs`, and
+ *      generates a token via the existing UI. The audit row attributes
+ *      the key to that admin.
+ *   3. Operator copies the raw `openobs_sa_...` token into the
+ *      `AUTO_INVESTIGATION_SA_TOKEN` env var and restarts the gateway.
+ */
+
+import type {
+  IOrgUserRepository,
+  IUserRepository,
+} from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/common/logging';
+
+const log = createLogger('seed-auto-investigation-sa');
+
+export const AUTO_INVESTIGATION_SA_LOGIN = 'openobs';
+export const AUTO_INVESTIGATION_SA_NAME = 'OpenObs Auto-Investigation';
+/** SA users always live under a synthetic email; matches serviceaccount-service.ts's convention. */
+export const AUTO_INVESTIGATION_SA_EMAIL = `${AUTO_INVESTIGATION_SA_LOGIN}@serviceaccount.local`;
+
+export interface SeedAutoInvestigationSaDeps {
+  users: IUserRepository;
+  orgUsers: IOrgUserRepository;
+}
+
+export interface SeedAutoInvestigationSaOptions {
+  orgId?: string;
+}
+
+/**
+ * Idempotently ensure the auto-investigation SA exists. Returns the
+ * SA user id (existing or newly created), or `null` if seeding is
+ * skipped (e.g. the org doesn't exist yet — caller should run after
+ * org bootstrap).
+ *
+ * The SA is given org-role `Editor`. The agent's tool surface doesn't
+ * include any plan-approval call site, so even though Editor's role
+ * matrix grants `plans:approve`, there's no path for the SA to use it.
+ * `plans:auto_edit` is NOT granted by Editor (per #99), so the SA
+ * cannot approve plans in auto-edit mode either.
+ */
+export async function seedAutoInvestigationSaIfNeeded(
+  deps: SeedAutoInvestigationSaDeps,
+  opts: SeedAutoInvestigationSaOptions = {},
+): Promise<string | null> {
+  const orgId = opts.orgId ?? 'org_main';
+
+  const existing = await deps.users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
+  if (existing) {
+    if (!existing.isServiceAccount) {
+      log.warn(
+        { userId: existing.id },
+        'a regular user with login=openobs already exists; refusing to overwrite. ' +
+        'Rename or delete that user, or set the auto-investigation SA up under a different login.',
+      );
+      return null;
+    }
+    // Ensure org membership is in place even if the row was created
+    // out-of-band (e.g. by a previous seed run that didn't finish).
+    const member = await deps.orgUsers.findMembership(orgId, existing.id);
+    if (!member) {
+      await deps.orgUsers.create({ orgId, userId: existing.id, role: 'Editor' });
+      log.info({ userId: existing.id, orgId }, 'auto-investigation SA org membership repaired');
+    }
+    return existing.id;
+  }
+
+  const user = await deps.users.create({
+    email: AUTO_INVESTIGATION_SA_EMAIL,
+    name: AUTO_INVESTIGATION_SA_NAME,
+    login: AUTO_INVESTIGATION_SA_LOGIN,
+    orgId,
+    isAdmin: false,
+    isDisabled: false,
+    isServiceAccount: true,
+    emailVerified: false,
+  });
+  await deps.orgUsers.create({ orgId, userId: user.id, role: 'Editor' });
+  log.info({ userId: user.id, login: user.login }, 'auto-investigation SA seeded');
+  return user.id;
+}


### PR DESCRIPTION
Closes design-doc §6 O1 (SA name = `openobs`).

Idempotent SA seed for the `AUTO_INVESTIGATION_SA_TOKEN` setup. Two-step story:
1. Boot creates the SA user (login=`openobs`, `is_service_account=1`, role=Editor).
2. Admin generates a key for it via the existing service-accounts UI (audit row attributes the key to that admin).
3. Operator copies the raw token to the env var.

Why no auto-mint: the existing `ApiKeyService` binds key creation to the caller's identity for audit. Auto-minting at boot bypasses that.

## Idempotency

| Pre-state | Behavior |
|---|---|
| SA user absent | Create + Editor membership |
| SA user present + membership ok | No-op |
| SA user present, membership missing | Membership repaired (no user recreation) |
| Regular user with login=`openobs` exists | Refuse + warn (operator must rename or pick different login) |

## Tests

4 cases. Full suite **1468 / 16 skipped** (was 1464). Lint clean.

## Reverting

`git revert <sha>` removes the seed call. Existing SAs persist (intentionally — removing a seeded user via revert would orphan keys).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic initialization of the auto-investigation service account now occurs during the authentication migration phase with graceful error handling to ensure uninterrupted startup.

* **Tests**
  * Added comprehensive test suite for auto-investigation service account initialization, validating idempotency, membership restoration, and conflict scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->