### PR TITLE
Audit: consolidate kubectl tokenizer + drop unused barrel exports

### DIFF
--- a/packages/adapters/src/execution/index.ts
+++ b/packages/adapters/src/execution/index.ts
@@ -10,6 +10,7 @@ export type {
 export {
   checkKubectl,
   parseKubectlArgv,
+  parseKubectlCommandString,
   KUBECTL_READ_VERBS,
   KUBECTL_WRITE_VERBS,
   KUBECTL_PERMANENT_DENY_VERBS,

--- a/packages/adapters/src/execution/kubectl-allowlist.ts
+++ b/packages/adapters/src/execution/kubectl-allowlist.ts
@@ -243,3 +243,57 @@ export const KUBECTL_READ_VERBS: ReadonlySet<string> = READ_VERBS;
 export const KUBECTL_WRITE_VERBS: ReadonlySet<string> = WRITE_VERBS;
 export const KUBECTL_PERMANENT_DENY_VERBS: ReadonlySet<string> = PERMANENT_DENY_VERBS;
 export const KUBECTL_PERMANENT_DENY_NAMESPACES: ReadonlySet<string> = PERMANENT_DENY_NAMESPACES;
+
+
+/**
+ * Tokenize a `kubectl ...` command STRING into argv. Strips the leading
+ * `kubectl` token if present, supports single- and double-quoted args,
+ * and refuses anything containing shell metacharacters (`/[\`$|;&><]/`)
+ * by returning an empty array.
+ *
+ * Used by callers that receive the command from a higher layer as a
+ * single string (chat input, agent tool args). The empty-array on
+ * shell-meta keeps unparseable-but-dangerous shapes from being silently
+ * passed to a downstream allowlist that only knows about kubectl verbs.
+ *
+ * If you already have argv (from a structured tool call), use
+ * `parseKubectlArgv` instead — it parses meaning out of argv tokens.
+ */
+export function parseKubectlCommandString(command: string): string[] {
+  const trimmed = command.trim();
+  if (!trimmed) return [];
+  if (/[`$|;&><]/.test(trimmed)) return [];
+
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < trimmed.length) {
+    const ch = trimmed[i] ?? '';
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      let j = i + 1;
+      let buf = '';
+      while (j < trimmed.length && trimmed[j] !== quote) {
+        buf += trimmed[j];
+        j++;
+      }
+      if (j >= trimmed.length) return []; // unterminated quote
+      tokens.push(buf);
+      i = j + 1;
+      continue;
+    }
+    let j = i;
+    let buf = '';
+    while (j < trimmed.length && !/\s/.test(trimmed[j] ?? '')) {
+      buf += trimmed[j];
+      j++;
+    }
+    tokens.push(buf);
+    i = j;
+  }
+  if (tokens[0] === 'kubectl') tokens.shift();
+  return tokens;
+}

--- a/packages/agent-core/src/agent/handlers/__tests__/ops-allowlist.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/ops-allowlist.test.ts
@@ -5,7 +5,8 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { AdapterRegistry } from '../../../adapters/index.js';
-import { handleOpsRunCommand, parseKubectlCommandString } from '../ops.js';
+import { handleOpsRunCommand } from '../ops.js';
+import { parseKubectlCommandString } from '@agentic-obs/adapters';
 import type { ActionContext } from '../_context.js';
 
 function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {

--- a/packages/agent-core/src/agent/handlers/ops.ts
+++ b/packages/agent-core/src/agent/handlers/ops.ts
@@ -1,60 +1,6 @@
-import { checkKubectl } from '@agentic-obs/adapters';
+import { checkKubectl, parseKubectlCommandString } from '@agentic-obs/adapters';
 import type { ActionContext } from './_context.js';
 import { withToolEventBoundary } from './_shared.js';
-
-/**
- * Best-effort argv parser for a `kubectl ...` command string.
- *
- * The `ops.run_command` tool accepts the command as one user-facing string,
- * so we don't have a structured argv at the handler boundary. We split
- * conservatively (whitespace, single+double quotes) to feed the P6
- * allowlist; any parse failure falls through to the runner, which is
- * still trusted to validate at its layer.
- *
- * Rules:
- *   - leading "kubectl" is dropped if present
- *   - "$(...)" / backticks / pipes / redirects are NOT supported and
- *     produce an empty argv (caller treats that as "couldn't validate"
- *     and lets the runner reject it).
- */
-export function parseKubectlCommandString(command: string): string[] {
-  const trimmed = command.trim();
-  if (!trimmed) return [];
-  if (/[`$|;&><]/.test(trimmed)) return [];
-
-  const tokens: string[] = [];
-  let i = 0;
-  while (i < trimmed.length) {
-    const ch = trimmed[i] ?? '';
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      i++;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      const quote = ch;
-      let j = i + 1;
-      let buf = '';
-      while (j < trimmed.length && trimmed[j] !== quote) {
-        buf += trimmed[j];
-        j++;
-      }
-      if (j >= trimmed.length) return []; // unterminated quote
-      tokens.push(buf);
-      i = j + 1;
-      continue;
-    }
-    let j = i;
-    let buf = '';
-    while (j < trimmed.length && !/\s/.test(trimmed[j] ?? '')) {
-      buf += trimmed[j];
-      j++;
-    }
-    tokens.push(buf);
-    i = j;
-  }
-  if (tokens[0] === 'kubectl') tokens.shift();
-  return tokens;
-}
 
 export async function handleOpsRunCommand(
   ctx: ActionContext,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -41,9 +41,7 @@ export type { Investigation, InvestigationPlan, InvestigationStatus } from '@age
 
 export {
   runBackgroundAgent,
-  type BackgroundAgentRunInput,
   type BackgroundRunnerDeps,
-  type ISaTokenResolver,
 } from './agent/background-runner.js';
 
 export type { AgentType } from './agent/agent-types.js';

--- a/packages/api-gateway/src/services/ops-command-runner-service.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.ts
@@ -1,5 +1,5 @@
 import type { Identity } from '@agentic-obs/common';
-import { KubectlExecutionAdapter } from '@agentic-obs/adapters';
+import { KubectlExecutionAdapter, parseKubectlCommandString } from '@agentic-obs/adapters';
 import type {
   IApprovalRequestRepository,
   IOpsConnectorRepository,
@@ -185,7 +185,7 @@ export class OpsCommandRunnerService {
     connector: OpsConnector,
     command: string,
   ): Promise<{ observation: string; decision: OpsCommandDecision }> {
-    const argv = tokenizeKubectlCommand(command).slice(1);
+    const argv = parseKubectlCommandString(command);
     if (argv.length === 0) {
       return { decision: 'denied', observation: 'empty kubectl command' };
     }
@@ -320,34 +320,6 @@ export function classifyOpsCommand(command: string): { decision: OpsCommandDecis
   }
 
   return { decision: 'approval_required', reason: 'unclassified kubectl command must be reviewed' };
-}
-
-function tokenizeKubectlCommand(command: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | null = null;
-  for (let i = 0; i < command.length; i += 1) {
-    const ch = command[i]!;
-    if (quote) {
-      if (ch === quote) quote = null;
-      else current += ch;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      quote = ch;
-      continue;
-    }
-    if (/\s/.test(ch)) {
-      if (current) {
-        tokens.push(current);
-        current = '';
-      }
-      continue;
-    }
-    current += ch;
-  }
-  if (current) tokens.push(current);
-  return tokens;
 }
 
 function formatKubectlObservation(


### PR DESCRIPTION
Sweep over the auto-remediation code looking for: god-file growth, duplicated helpers, unused exports, missing tests. Two findings, both fixable here.

## 1. Duplicate kubectl tokenizers consolidated

`parseKubectlCommandString` (agent-core, strict — rejects shell meta) and `tokenizeKubectlCommand` (api-gateway, lenient) both turned `kubectl ...` strings into argv. Now consolidated as `parseKubectlCommandString` exported from `@agentic-obs/adapters`. Both call sites import from there.

| Concern | Behavior |
|---|---|
| Shell metacharacters in command | Now rejected with empty argv -> upstream returns `denied`. Was: passed through to kubectl. |
| Unterminated quotes | Now rejected. Was: silently appended to last token. |
| Leading `kubectl` token | Stripped by tokenizer. Was: stripped via `.slice(1)` at call site. |

The api-gateway path runs through `classifyOpsCommand` upstream which already says 'only kubectl commands are supported', so the strict tokenizer is defense-in-depth, not a regression.

## 2. Unused barrel exports trimmed

`BackgroundAgentRunInput` and `ISaTokenResolver` were re-exported from `@agentic-obs/agent-core` in #105 but have zero callers outside agent-core. Dropped. `runBackgroundAgent` and `BackgroundRunnerDeps` stay (used by dispatcher).

## Other findings (no action)

| Concern | Verdict |
|---|---|
| `PlanExecutorService` 476 LOC | One state machine, 5 public + 6 private methods all about plan lifecycle. Splitting is artificial. Keep. |
| `ops-command-runner-service.ts` 370 LOC | Pre-existing structure. Per CLAUDE.md 'don't refactor things that aren't broken'. Keep. |

## Tests

Full suite: **1474 / 16 skipped** (no change). Lint clean.

## Reverting

`git revert <sha>`. The barrel exports come back; the tokenizer split returns. No data migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `BackgroundAgentRunInput` and `ISaTokenResolver` types from public exports in the agent-core package.

* **Refactor**
  * Consolidated kubectl command string parsing into a shared utility across packages for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->