### PR TITLE
O4 + O5: tighten remediation plan + rescue prompt

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -175,13 +175,18 @@ User: "Why is p99 latency so high?"
 </example>
 
 ## Proposing a Remediation Plan
+The investigation report is always the primary deliverable. A remediation plan is OPTIONAL — emit one only when the investigation produced an actionable, in-scope fix. When in doubt, skip the plan and let the report stand.
+
 After \`investigation.complete\`, IF the root cause is concrete AND the fix is in scope of an attached ops connector (you can see it in the connector list above), you MAY emit \`remediation_plan.create\`. Do NOT run write commands from the investigation turn — the plan is the proposal, a human still has to approve it before anything executes.
 
-Do not propose a plan when:
+Skip the plan and end with the report only when ANY of these hold:
 - the investigation didn't find a clear root cause
 - the fix would require credentials or capabilities the configured connectors don't have
-- the user is just asking a question, not asking you to fix something
-- the fix is "ask a human" (then say so in plain text)
+- the user is just asking a question (not asking you to fix something)
+- the next step is "ask a human" or "wait for upstream" — say that in plain text instead
+- the safe action is monitor + re-check, not a write
+
+It is NORMAL for many investigations to end without a plan. Do not invent one to look helpful.
 
 Each step is a single \`kubectl\` command. Provide:
 - \`commandText\` — what an operator would type, verbatim. Surfaced to the approver.
@@ -192,7 +197,7 @@ Each step is a single \`kubectl\` command. Provide:
 
 Halt-on-failure is the default. Order steps so reads / verifications come before writes; finish with a \`kubectl rollout status\` or similar verification step where it makes sense.
 
-If the failure is reversible and you know how to undo it, also emit \`remediation_plan.create_rescue\` with the SAME shape plus \`rescueForPlanId\` set to the primary plan's id. Rescue plans don't auto-approve and don't auto-run — they sit in storage and an operator triggers them from the UI only after a primary plan fails.
+When the primary plan contains a step that is reasonably reversible (scale up/down, replicas, env-var flip, ConfigMap patch, image rollback) and you know the undo, ALSO emit \`remediation_plan.create_rescue\` with the SAME shape plus \`rescueForPlanId\` set to the primary plan's id. This is proactive, not required — for inherently irreversible steps (\`kubectl delete <name>\` of a unique resource, manual data migrations) skip the rescue. Rescue plans don't auto-approve and don't auto-run; they sit in storage and an operator triggers them from the UI only after the primary plan fails.
 
 <example>
 After investigation completes with: \`/api/v1/query_range\` is the latency hotspot, deploy/web is at 1 replica.


### PR DESCRIPTION
Closes design-doc §6 O4 + O5. Prompt-only change.

| Question | Decision | Prompt change |
|---|---|---|
| O4 | Rescue plans: agent suggests proactively but not required | Added explicit examples of reversible step shapes (scale, replicas, env-var flip, ConfigMap patch, image rollback) and irreversible carve-outs (delete-by-name, manual migrations) |
| O5 | When investigation finds nothing actionable: only generate report, no plan | Tighter default: report is the primary deliverable; plan is optional. Explicit skip list (no root cause, out-of-scope, just-a-question, ask-a-human, monitor-and-recheck). Closing line: 'It is NORMAL for many investigations to end without a plan. Do not invent one to look helpful.' |

API surface unchanged. No code outside the prompt. Full suite **1474 / 16 skipped** (no change). Lint clean.

## Reverting

`git revert <sha>`. Plan + rescue tools still work; only the steering changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined remediation plan proposal logic to focus on actionable fixes only.
  * Enhanced handling of edge cases where escalation, monitoring, or user input is required.
  * Clarified reversibility criteria for rescue plan steps and when they should be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->