### PR TITLE
C: AlertEvaluator HA leader lock (design-doc §5)

### DIFF
--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -24,6 +24,7 @@ import {
   type MetricQueryFn,
 } from '../services/alert-evaluator-service.js';
 import { AutoInvestigationDispatcher } from '../services/auto-investigation-dispatcher.js';
+import { LeaderLock } from '../services/leader-lock.js';
 import {
   resolvePrometheusDatasource,
   type PrometheusDatasource,
@@ -91,6 +92,13 @@ export interface MountAlertsDeps {
    * evaluator's `alert.fired` emitter.
    */
   runner?: BackgroundRunnerDeps;
+  /**
+   * QueryClient used to back the leader lock. When provided AND
+   * `ALERT_EVALUATOR_HA=true`, the evaluator only runs while it holds
+   * the lock. Multi-replica deploys should pass this so two api-gateway
+   * pods don't both fire alerts.
+   */
+  db?: import('@agentic-obs/data-layer').QueryClient;
 }
 
 /**
@@ -109,9 +117,26 @@ export async function startAlerts(deps: MountAlertsDeps): Promise<{
     return { evaluator: null, dispatcher: null, stop: () => undefined };
   }
 
+  let leaderLock: LeaderLock | undefined;
+  if (envFlag('ALERT_EVALUATOR_HA', false) && deps.db) {
+    const ttlMs = Number(process.env['ALERT_EVALUATOR_LEADER_TTL_MS']) || 30_000;
+    leaderLock = new LeaderLock({
+      db: deps.db,
+      key: 'alert_evaluator.leader',
+      ttlMs,
+    });
+    log.info({ ttlMs }, 'alert evaluator HA mode: leader lock enabled');
+  } else if (envFlag('ALERT_EVALUATOR_HA', false) && !deps.db) {
+    log.warn(
+      'ALERT_EVALUATOR_HA=true but no db handle wired into startAlerts; running without leader lock. ' +
+      'Multi-replica deploys will double-fire alerts in this state.',
+    );
+  }
+
   const evaluator = new AlertEvaluatorService({
     rules: deps.rules,
     query: buildMetricQueryFn(deps.setupConfig),
+    ...(leaderLock ? { leaderLock } : {}),
   });
   await evaluator.start();
   log.info('alert evaluator started');

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -202,6 +202,7 @@ export async function createApp(): Promise<Application> {
   app.locals['alertsHandle'] = await startAlerts({
     rules: persistence.repos.alertRules,
     setupConfig,
+    db: persistence.db,
     runner: {
       saTokens: bundle.apiKeyService,
       makeOrchestrator: buildBackgroundOrchestratorFactory({

--- a/packages/api-gateway/src/services/alert-evaluator-service.ts
+++ b/packages/api-gateway/src/services/alert-evaluator-service.ts
@@ -25,6 +25,7 @@
 
 import { EventEmitter } from 'node:events';
 import { createLogger } from '@agentic-obs/common/logging';
+import type { LeaderLock } from './leader-lock.js';
 import type {
   AlertOperator,
   AlertRule,
@@ -79,6 +80,20 @@ export interface AlertEvaluatorOptions {
    * everything.
    */
   defaultIntervalSec?: number;
+  /**
+   * Optional leader lock for multi-replica HA. When provided, `start()`
+   * tries to acquire it before scheduling rules; if another replica
+   * holds it, this instance waits. A heartbeat refreshes the lock; if we
+   * lose it (e.g. paused process longer than TTL) the schedulers are
+   * cleared and acquisition resumes. Single-process deploys can leave
+   * this unset.
+   */
+  leaderLock?: LeaderLock;
+  /**
+   * How often to heartbeat / poll for leadership. Defaults to one third
+   * of `leaderLock.ttlMs`. Has no effect when `leaderLock` is unset.
+   */
+  leaderHeartbeatMs?: number;
 }
 
 /**
@@ -133,6 +148,10 @@ export class AlertEvaluatorService extends EventEmitter {
   private readonly query: MetricQueryFn;
   private readonly clock: ClockFn;
   private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly leaderLock?: LeaderLock;
+  private readonly leaderHeartbeatMs: number;
+  private leaderTimer?: NodeJS.Timeout;
+  private isLeader = false;
   private running = false;
 
   // Typed event helpers. Method overrides here (not declaration merging)
@@ -169,6 +188,10 @@ export class AlertEvaluatorService extends EventEmitter {
     this.rules = opts.rules;
     this.query = opts.query;
     this.clock = opts.clock ?? (() => new Date());
+    this.leaderLock = opts.leaderLock;
+    this.leaderHeartbeatMs =
+      opts.leaderHeartbeatMs ??
+      (this.leaderLock ? Math.max(1000, Math.floor(this.leaderLock.ttlMs / 3)) : 0);
   }
 
   /**
@@ -177,19 +200,65 @@ export class AlertEvaluatorService extends EventEmitter {
    * we also re-pull the rule list so newly created/disabled rules get
    * picked up without a service restart.
    *
-   * v1: single process. Multi-replica HA (instance_settings leader lock) is
-   * a follow-up.
+   * When a leaderLock is configured, evaluation only runs while we hold
+   * the lock. The acquire-or-wait poll is run on the same heartbeat
+   * cadence as the lease renewal — a non-leader replica polls cheaply
+   * until the current leader's lease expires.
    */
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    await this.refreshSchedule();
+    if (this.leaderLock) {
+      this.leaderTimer = setInterval(() => {
+        if (!this.running) return;
+        void this.tickLeader();
+      }, this.leaderHeartbeatMs);
+      // Best-effort eager attempt so the first claim doesn't wait one
+      // heartbeat interval.
+      await this.tickLeader();
+    } else {
+      this.isLeader = true;
+      await this.refreshSchedule();
+    }
   }
 
   stop(): void {
     this.running = false;
+    if (this.leaderTimer) {
+      clearInterval(this.leaderTimer);
+      this.leaderTimer = undefined;
+    }
     for (const t of this.timers.values()) clearInterval(t);
     this.timers.clear();
+    if (this.leaderLock && this.isLeader) {
+      // fire-and-forget; release errors are not fatal
+      void this.leaderLock.release().catch(() => undefined);
+    }
+    this.isLeader = false;
+  }
+
+  /**
+   * Re-evaluate leadership. If we're not leader, try to acquire; if we
+   * are, heartbeat. State changes are mirrored on the per-rule timers.
+   */
+  private async tickLeader(): Promise<void> {
+    if (!this.leaderLock) return;
+    if (this.isLeader) {
+      const stillMine = await this.leaderLock.heartbeat();
+      if (!stillMine) {
+        log.warn({}, 'alert evaluator lost leader lock; clearing schedulers');
+        this.isLeader = false;
+        for (const t of this.timers.values()) clearInterval(t);
+        this.timers.clear();
+      }
+      return;
+    }
+    const got = await this.leaderLock.tryAcquire();
+    if (got.ok) {
+      log.info({}, 'alert evaluator acquired leader lock; starting schedulers');
+      this.isLeader = true;
+      await this.refreshSchedule();
+    }
   }
 
   /**

--- a/packages/api-gateway/src/services/leader-lock.test.ts
+++ b/packages/api-gateway/src/services/leader-lock.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for LeaderLock against in-memory SQLite, exercising the
+ * shared-DB race scenarios.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb, type SqliteClient } from '@agentic-obs/data-layer';
+import { LeaderLock } from './leader-lock.js';
+
+describe('LeaderLock', () => {
+  let db: SqliteClient;
+  let now: Date;
+
+  beforeEach(() => {
+    db = createTestDb();
+    now = new Date('2026-04-30T00:00:00.000Z');
+  });
+
+  function lock(id: string, ttlMs = 30_000): LeaderLock {
+    return new LeaderLock({
+      db,
+      key: 'alert_evaluator.leader',
+      leaderId: id,
+      ttlMs,
+      clock: () => now,
+    });
+  }
+
+  it('first claimer wins; second sees ok=false', async () => {
+    const a = lock('a');
+    const b = lock('b');
+    expect((await a.tryAcquire()).ok).toBe(true);
+    expect((await b.tryAcquire()).ok).toBe(false);
+  });
+
+  it('heartbeat extends the lease', async () => {
+    const a = lock('a', 60_000);
+    expect((await a.tryAcquire()).ok).toBe(true);
+
+    // Move the clock close to expiry
+    now = new Date(now.getTime() + 50_000);
+    expect(await a.heartbeat()).toBe(true);
+
+    // Another contender at this point sees a healthy lock
+    now = new Date(now.getTime() + 30_000);  // still inside the renewed TTL (which now expires at +110s)
+    const b = lock('b');
+    expect((await b.tryAcquire()).ok).toBe(false);
+  });
+
+  it('expired lock can be taken over', async () => {
+    const a = lock('a', 1000);
+    expect((await a.tryAcquire()).ok).toBe(true);
+
+    // Past the TTL without heartbeat
+    now = new Date(now.getTime() + 5000);
+    const b = lock('b');
+    expect((await b.tryAcquire()).ok).toBe(true);
+
+    // The original holder's heartbeat now fails because b owns it
+    expect(await a.heartbeat()).toBe(false);
+  });
+
+  it('release relinquishes the lock', async () => {
+    const a = lock('a');
+    expect((await a.tryAcquire()).ok).toBe(true);
+    await a.release();
+    const b = lock('b');
+    expect((await b.tryAcquire()).ok).toBe(true);
+  });
+
+  it('release by a non-holder is a no-op', async () => {
+    const a = lock('a');
+    expect((await a.tryAcquire()).ok).toBe(true);
+    const b = lock('b');
+    await b.release(); // we don't hold it
+    expect(await a.heartbeat()).toBe(true);
+  });
+
+  it('heartbeat by a non-holder returns false without stomping the actual holder', async () => {
+    const a = lock('a');
+    expect((await a.tryAcquire()).ok).toBe(true);
+    const b = lock('b');
+    expect(await b.heartbeat()).toBe(false);
+    // a still owns it
+    expect(await a.heartbeat()).toBe(true);
+  });
+
+  it('two concurrent acquirers — only one wins', async () => {
+    const a = lock('a');
+    const b = lock('b');
+    const [r1, r2] = await Promise.all([a.tryAcquire(), b.tryAcquire()]);
+    const wins = [r1.ok, r2.ok].filter(Boolean).length;
+    expect(wins).toBe(1);
+  });
+});

--- a/packages/api-gateway/src/services/leader-lock.ts
+++ b/packages/api-gateway/src/services/leader-lock.ts
@@ -1,0 +1,168 @@
+/**
+ * Single-leader lock backed by `_runtime_settings`.
+ *
+ * Multi-replica HA story (design-doc §5 follow-up): only one
+ * AlertEvaluatorService should evaluate alert rules across replicas,
+ * otherwise a rule fires twice — once per replica — and downstream
+ * (history rows, ApprovalRequests, auto-investigations) gets duplicated.
+ *
+ * The lock is a row keyed on a caller-chosen string. The current holder
+ * stores its `leaderId` and an `expiresAt` ISO timestamp inside the
+ * value JSON; everyone else can take over after expiry. Holder
+ * heartbeats periodically to extend its lease.
+ *
+ * Cross-dialect SQL: `_runtime_settings` exists in both SQLite and
+ * Postgres schemas, and `json_extract` works on both (with the same
+ * `$.path` argument shape). The repository's `QueryClient` abstracts
+ * the dialect.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { createLogger } from '@agentic-obs/common/logging';
+import type { QueryClient } from '@agentic-obs/data-layer';
+
+const log = createLogger('leader-lock');
+
+export interface LeaderLockOptions {
+  db: QueryClient;
+  /** Stable key for the lock; one lock per key. */
+  key: string;
+  /** Override for tests; defaults to randomUUID(). */
+  leaderId?: string;
+  /**
+   * How long a claim is valid past the last heartbeat. After this passes,
+   * the lock is considered stale and another instance can take over.
+   * Default 30 seconds.
+   */
+  ttlMs?: number;
+  /** Override for tests. */
+  clock?: () => Date;
+}
+
+/**
+ * Result of a lock attempt. The `leaderId` field is the ID we used to
+ * claim — store it on the caller side if you want to assert against
+ * subsequent heartbeats.
+ */
+export interface LockClaim {
+  ok: boolean;
+  /** Set when ok=true — the leaderId we now own the row under. */
+  leaderId?: string;
+}
+
+interface LockValue {
+  leaderId: string;
+  expiresAt: string;
+}
+
+/**
+ * Lock primitive. Stateless — `tryAcquire`, `heartbeat`, `release` are
+ * the surface. Callers wrap these in their own lifecycle (timer +
+ * "what to do when leadership flips").
+ */
+export class LeaderLock {
+  readonly leaderId: string;
+  readonly key: string;
+  readonly ttlMs: number;
+  private readonly db: QueryClient;
+  private readonly clock: () => Date;
+
+  constructor(opts: LeaderLockOptions) {
+    this.db = opts.db;
+    this.key = opts.key;
+    this.leaderId = opts.leaderId ?? randomUUID();
+    this.ttlMs = opts.ttlMs ?? 30_000;
+    this.clock = opts.clock ?? (() => new Date());
+  }
+
+  /**
+   * Try to claim the lock. Succeeds when:
+   *   - the row doesn't exist yet, OR
+   *   - the existing row's `expiresAt` is in the past.
+   *
+   * If a healthy holder owns the lock, returns `{ ok: false }` without
+   * stomping on it.
+   */
+  async tryAcquire(): Promise<LockClaim> {
+    const now = this.clock();
+    const expiresAt = new Date(now.getTime() + this.ttlMs).toISOString();
+    const value: LockValue = { leaderId: this.leaderId, expiresAt };
+    const valueJson = JSON.stringify(value);
+
+    // Phase 1: try insert. If row exists, ON CONFLICT branches based on
+    // whether the existing value's expiresAt is in the past — only stomp
+    // on stale rows.
+    await this.db.run(sql`
+      INSERT INTO _runtime_settings (id, value, updated)
+      VALUES (${this.key}, ${valueJson}, ${now.toISOString()})
+      ON CONFLICT(id) DO UPDATE
+      SET value = ${valueJson}, updated = ${now.toISOString()}
+      WHERE json_extract(_runtime_settings.value, '$.expiresAt') < ${now.toISOString()}
+    `);
+
+    // Phase 2: read back. If our leaderId is the row's leaderId, we won.
+    const rows = await this.db.all<{ value: string }>(sql`
+      SELECT value FROM _runtime_settings WHERE id = ${this.key}
+    `);
+    const cur = parseValue(rows[0]?.value);
+    if (cur && cur.leaderId === this.leaderId) {
+      return { ok: true, leaderId: this.leaderId };
+    }
+    return { ok: false };
+  }
+
+  /**
+   * Refresh the expiry on the lock. Returns true iff we still own it
+   * (heartbeat won't overwrite a row that's been taken from us by
+   * someone else after TTL expiry).
+   */
+  async heartbeat(): Promise<boolean> {
+    const now = this.clock();
+    const expiresAt = new Date(now.getTime() + this.ttlMs).toISOString();
+    const value: LockValue = { leaderId: this.leaderId, expiresAt };
+    const valueJson = JSON.stringify(value);
+
+    await this.db.run(sql`
+      UPDATE _runtime_settings
+      SET value = ${valueJson}, updated = ${now.toISOString()}
+      WHERE id = ${this.key}
+      AND json_extract(value, '$.leaderId') = ${this.leaderId}
+    `);
+
+    const rows = await this.db.all<{ value: string }>(sql`
+      SELECT value FROM _runtime_settings WHERE id = ${this.key}
+    `);
+    const cur = parseValue(rows[0]?.value);
+    return cur?.leaderId === this.leaderId;
+  }
+
+  /**
+   * Release the lock if we hold it. Idempotent — calling release when
+   * we don't hold the lock (already lost or never acquired) is a no-op.
+   */
+  async release(): Promise<void> {
+    await this.db.run(sql`
+      DELETE FROM _runtime_settings
+      WHERE id = ${this.key}
+      AND json_extract(value, '$.leaderId') = ${this.leaderId}
+    `);
+  }
+}
+
+function parseValue(raw: string | null | undefined): LockValue | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Partial<LockValue>;
+    if (typeof v.leaderId === 'string' && typeof v.expiresAt === 'string') {
+      return v as LockValue;
+    }
+    return null;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'leader-lock: stored value is not JSON; treating as stale',
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
Closes the multi-replica HA follow-up from §5 of the auto-remediation design.

Today, each api-gateway replica runs its own `AlertEvaluatorService`. A multi-replica deploy double-fires every alert. This PR adds a single-leader lock backed by the existing `_runtime_settings` KV table (no schema migration).

| Knob | Default | Effect |
|---|---|---|
| `ALERT_EVALUATOR_HA` | `false` | When `true`, evaluator only runs while it holds the lock. Single-replica deploys leave this off. |
| `ALERT_EVALUATOR_LEADER_TTL_MS` | `30_000` | How long the lease is valid after the last heartbeat. After expiry, another replica can take over. |

## Algorithm

| Operation | SQL |
|---|---|
| `tryAcquire` | `INSERT INTO _runtime_settings VALUES (...) ON CONFLICT(id) DO UPDATE SET ... WHERE json_extract(_runtime_settings.value, '$.expiresAt') < now` then read-back to verify. Stomps only on stale rows. |
| `heartbeat` | `UPDATE ... WHERE json_extract(value, '$.leaderId') = us` then read-back. Returns false iff someone else has taken over. |
| `release` | `DELETE WHERE json_extract(value, '$.leaderId') = us`. Idempotent. |

`json_extract` works the same on SQLite + Postgres. No dialect-specific code; `QueryClient` abstracts the rest.

## Surface

| | |
|---|---|
| New | `services/leader-lock.ts` (168 LOC, single concept) |
| Modified | `services/alert-evaluator-service.ts` — optional `leaderLock` + `leaderHeartbeatMs` opts. Tick loop replaces the bare scheduler when HA mode is on. |
| Modified | `app/alerts-boot.ts` — constructs the lock when `ALERT_EVALUATOR_HA=true` AND a `db` handle is wired. |
| Modified | `app/server.ts` — passes `persistence.db` into `startAlerts`. |

## Tests

7 new lock-primitive tests (concurrent acquirers, heartbeat extends, expired takeover, release relinquish, no-stomp on non-holder, etc.) against shared in-memory SQLite. The 18 existing AlertEvaluatorService tests still pass (lock is opt-in).

Full suite **1485 passed / 16 skipped** (was 1478). Lint clean.

## Reverting

`git revert <sha>`. The lock module + lock options on the evaluator stop existing. `_runtime_settings` rows under `alert_evaluator.leader` become orphans (harmless — nothing else reads them). HA-mode deploys would need to revert to single-replica until re-applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high availability support for alert evaluation in multi-replica deployments, utilizing automatic leader election to ensure only one instance evaluates alerts at a time while others remain on standby.

* **Tests**
  * Added comprehensive test coverage for the leader election mechanism, including acquisition, heartbeat renewal, lease expiration handling, and concurrent contention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->