### PR TITLE
Install kubectl in runtime image + K8s-friendly helm defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,16 @@ FROM node:20-alpine AS runner
 
 WORKDIR /app
 
+# kubectl is required by the Kubernetes ops connector (spawned as a child
+# process). Pinned to a stable minor; bump alongside cluster version skew.
+ARG KUBECTL_VERSION=v1.31.4
+RUN apk add --no-cache curl ca-certificates \
+    && ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=3000 \

--- a/helm/openobs/templates/configmap.yaml
+++ b/helm/openobs/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   SESSION_TTL: {{ .Values.env.SESSION_TTL | quote }}
   PROACTIVE_CHECK_INTERVAL_MS: {{ .Values.env.PROACTIVE_CHECK_INTERVAL_MS | quote }}
   PROACTIVE_HISTORY_SIZE: {{ .Values.env.PROACTIVE_HISTORY_SIZE | quote }}
+  OPENOBS_ALLOW_PRIVATE_URLS: {{ .Values.env.OPENOBS_ALLOW_PRIVATE_URLS | quote }}
   {{- if .Values.env.LLM_FALLBACK_PROVIDER }}
   LLM_FALLBACK_PROVIDER: {{ .Values.env.LLM_FALLBACK_PROVIDER | quote }}
   {{- end }}

--- a/helm/openobs/values.yaml
+++ b/helm/openobs/values.yaml
@@ -81,6 +81,10 @@ env:
   SESSION_TTL: "86400"
   PROACTIVE_CHECK_INTERVAL_MS: "60000"
   PROACTIVE_HISTORY_SIZE: "100"
+  # In-cluster datasources (e.g. http://prometheus.monitoring:9090) resolve
+  # to RFC1918 addresses; the helm chart targets self-hosted operators, so
+  # default to permissive. Set to "false" for multi-tenant / public deploys.
+  OPENOBS_ALLOW_PRIVATE_URLS: "true"
   extra: {}
 
 secretEnv:


### PR DESCRIPTION
## Summary
- Install `kubectl` v1.31.4 into the runtime Docker image so the Kubernetes ops connector's spawned `kubectl` calls don't ENOENT.
- Flip helm chart defaults for typical in-cluster installs:
  - `env.OPENOBS_ALLOW_PRIVATE_URLS=true` — datasources pointed at in-cluster services like `http://prometheus.monitoring:9090` (RFC1918) now pass the SSRF guard. Multi-tenant deploys can flip back to `"false"`.
  - `configmap.yaml` renders `OPENOBS_ALLOW_PRIVATE_URLS` so `values.yaml` overrides actually reach the pod.

## Why
Hit while smoke-testing auto-remediation in a kind cluster. The K8s connector saved fine, "Test Connection" passed, then every agent tool call failed with `ENOENT (binary not found)` because the runtime image is `node:20-alpine` with no kubectl. Separately, in-cluster Prometheus URLs were rejected by the SSRF guard until `OPENOBS_ALLOW_PRIVATE_URLS=true` was set, but the helm chart had no template wiring for it.

## Test plan
- [x] `docker build .` succeeds; resulting image has `/usr/local/bin/kubectl`.
- [x] `helm upgrade openobs helm/openobs` renders ConfigMap with `OPENOBS_ALLOW_PRIVATE_URLS: "true"`.
- [x] In a kind cluster, configured Prometheus datasource at `http://prometheus.openobs-demo.svc.cluster.local:9090` connects without `OPENOBS_ALLOW_PRIVATE_URLS` override.
- [x] Configured Kubernetes ops connector with in-cluster kubeconfig; `kubectl get ns` via agent succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `OPENOBS_ALLOW_PRIVATE_URLS` configuration option to control private URL access in deployments (enabled by default).

* **Chores**
  * Updated container image to include kubectl binary for enhanced operational capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->