### PR TITLE
O2: namespace-scoped plans:auto_edit

### DIFF
--- a/packages/api-gateway/src/routes/plans.ts
+++ b/packages/api-gateway/src/routes/plans.ts
@@ -30,6 +30,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import type { PlanExecutorService } from '../services/plan-executor-service.js';
+import { extractPlanNamespaces } from '../services/plan-namespaces.js';
 
 export interface PlansRouterDeps {
   plans: IRemediationPlanRepository;
@@ -137,19 +138,48 @@ export function createPlansRouter(deps: PlansRouterDeps): Router {
         const autoEdit = body.autoEdit === true;
 
         if (autoEdit) {
-          // Second permission check — auto-edit is its own action, not bundled
-          // with PlansApprove.
-          const allowed = await deps.ac.evaluate(
-            auth,
-            ac.eval(ACTIONS.PlansAutoEdit, `plans:uid:${req.params['id'] ?? ''}`),
-          );
-          if (!allowed) {
-            const err: ApiError = {
-              code: 'FORBIDDEN',
-              message: 'auto-edit requires plans:auto_edit permission',
-            };
-            res.status(403).json(err);
+          // Two-layered auto-edit gate (design-doc §6 O2):
+          //   1. Cluster-wide grant `plans:auto_edit` on `plans:*` short-
+          //      circuits — this is the existing 'auto-edit anything' privilege.
+          //   2. Otherwise, narrow to the namespaces this specific plan
+          //      touches. Caller must hold `plans:auto_edit` on
+          //      `plans:namespace:<ns>` for every namespace the plan
+          //      writes to. A plan with any cluster-scoped step can NOT
+          //      be narrowed and falls back to requiring `plans:*`.
+          const plan = await deps.plans.findByIdInOrg(auth.orgId, req.params['id'] ?? '');
+          if (!plan) {
+            const err: ApiError = { code: 'NOT_FOUND', message: 'plan not found' };
+            res.status(404).json(err);
             return;
+          }
+          const wildcard = await deps.ac.evaluate(
+            auth,
+            ac.eval(ACTIONS.PlansAutoEdit, 'plans:*'),
+          );
+          if (!wildcard) {
+            const summary = extractPlanNamespaces(plan);
+            if (summary.hasClusterScoped) {
+              const err: ApiError = {
+                code: 'FORBIDDEN',
+                message: 'auto-edit on a plan with a cluster-scoped step requires plans:auto_edit on plans:* (cluster-wide grant)',
+              };
+              res.status(403).json(err);
+              return;
+            }
+            for (const ns of summary.namespaces) {
+              const ok = await deps.ac.evaluate(
+                auth,
+                ac.eval(ACTIONS.PlansAutoEdit, `plans:namespace:${ns}`),
+              );
+              if (!ok) {
+                const err: ApiError = {
+                  code: 'FORBIDDEN',
+                  message: `auto-edit requires plans:auto_edit on plans:namespace:${ns}`,
+                };
+                res.status(403).json(err);
+                return;
+              }
+            }
           }
         }
 

--- a/packages/api-gateway/src/services/plan-namespaces.test.ts
+++ b/packages/api-gateway/src/services/plan-namespaces.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import type { RemediationPlan, RemediationPlanStep } from '@agentic-obs/data-layer';
+import { extractPlanNamespaces } from './plan-namespaces.js';
+
+function step(overrides: Partial<RemediationPlanStep>): RemediationPlanStep {
+  return {
+    id: 's',
+    planId: 'p',
+    ordinal: 0,
+    kind: 'ops.run_command',
+    commandText: '',
+    paramsJson: { argv: [] },
+    dryRunText: null,
+    riskNote: null,
+    continueOnError: false,
+    status: 'pending',
+    approvalRequestId: null,
+    executedAt: null,
+    outputText: null,
+    errorText: null,
+    ...overrides,
+  };
+}
+
+function plan(steps: RemediationPlanStep[]): RemediationPlan {
+  return {
+    id: 'p1',
+    orgId: 'org_main',
+    investigationId: 'inv-1',
+    rescueForPlanId: null,
+    summary: '',
+    status: 'pending_approval',
+    autoEdit: false,
+    approvalRequestId: null,
+    createdBy: 'agent',
+    createdAt: '',
+    expiresAt: '',
+    resolvedAt: null,
+    resolvedBy: null,
+    steps,
+  };
+}
+
+describe('extractPlanNamespaces', () => {
+  it('returns empty + cluster-scoped flag when steps have no -n flag', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ paramsJson: { argv: ['get', 'nodes'] } }),
+    ]));
+    expect(r.namespaces).toEqual([]);
+    expect(r.hasClusterScoped).toBe(true);
+  });
+
+  it('parses -n', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ paramsJson: { argv: ['scale', 'deploy/web', '-n', 'app', '--replicas=3'] } }),
+    ]));
+    expect(r.namespaces).toEqual(['app']);
+    expect(r.hasClusterScoped).toBe(false);
+  });
+
+  it('parses --namespace=', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ paramsJson: { argv: ['get', 'pods', '--namespace=payments'] } }),
+    ]));
+    expect(r.namespaces).toEqual(['payments']);
+  });
+
+  it('dedupes + sorts across multiple steps', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ ordinal: 0, paramsJson: { argv: ['scale', 'a', '-n', 'app'] } }),
+      step({ ordinal: 1, paramsJson: { argv: ['scale', 'b', '-n', 'payments'] } }),
+      step({ ordinal: 2, paramsJson: { argv: ['rollout', 'status', 'a', '-n', 'app'] } }),
+    ]));
+    expect(r.namespaces).toEqual(['app', 'payments']);
+    expect(r.hasClusterScoped).toBe(false);
+  });
+
+  it('mixed cluster-scoped + namespaced flags both', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ ordinal: 0, paramsJson: { argv: ['scale', 'a', '-n', 'app'] } }),
+      step({ ordinal: 1, paramsJson: { argv: ['get', 'nodes'] } }),
+    ]));
+    expect(r.namespaces).toEqual(['app']);
+    expect(r.hasClusterScoped).toBe(true);
+  });
+
+  it('treats malformed argv as cluster-scoped (defensive)', () => {
+    const r = extractPlanNamespaces(plan([
+      step({ paramsJson: { argv: 'not an array' as unknown as string[] } }),
+    ]));
+    expect(r.hasClusterScoped).toBe(true);
+  });
+});

--- a/packages/api-gateway/src/services/plan-namespaces.ts
+++ b/packages/api-gateway/src/services/plan-namespaces.ts
@@ -1,0 +1,66 @@
+/**
+ * Extract the set of Kubernetes namespaces a RemediationPlan touches.
+ *
+ * Used by the approve route to gate `plans:auto_edit` per-namespace
+ * (design-doc §6 O2): an operator can be granted auto-edit for some
+ * namespaces (e.g. `app`) without granting it cluster-wide.
+ *
+ * Pure function — no I/O. Walks each step's `paramsJson.argv` and
+ * pulls out the value of `-n` / `--namespace` / `--namespace=`. A
+ * step without a namespace flag is "cluster-scoped" and we surface
+ * that explicitly; plans with cluster-scoped writes can't be
+ * narrowed by namespace and require the `plans:*` (cluster-wide)
+ * grant.
+ */
+
+import type { RemediationPlan } from '@agentic-obs/data-layer';
+
+export interface PlanNamespaceSummary {
+  /** Distinct namespaces named explicitly across all steps, sorted. */
+  namespaces: string[];
+  /**
+   * True when at least one step has no `--namespace` flag. Such a step
+   * may be a cluster-scoped read (e.g. `kubectl get nodes`) — in that
+   * case namespace narrowing doesn't apply and the caller needs the
+   * cluster-wide `plans:*` grant for auto-edit.
+   */
+  hasClusterScoped: boolean;
+}
+
+export function extractPlanNamespaces(plan: RemediationPlan): PlanNamespaceSummary {
+  const namespaces = new Set<string>();
+  let hasClusterScoped = false;
+  for (const step of plan.steps) {
+    if (step.kind !== 'ops.run_command') continue;
+    const argv = step.paramsJson['argv'];
+    if (!Array.isArray(argv)) {
+      // Malformed step paramsJson — treat as cluster-scoped (most
+      // restrictive). The plan creation path validates step shapes,
+      // so this branch is defensive.
+      hasClusterScoped = true;
+      continue;
+    }
+    const ns = readNamespaceFromArgv(argv as string[]);
+    if (ns === null) {
+      hasClusterScoped = true;
+    } else {
+      namespaces.add(ns);
+    }
+  }
+  return { namespaces: [...namespaces].sort(), hasClusterScoped };
+}
+
+function readNamespaceFromArgv(argv: readonly string[]): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i] ?? '';
+    if (tok === '-n' || tok === '--namespace') {
+      const val = argv[i + 1];
+      return typeof val === 'string' && val.length > 0 ? val : null;
+    }
+    if (tok.startsWith('--namespace=')) {
+      const val = tok.slice('--namespace='.length);
+      return val.length > 0 ? val : null;
+    }
+  }
+  return null;
+}

--- a/packages/common/src/rbac/fixed-roles-def.ts
+++ b/packages/common/src/rbac/fixed-roles-def.ts
@@ -685,8 +685,8 @@ const PLANS_APPROVER = def(
 
 const PLANS_AUTO_EDITOR = def(
   'fixed:plans:auto_editor',
-  'Plans auto-editor',
-  'Approve a plan in auto-edit mode (executor skips per-step approvals). Sensitive — grant explicitly.',
+  'Plans auto-editor (cluster-wide)',
+  'Approve a plan in auto-edit mode for ANY namespace (skips per-step approvals). Sensitive — grant explicitly. For namespace-narrowed auto-edit, grant `plans:auto_edit` on a `plans:namespace:<ns>` scope instead of using this fixed role.',
   'Plans',
   [
     { action: ACTIONS.PlansRead, scope: 'plans:*' },


### PR DESCRIPTION
Closes design-doc §6 O2.

`plans:auto_edit` gate is now two-layered:

| Caller has | Allowed to auto-edit |
|---|---|
| `plans:auto_edit` on `plans:*` | any plan (existing privilege; unchanged) |
| `plans:auto_edit` on `plans:namespace:<ns>` | plans whose steps ALL target that namespace |
| Neither | plan-level approve still works; auto-edit returns 403 |

A plan with any **cluster-scoped** step (no `-n` / `--namespace=` flag, e.g. `kubectl get nodes`) cannot be narrowed and requires the cluster-wide `plans:*` grant. Error messages name the offending namespace.

## Surface

| | |
|---|---|
| New | `services/plan-namespaces.ts` — pure helper extracting touched namespaces from step argv |
| Updated | `routes/plans.ts` approve handler — two-layer gate |
| Updated description | `fixed:plans:auto_editor` stays cluster-wide; description now points narrowed users at `plans:namespace:<ns>` |

## Architecture self-check

- One pure helper, no new RBAC primitives.
- Reuses `ac.evaluate` and the existing scope evaluator (which already supports arbitrary scope strings).
- Existing cluster-wide auto-editors keep their grant (no migration).
- Handler grew ~30 LOC inside the existing function. No god-file growth.

## Tests

6 new helper tests + existing route tests still pass. Full suite **1474 / 16 skipped** (was 1468). Lint clean.

## Reverting

`git revert <sha>` brings back the single `plans:*` gate. Namespace-scoped grants persist in the DB but stop having a runtime effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan approval endpoint now returns a 404 error when a plan is not found.

* **New Features**
  * Enhanced plan approval authorization with improved permission checking that supports both cluster-wide and namespace-scoped access levels.

* **Documentation**
  * Updated role metadata to clarify namespace-scoped permission usage and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->