### PR TITLE
Fix Investigate 404 + surface pending plans in UI

### DIFF
--- a/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
+++ b/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit test for POST /api/alert-rules/:id/investigate.
+ *
+ * The bug this guards against: the route used to call
+ * `investigationStore.create` without a `workspaceId`, so the resulting
+ * investigation was unreachable from the same workspace's GET handler
+ * (which filters by workspaceId) — operators saw "Investigation not
+ * found" after clicking Investigate. The fix passes the rule's
+ * workspaceId through.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { AlertRule } from '@agentic-obs/common';
+import type { Identity } from '@agentic-obs/common';
+import { setAuthMiddleware } from '../middleware/auth.js';
+import { createAlertRulesRouter } from './alert-rules.js';
+
+const ALWAYS_ALLOW: { evaluate: () => Promise<true>; eval: (...a: unknown[]) => unknown } = {
+  evaluate: async () => true as const,
+  eval: () => ({}),
+};
+
+const SETUP_CONFIG_STUB = {} as unknown as ConstructorParameters<
+  typeof import('../services/alert-rule-service.js').AlertRuleService
+>[1];
+
+function makeRule(overrides: Partial<AlertRule> = {}): AlertRule {
+  return {
+    id: 'r1',
+    name: 'Test Rule',
+    description: '',
+    condition: { query: 'up', operator: '<', threshold: 1, forDurationSec: 0 },
+    evaluationIntervalSec: 60,
+    severity: 'high',
+    labels: {},
+    state: 'firing',
+    stateChangedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    fireCount: 1,
+    workspaceId: 'ws_team_a',
+    ...overrides,
+  } as AlertRule;
+}
+
+function makeApp(opts: {
+  rule: AlertRule | null;
+  identity: Identity;
+  capturedCreate: ReturnType<typeof vi.fn>;
+}) {
+  const store = {
+    findById: vi.fn(async () => opts.rule),
+    update: vi.fn(async () => undefined),
+  } as unknown as Parameters<typeof createAlertRulesRouter>[0]['alertRuleStore'];
+
+  const investigationStore = {
+    create: opts.capturedCreate,
+  } as unknown as Parameters<typeof createAlertRulesRouter>[0]['investigationStore'];
+
+  setAuthMiddleware((req, _res, next) => {
+    (req as express.Request & { auth?: Identity }).auth = opts.identity;
+    next();
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/alert-rules',
+    createAlertRulesRouter({
+      alertRuleStore: store,
+      investigationStore,
+      setupConfig: SETUP_CONFIG_STUB,
+      ac: ALWAYS_ALLOW as unknown as Parameters<typeof createAlertRulesRouter>[0]['ac'],
+    }),
+  );
+  return app;
+}
+
+describe('POST /api/alert-rules/:id/investigate', () => {
+  beforeEach(() => {
+    setAuthMiddleware(null);
+  });
+
+  it('passes the rule\'s workspaceId to investigationStore.create', async () => {
+    const create = vi.fn(async (input: { workspaceId?: string }) => ({
+      id: 'inv_1',
+      workspaceId: input.workspaceId,
+    }));
+    const app = makeApp({
+      rule: makeRule({ workspaceId: 'ws_team_a' }),
+      identity: { userId: 'u1', orgId: 'ws_team_a', orgRole: 'Editor', isServerAdmin: false, authenticatedBy: 'session' },
+      capturedCreate: create,
+    });
+
+    const res = await request(app)
+      .post('/api/alert-rules/r1/investigate')
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ investigationId: 'inv_1', existing: false });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect((create.mock.calls[0] as unknown[])?.[0]).toMatchObject({ workspaceId: 'ws_team_a' });
+  });
+
+  it('falls back to the requester\'s workspace when the rule has none', async () => {
+    const create = vi.fn(async () => ({ id: 'inv_2' }));
+    const app = makeApp({
+      rule: makeRule({ workspaceId: undefined }),
+      identity: { userId: 'u1', orgId: 'org_main', orgRole: 'Editor', isServerAdmin: false, authenticatedBy: 'session' },
+      capturedCreate: create,
+    });
+
+    await request(app)
+      .post('/api/alert-rules/r1/investigate')
+      .send({})
+      .expect(200);
+
+    expect((create.mock.calls[0] as unknown[])?.[0]).toMatchObject({ workspaceId: 'org_main' });
+  });
+});

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -405,10 +405,16 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         }
 
         const question = `Investigate alert "${rule.name}": ${rule.condition.query} ${rule.condition.operator} ${rule.condition.threshold}`;
+        // Scope the investigation to the rule's workspace so the operator
+        // viewing it from the same workspace can read it back. Falling back
+        // to the requester's workspace covers older rules without an
+        // explicit workspaceId.
+        const workspaceId = rule.workspaceId ?? resolveOrgId(req);
         const investigation = await deps.investigationStore.create({
           question,
           sessionId: `ses_alert_${Date.now()}`,
           userId: 'alert-system',
+          workspaceId,
         });
 
         // Investigation orchestration now handled by the dashboard agent via chat

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext.js';
 import { useTheme } from '../contexts/ThemeContext.js';
 import { OpenObsLogo } from './OpenObsLogo.js';
 import { OrgSwitcher } from './OrgSwitcher.js';
+import { plansApi } from '../api/client.js';
 
 /* ───── Icon components ───── */
 
@@ -33,6 +34,15 @@ function InvestigationIcon({ className }: { className?: string }) {
     <svg className={className ?? 'w-5 h-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
       <circle cx="12" cy="12" r="9" strokeLinecap="round" strokeLinejoin="round" />
       <polygon points="16.24,7.76 14.12,14.12 7.76,16.24 9.88,9.88" stroke="currentColor" strokeWidth={1.8} strokeLinejoin="round" fill="none" />
+    </svg>
+  );
+}
+
+/* Actions — checkmark/clipboard icon for the Action Center */
+function ActionsIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className ?? 'w-5 h-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
     </svg>
   );
 }
@@ -106,16 +116,20 @@ interface SidebarItemProps {
   icon: React.ReactNode;
   end?: boolean;
   expanded: boolean;
+  /** Optional small badge (e.g. pending count) shown on the icon / label. */
+  badge?: number;
 }
 
-function SidebarItem({ to, label, icon, end, expanded }: SidebarItemProps) {
+function SidebarItem({ to, label, icon, end, expanded, badge }: SidebarItemProps) {
+  const showBadge = typeof badge === 'number' && badge > 0;
+  const badgeLabel = showBadge ? (badge > 99 ? '99+' : String(badge)) : null;
   return (
     <NavLink
       to={to}
       end={end}
-      title={expanded ? undefined : label}
+      title={expanded ? undefined : (showBadge ? `${label} (${badgeLabel} pending)` : label)}
       className={({ isActive }) =>
-        `flex items-center gap-3 h-10 rounded-lg transition-colors ${
+        `relative flex items-center gap-3 h-10 rounded-lg transition-colors ${
           expanded ? 'px-3 w-full' : 'justify-center w-10'
         } ${
           isActive
@@ -124,8 +138,30 @@ function SidebarItem({ to, label, icon, end, expanded }: SidebarItemProps) {
         }`
       }
     >
-      {icon}
-      {expanded && <span className="text-sm font-medium truncate">{label}</span>}
+      <span className="relative inline-flex">
+        {icon}
+        {showBadge && !expanded && (
+          <span
+            aria-label={`${badgeLabel} pending`}
+            className="absolute -top-1 -right-1.5 min-w-[16px] h-4 px-1 rounded-full bg-primary text-on-primary-fixed text-[10px] font-bold leading-4 text-center"
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </span>
+      {expanded && (
+        <>
+          <span className="text-sm font-medium truncate">{label}</span>
+          {showBadge && (
+            <span
+              aria-label={`${badgeLabel} pending`}
+              className="ml-auto inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full bg-primary text-on-primary-fixed text-[10px] font-bold"
+            >
+              {badgeLabel}
+            </span>
+          )}
+        </>
+      )}
     </NavLink>
   );
 }
@@ -251,6 +287,25 @@ export default function Navigation() {
     window.localStorage.setItem('openobs:sidebar-expanded', expanded ? '1' : '0');
   }, [expanded]);
 
+  // Pending-plan badge for the Action Center entry. Polled every 30s
+  // (per the UX brief) so operators see remediation work waiting on them
+  // even if they aren't on the alerts/investigation pages.
+  const [pendingPlans, setPendingPlans] = useState(0);
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    const fetchOnce = () => {
+      void plansApi.list({ status: 'pending_approval' })
+        .then(({ data }) => {
+          if (!cancelled) setPendingPlans(data?.length ?? 0);
+        })
+        .catch(() => { /* non-fatal — leave previous count */ });
+    };
+    fetchOnce();
+    const timer = setInterval(fetchOnce, 30_000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [user]);
+
   const handleLogout = async () => {
     await logout();
     navigate('/login', { replace: true });
@@ -317,6 +372,7 @@ export default function Navigation() {
         <SidebarItem to="/dashboards" label="Dashboards" icon={<DashboardIcon />} expanded={expanded} />
         <SidebarItem to="/investigations" label="Investigations" icon={<InvestigationIcon />} expanded={expanded} />
         <SidebarItem to="/alerts" label="Alerts" icon={<AlertsIcon />} expanded={expanded} />
+        <SidebarItem to="/actions" label="Actions" icon={<ActionsIcon />} expanded={expanded} badge={pendingPlans} />
       </div>
 
       {/* Bottom nav items */}

--- a/packages/web/src/components/plans/InvestigationPlanBanner.tsx
+++ b/packages/web/src/components/plans/InvestigationPlanBanner.tsx
@@ -43,19 +43,59 @@ export default function InvestigationPlanBanner({ investigationId }: Props) {
   const headline = ordered[0];
   if (!headline) return null;
 
+  const isUrgent = URGENT_STATUSES.has(headline.status);
+
   return (
-    <Link
-      to={`/plans/${headline.id}`}
-      className="block px-3 py-1.5 rounded-md bg-primary/10 text-primary hover:bg-primary/15 text-xs font-medium border border-primary/20 transition-colors"
+    <div
+      className={`flex items-center gap-3 px-4 py-3 border-b ${
+        isUrgent
+          ? 'bg-primary/10 border-primary/30'
+          : 'bg-surface-high border-outline-variant/40'
+      }`}
+      data-testid="investigation-plan-banner"
     >
-      {headline.status === 'pending_approval'
-        ? 'Remediation plan ready → Review'
-        : headline.status === 'failed'
-        ? 'Remediation plan failed → Open'
-        : `Remediation plan (${headline.status.replace(/_/g, ' ')})`}
-      {plans.length > 1 && (
-        <span className="ml-1 opacity-70">+{plans.length - 1} more</span>
-      )}
-    </Link>
+      <span
+        className={`shrink-0 w-2 h-2 rounded-full ${
+          headline.status === 'pending_approval'
+            ? 'bg-primary animate-pulse'
+            : headline.status === 'failed'
+            ? 'bg-error'
+            : 'bg-on-surface-variant'
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <div className={`text-sm font-semibold ${isUrgent ? 'text-primary' : 'text-on-surface'}`}>
+          {headline.status === 'pending_approval'
+            ? 'Remediation plan ready for review'
+            : headline.status === 'failed'
+            ? 'Remediation plan failed'
+            : `Remediation plan (${headline.status.replace(/_/g, ' ')})`}
+        </div>
+        {headline.summary && (
+          <div className="text-xs text-on-surface-variant truncate mt-0.5">
+            {headline.summary}
+          </div>
+        )}
+      </div>
+      <Link
+        to="/actions?tab=plans"
+        className="shrink-0 text-xs text-on-surface-variant hover:text-on-surface underline-offset-2 hover:underline"
+      >
+        View all plans
+      </Link>
+      <Link
+        to={`/plans/${headline.id}`}
+        className={`shrink-0 px-3 py-1.5 rounded-lg text-xs font-semibold transition-opacity ${
+          isUrgent
+            ? 'bg-primary text-on-primary-fixed hover:opacity-90'
+            : 'bg-surface-highest text-on-surface hover:bg-surface-high'
+        }`}
+      >
+        {headline.status === 'pending_approval' ? 'Review plan →' : 'Open plan →'}
+        {plans.length > 1 && (
+          <span className="ml-1.5 opacity-70 font-normal">+{plans.length - 1} more</span>
+        )}
+      </Link>
+    </div>
   );
 }

--- a/packages/web/src/pages/ActionCenter.tsx
+++ b/packages/web/src/pages/ActionCenter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { apiClient, plansApi } from '../api/client.js';
 import type { RemediationPlan } from '../api/client.js';
 import { relativeTime } from '../utils/time.js';
@@ -166,7 +166,29 @@ export default function ActionCenter() {
   const [processing, setProcessing] = useState<Set<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionInfo, setActionInfo] = useState<string | null>(null);
-  const [tab, setTab] = useState<'pending' | 'plans' | 'resolved'>('pending');
+  // Tab can be deep-linked via `?tab=plans` so the sidebar pending-plan
+  // badge (and the InvestigationDetail "View all plans" link) can land
+  // operators directly on the Plans view.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const initialTab: 'pending' | 'plans' | 'resolved' =
+    tabParam === 'plans' || tabParam === 'resolved' ? tabParam : 'pending';
+  const [tab, setTabState] = useState<'pending' | 'plans' | 'resolved'>(initialTab);
+  const setTab = useCallback((next: 'pending' | 'plans' | 'resolved') => {
+    setTabState(next);
+    const params = new URLSearchParams(searchParams);
+    if (next === 'pending') params.delete('tab');
+    else params.set('tab', next);
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
+  // React to external URL changes (e.g. clicking the sidebar badge while
+  // already on /actions).
+  useEffect(() => {
+    const t = searchParams.get('tab');
+    const next: 'pending' | 'plans' | 'resolved' =
+      t === 'plans' || t === 'resolved' ? t : 'pending';
+    setTabState((prev) => (prev === next ? prev : next));
+  }, [searchParams]);
   const [plans, setPlans] = useState<RemediationPlan[]>([]);
 
   const loadApprovals = useCallback(async () => {

--- a/packages/web/src/pages/Alerts.tsx
+++ b/packages/web/src/pages/Alerts.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { apiClient } from '../api/client.js';
+import { apiClient, plansApi } from '../api/client.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import { relativeTime } from '../utils/time.js';
 import { useAuth } from '../contexts/AuthContext.js';
@@ -88,6 +88,7 @@ function AlertRuleRow({
   navigate,
   canWrite,
   canDelete,
+  pendingPlanId,
 }: {
   rule: AlertRule;
   expanded: boolean;
@@ -100,6 +101,7 @@ function AlertRuleRow({
   navigate: (path: string, opts?: { state?: unknown }) => void;
   canWrite: boolean;
   canDelete: boolean;
+  pendingPlanId?: string;
 }) {
   const stateStyle = STATE_STYLES[rule.state];
   const isDisabled = rule.state === 'disabled';
@@ -243,6 +245,16 @@ function AlertRuleRow({
               </button>
             )}
 
+            {pendingPlanId && (
+              <button
+                type="button"
+                onClick={() => navigate(`/plans/${pendingPlanId}`)}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-[var(--color-primary)] text-on-primary-fixed hover:opacity-90 transition-opacity"
+              >
+                Review plan →
+              </button>
+            )}
+
             {(rule.state === 'firing' || rule.state === 'pending') && (
               <button
                 type="button"
@@ -321,6 +333,7 @@ export default function Alerts() {
   const [groupBy, setGroupBy] = useState<'none' | 'severity'>('none');
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [investigatingId, setInvestigatingId] = useState<string | null>(null);
+  const [pendingPlanByInvestigation, setPendingPlanByInvestigation] = useState<Record<string, string>>({});
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Keyboard shortcut: / to focus search
@@ -349,6 +362,29 @@ export default function Alerts() {
     const timer = setInterval(() => { void loadRules(); }, 10_000);
     return () => clearInterval(timer);
   }, [loadRules]);
+
+  // Pull pending-approval plans once and index by investigationId so
+  // each rule row can surface a "Review plan" CTA without an N+1 fetch.
+  const loadPendingPlans = useCallback(async () => {
+    try {
+      const { data } = await plansApi.list({ status: 'pending_approval' });
+      const map: Record<string, string> = {};
+      for (const p of data ?? []) {
+        if (p.investigationId && !map[p.investigationId]) {
+          map[p.investigationId] = p.id;
+        }
+      }
+      setPendingPlanByInvestigation(map);
+    } catch {
+      // Plans endpoint failures shouldn't break the alerts page.
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPendingPlans();
+    const timer = setInterval(() => { void loadPendingPlans(); }, 10_000);
+    return () => clearInterval(timer);
+  }, [loadPendingPlans]);
 
   const handleToggle = useCallback(async (rule: AlertRule) => {
     const nextState = rule.state === 'disabled' ? 'enable' : 'disable';
@@ -596,6 +632,7 @@ export default function Alerts() {
                       navigate={navigate}
                       canWrite={canWriteRule}
                       canDelete={canDeleteRule}
+                      pendingPlanId={rule.investigationId ? pendingPlanByInvestigation[rule.investigationId] : undefined}
                     />
                   ))}
                 </div>

--- a/packages/web/src/pages/InvestigationDetail.tsx
+++ b/packages/web/src/pages/InvestigationDetail.tsx
@@ -486,9 +486,6 @@ export default function InvestigationDetail() {
           </div>
         </div>
 
-        {/* Remediation plan banner (auto-remediation P7) */}
-        <InvestigationPlanBanner investigationId={investigation.id} />
-
         {/* Status badge */}
         <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
           isGenerating
@@ -501,6 +498,10 @@ export default function InvestigationDetail() {
           {getInvestigationStatusStyle(investigation.status).label}
         </div>
       </div>
+
+      {/* Remediation plan banner (auto-remediation P7) — lifted above the
+          fold so operators can find approval without hunting. */}
+      <InvestigationPlanBanner investigationId={investigation.id} />
 
       {/* Content + Chat split — same layout as DashboardWorkspace */}
       <div className="flex-1 flex overflow-hidden">


### PR DESCRIPTION
## Summary

Two UX fixes for the alert → investigation → plan flow that bit us during e2e testing.

**1. Investigate button no longer 404s.** When the auto-investigation dispatcher creates an investigation off an alert.fired event, the row needs a workspaceId so the GET handler's `findByIdInWorkspace` will return it. POST /alert-rules/:id/investigate now propagates `rule.workspaceId` (with a fallback to the requester's orgId). The InvestigationDetail page already had an in-progress view + 3s polling — they finally render now that the row is reachable.

**2. Pending plans are findable.**
- Alerts row shows a primary "Review plan →" button when an investigation has a pending plan (parent polls `/api/plans?status=pending_approval`, indexes by investigationId).
- InvestigationDetail has a full-width plan banner under the header — pulsing dot for pending state, plain treatment otherwise, plus a "View all plans" deep link to `/actions?tab=plans`.
- Sidebar "Actions" entry with a pending-plan count badge (polls every 30s, works in collapsed and expanded states).
- ActionCenter reads `?tab=plans|resolved` from the URL via useSearchParams.

## Why
- Operators clicked Investigate, got "not found", couldn't recover.
- Operators couldn't find where to approve plans — the route exists at `/actions` but had no nav entry.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 691/691 api-gateway, 113/113 web
- [x] New `alert-rules-investigate.test.ts`: rule-level workspaceId propagated; falls back to requester orgId.
- [ ] Manual: trigger an alert, click Investigate from the Alerts page → see live progress view (no 404).
- [ ] Manual: wait for a plan → "Review plan" button appears on the Alerts row, banner appears on InvestigationDetail, badge appears on Actions sidebar entry.
- [ ] Manual: click banner / button → /plans/:id approve view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Actions" sidebar entry displaying pending approval count with auto-refresh polling.
  * Enabled deep-linking to specific tabs (pending/plans/resolved) in the action center via URL query parameters.
  * Added "Review plan" action buttons on alerts when pending approvals exist.

* **Style**
  * Redesigned investigation plan banner with urgent status indicators, colored badges, and enhanced visual hierarchy.
  * Repositioned investigation detail banner for improved layout.

* **Tests**
  * Added comprehensive test suite for the investigate endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->