### PR TITLE
Grant ops-commands-runner role to auto-investigation SA

### DIFF
--- a/packages/api-gateway/src/app/auth-routes.ts
+++ b/packages/api-gateway/src/app/auth-routes.ts
@@ -35,6 +35,7 @@ import {
 } from '../middleware/auth.js';
 import { createOrgContextMiddleware } from '../middleware/org-context.js';
 import { ApiKeyService } from '../services/apikey-service.js';
+import { RoleService } from '../services/role-service.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import type { AuthRepositoryBundle } from './persistence.js';
@@ -87,9 +88,16 @@ async function runAuthMigration(
   // SA only matters for the alert.fired auto-trigger, and that path is
   // separately gated by AUTO_INVESTIGATION_SA_TOKEN at boot.
   try {
+    const roleService = new RoleService(
+      authRepos.roles,
+      authRepos.permissions,
+      authRepos.userRoles,
+      authRepos.teamRoles,
+    );
     await seedAutoInvestigationSaIfNeeded({
       users: authRepos.users,
       orgUsers: authRepos.orgUsers,
+      roles: roleService,
     });
   } catch (err) {
     log.error(

--- a/packages/api-gateway/src/app/auth-routes.ts
+++ b/packages/api-gateway/src/app/auth-routes.ts
@@ -38,7 +38,7 @@ import { ApiKeyService } from '../services/apikey-service.js';
 import { RoleService } from '../services/role-service.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
-import type { AuthRepositoryBundle } from './persistence.js';
+import type { AuthRepositoryBundle, RbacRepositoryBundle } from './persistence.js';
 import type { QueryClient } from '@agentic-obs/data-layer';
 
 const log = createLogger('auth-routes');
@@ -60,6 +60,7 @@ export interface AuthSubsystemBundle {
 async function runAuthMigration(
   db: QueryClient,
   authRepos: AuthRepositories,
+  rbacRepos: RbacRepositoryBundle,
 ): Promise<void> {
   try {
     await migrateAuthToDbIfNeeded({
@@ -89,10 +90,10 @@ async function runAuthMigration(
   // separately gated by AUTO_INVESTIGATION_SA_TOKEN at boot.
   try {
     const roleService = new RoleService(
-      authRepos.roles,
-      authRepos.permissions,
-      authRepos.userRoles,
-      authRepos.teamRoles,
+      rbacRepos.roles,
+      rbacRepos.permissions,
+      rbacRepos.userRoles,
+      rbacRepos.teamRoles,
     );
     await seedAutoInvestigationSaIfNeeded({
       users: authRepos.users,
@@ -116,9 +117,10 @@ async function runAuthMigration(
 export async function buildAuthSubsystem(
   db: QueryClient,
   authRepos: AuthRepositories,
+  rbacRepos: RbacRepositoryBundle,
   quotas: IQuotaRepository,
 ): Promise<AuthSubsystemBundle> {
-  await runAuthMigration(db, authRepos);
+  await runAuthMigration(db, authRepos, rbacRepos);
 
   const authSub = await createAuthSubsystem(authRepos);
 

--- a/packages/api-gateway/src/auth/seed-auto-investigation-sa.test.ts
+++ b/packages/api-gateway/src/auth/seed-auto-investigation-sa.test.ts
@@ -1,29 +1,59 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   createTestDb,
+  seedDefaultOrg,
+  seedRbacForOrg,
   UserRepository,
   OrgUserRepository,
+  RoleRepository,
+  PermissionRepository,
+  UserRoleRepository,
+  TeamRoleRepository,
   type SqliteClient,
 } from '@agentic-obs/data-layer';
+import { RoleService } from '../services/role-service.js';
 import {
   seedAutoInvestigationSaIfNeeded,
   AUTO_INVESTIGATION_SA_LOGIN,
   AUTO_INVESTIGATION_SA_EMAIL,
 } from './seed-auto-investigation-sa.js';
 
+// We assert by role.name (the `fixed:ops.commands:runner` form) — it's
+// stable and easier to grep for than the uid (`fixed_ops_commands_runner`).
+const OPS_COMMANDS_RUNNER_ROLE_NAME = 'fixed:ops.commands:runner';
+
 describe('seedAutoInvestigationSaIfNeeded', () => {
   let db: SqliteClient;
   let users: UserRepository;
   let orgUsers: OrgUserRepository;
+  let roles: RoleService;
+  let userRolesRepo: UserRoleRepository;
+  let rolesRepo: RoleRepository;
 
   beforeEach(async () => {
     db = createTestDb();
+    await seedDefaultOrg(db);
+    await seedRbacForOrg(db, 'org_main');
     users = new UserRepository(db);
     orgUsers = new OrgUserRepository(db);
+    rolesRepo = new RoleRepository(db);
+    const permissionsRepo = new PermissionRepository(db);
+    userRolesRepo = new UserRoleRepository(db);
+    const teamRolesRepo = new TeamRoleRepository(db);
+    roles = new RoleService(rolesRepo, permissionsRepo, userRolesRepo, teamRolesRepo);
   });
 
-  it('creates the SA user + org membership when missing', async () => {
-    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+  async function userHasOpsCommandsRunner(userId: string): Promise<boolean> {
+    const assigned = await userRolesRepo.listByUser(userId, 'org_main');
+    for (const r of assigned) {
+      const role = await rolesRepo.findById(r.roleId);
+      if (role?.name === OPS_COMMANDS_RUNNER_ROLE_NAME) return true;
+    }
+    return false;
+  }
+
+  it('creates the SA user + org membership + ops-commands-runner role when missing', async () => {
+    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
     expect(id).not.toBeNull();
     const user = await users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
     expect(user).not.toBeNull();
@@ -31,22 +61,41 @@ describe('seedAutoInvestigationSaIfNeeded', () => {
     expect(user!.email).toBe(AUTO_INVESTIGATION_SA_EMAIL);
     const member = await orgUsers.findMembership('org_main', user!.id);
     expect(member?.role).toBe('Editor');
+    expect(await userHasOpsCommandsRunner(user!.id)).toBe(true);
   });
 
-  it('is idempotent: a second run is a no-op', async () => {
-    const id1 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
-    const id2 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+  it('is idempotent: a second run is a no-op and the fixed role stays assigned exactly once', async () => {
+    const id1 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
+    const id2 = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
     expect(id1).toBe(id2);
+    const assigned = await userRolesRepo.listByUser(id1!, 'org_main');
+    const matching: string[] = [];
+    for (const r of assigned) {
+      const role = await rolesRepo.findById(r.roleId);
+      if (role?.name === OPS_COMMANDS_RUNNER_ROLE_NAME) matching.push(role.name);
+    }
+    expect(matching).toEqual([OPS_COMMANDS_RUNNER_ROLE_NAME]);
+  });
+
+  it('upgrades existing SA installs by assigning the fixed role on re-seed', async () => {
+    // Simulate an "old" install: SA exists with Editor membership but no fixed role.
+    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    expect(id).not.toBeNull();
+    expect(await userHasOpsCommandsRunner(id!)).toBe(false);
+    // Re-seed (now with role service wired) — the fixed role must be added.
+    const after = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
+    expect(after).toBe(id);
+    expect(await userHasOpsCommandsRunner(id!)).toBe(true);
   });
 
   it('repairs missing org membership without recreating the user', async () => {
-    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    const id = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
     expect(id).not.toBeNull();
     // Drop the org membership row directly to simulate a partial seed
     const member = await orgUsers.findMembership('org_main', id!);
     expect(member).not.toBeNull();
     await orgUsers.remove('org_main', id!);
-    const after = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    const after = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
     expect(after).toBe(id);
     const repaired = await orgUsers.findMembership('org_main', id!);
     expect(repaired?.role).toBe('Editor');
@@ -61,7 +110,7 @@ describe('seedAutoInvestigationSaIfNeeded', () => {
       isAdmin: false,
       emailVerified: true,
     });
-    const result = await seedAutoInvestigationSaIfNeeded({ users, orgUsers });
+    const result = await seedAutoInvestigationSaIfNeeded({ users, orgUsers, roles });
     expect(result).toBeNull();
     const user = await users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
     expect(user!.isServiceAccount).toBe(false);

--- a/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
+++ b/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
@@ -26,6 +26,15 @@ import type {
   IUserRepository,
 } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
+import type { RoleService } from '../services/role-service.js';
+
+/**
+ * Fixed role uid that bundles OpsConnectorsRead + OpsCommandsRun on
+ * `ops.connectors:*`. The role's `name` is `fixed:ops.commands:runner`;
+ * `RoleService.assignRoleToUser` looks roles up by `uid`, which is the
+ * `:`/`.`-replaced form (see fixed-roles-def.ts `def()`).
+ */
+const OPS_COMMANDS_RUNNER_ROLE_UID = 'fixed_ops_commands_runner';
 
 const log = createLogger('seed-auto-investigation-sa');
 
@@ -37,6 +46,13 @@ export const AUTO_INVESTIGATION_SA_EMAIL = `${AUTO_INVESTIGATION_SA_LOGIN}@servi
 export interface SeedAutoInvestigationSaDeps {
   users: IUserRepository;
   orgUsers: IOrgUserRepository;
+  /**
+   * Optional role service used to assign the `fixed:ops.commands:runner`
+   * role to the SA so the ReAct loop's `ops_run_command` (kubectl) path is
+   * permitted. When omitted, the fixed-role assignment is skipped — useful
+   * for tests that don't care about RBAC wiring.
+   */
+  roles?: RoleService;
 }
 
 export interface SeedAutoInvestigationSaOptions {
@@ -54,6 +70,17 @@ export interface SeedAutoInvestigationSaOptions {
  * matrix grants `plans:approve`, there's no path for the SA to use it.
  * `plans:auto_edit` is NOT granted by Editor (per #99), so the SA
  * cannot approve plans in auto-edit mode either.
+ *
+ * Editor does NOT grant `ACTIONS.OpsCommandsRun`, so the ReAct loop's
+ * `ops_run_command` (kubectl get/describe) path is denied by the
+ * permission gate in agent-core/tool-permissions.ts. To unblock that
+ * path the SA is additionally assigned the fixed role
+ * `fixed:ops.commands:runner` (defined in
+ * packages/common/src/rbac/fixed-roles-def.ts as OPS_COMMANDS_RUNNER),
+ * which bundles `ops.connectors:read` + `ops.commands:run` on
+ * `ops.connectors:*`. The assignment is idempotent and runs every boot
+ * regardless of whether the SA user already exists, so existing
+ * installs upgrade automatically.
  */
 export async function seedAutoInvestigationSaIfNeeded(
   deps: SeedAutoInvestigationSaDeps,
@@ -62,6 +89,7 @@ export async function seedAutoInvestigationSaIfNeeded(
   const orgId = opts.orgId ?? 'org_main';
 
   const existing = await deps.users.findByLogin(AUTO_INVESTIGATION_SA_LOGIN);
+  let userId: string;
   if (existing) {
     if (!existing.isServiceAccount) {
       log.warn(
@@ -78,20 +106,37 @@ export async function seedAutoInvestigationSaIfNeeded(
       await deps.orgUsers.create({ orgId, userId: existing.id, role: 'Editor' });
       log.info({ userId: existing.id, orgId }, 'auto-investigation SA org membership repaired');
     }
-    return existing.id;
+    userId = existing.id;
+  } else {
+    const user = await deps.users.create({
+      email: AUTO_INVESTIGATION_SA_EMAIL,
+      name: AUTO_INVESTIGATION_SA_NAME,
+      login: AUTO_INVESTIGATION_SA_LOGIN,
+      orgId,
+      isAdmin: false,
+      isDisabled: false,
+      isServiceAccount: true,
+      emailVerified: false,
+    });
+    await deps.orgUsers.create({ orgId, userId: user.id, role: 'Editor' });
+    log.info({ userId: user.id, login: user.login }, 'auto-investigation SA seeded');
+    userId = user.id;
   }
 
-  const user = await deps.users.create({
-    email: AUTO_INVESTIGATION_SA_EMAIL,
-    name: AUTO_INVESTIGATION_SA_NAME,
-    login: AUTO_INVESTIGATION_SA_LOGIN,
-    orgId,
-    isAdmin: false,
-    isDisabled: false,
-    isServiceAccount: true,
-    emailVerified: false,
-  });
-  await deps.orgUsers.create({ orgId, userId: user.id, role: 'Editor' });
-  log.info({ userId: user.id, login: user.login }, 'auto-investigation SA seeded');
-  return user.id;
+  // Always (re)attempt the fixed-role assignment so existing installs
+  // upgrade on the next boot. `assignRoleToUser` is idempotent: it
+  // skips the insert when the role is already assigned.
+  if (deps.roles) {
+    try {
+      await deps.roles.assignRoleToUser(orgId, userId, OPS_COMMANDS_RUNNER_ROLE_UID);
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : err, userId, orgId, roleUid: OPS_COMMANDS_RUNNER_ROLE_UID },
+        'failed to assign ops-commands-runner fixed role to auto-investigation SA; ' +
+        'kubectl/ops_run_command will be denied for auto-investigations until this is fixed',
+      );
+    }
+  }
+
+  return userId;
 }

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -143,6 +143,7 @@ export async function createApp(): Promise<Application> {
   const bundle = await buildAuthSubsystem(
     persistence.db,
     persistence.authRepos,
+    persistence.rbacRepos,
     persistence.rbacRepos.quotas,
   );
 

--- a/packages/api-gateway/src/services/ops-command-runner-service.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.ts
@@ -237,13 +237,13 @@ export class OpsCommandRunnerService {
       };
     }
 
-	    return {
-	      decision: mode === 'read' ? 'read' : 'executed',
-	      observation: formatKubectlObservation(mode, command, {
-	        exitCode: result.success ? 0 : 1,
-	        stdout: typeof result.output === 'string' ? result.output : '',
-	        stderr: result.error ?? '',
-	      }),
+        return {
+          decision: mode === 'read' ? 'read' : 'executed',
+          observation: formatKubectlObservation(mode, command, {
+            exitCode: result.success ? 0 : 1,
+            stdout: typeof result.output === 'string' ? result.output : '',
+            stderr: result.error ?? '',
+          }),
     };
   }
 


### PR DESCRIPTION
## Summary

Auto-investigation can never produce a kubectl-based remediation plan today because the seeded `openobs` service account lacks `ACTIONS.OpsCommandsRun`. The SA only gets the Editor org role (which doesn't include OpsCommandsRun), so when the ReAct loop reaches step 5 and calls `ops_run_command`, the orchestrator denies it and the agent gives up with "permission issue ... can't run kubectl on the cluster."

This change additionally assigns the existing `fixed:ops.commands:runner` fixed role (defined in [packages/common/src/rbac/fixed-roles-def.ts](packages/common/src/rbac/fixed-roles-def.ts) — bundles `OpsConnectorsRead` + `OpsCommandsRun` on `ops.connectors:*`) to the SA on every boot. Idempotent for both fresh installs and upgrades of existing installs.

## Implementation
- `seed-auto-investigation-sa.ts`: optional `roles: RoleService` on the deps; refactored so fixed-role assignment runs unconditionally on both fresh-create and existing-SA paths.
- `auth-routes.ts`: wires a `RoleService` from the existing `authRepos` bundle and passes it in.
- Header comment in seed-auto-investigation-sa.ts updated to explain the runner role.
- Caught a subtle issue during implementation: `RoleService.findAcrossScopes` looks up by uid (`fixed_ops_commands_runner` after `:`/`.` replacement), not by display name. Tests caught this; constant corrected.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 1524 passed / 19 skipped / 0 failed
- [x] New test "upgrade existing SA install" seeds without the role first, then re-seeds with roles wired and asserts the role is added (covers the migration path).
- [ ] Manual: deploy to kind, trigger an alert, observe ReAct loop's `ops_run_command` step succeeds (no `denied by rbac` log line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-investigation service account provisioning is idempotent and reliably assigns the required runner role on startup. Missing-role cases are repaired without creating duplicate accounts; role-assignment failures are logged and non-fatal.
* **Tests**
  * Added/updated tests to verify role assignment, idempotency, and upgrade behavior when the service account exists without the required role.
* **Style**
  * Minor formatting cleanup in the ops command runner service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->