### PR TITLE
Guide investigation hypothesis ordering when metric drops to zero

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -147,6 +147,11 @@ The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not
 - Specific numbers inline: not "high", but "120ms vs <50ms baseline".
 - Complete paragraphs, not bullet lists.
 
+### When the metric is absent, zero, or near-zero
+A drop to zero (or no samples) is ambiguous. By base rate the cause is usually (a) the service is down, (b) the scrape target moved, (c) the metric was renamed in a recent deploy, or (d) genuinely zero traffic. (a) is the most common; "monitoring is misconfigured" is rare and should NOT be your first conclusion without positive evidence.
+
+Disambiguate with whatever tools your current run has access to: \`up{...}\` and neighbor metrics from the same job will rule (a) in or out from the metrics side; \`changes_list_recent\` covers (c); cluster-side checks via an Ops connector cover (a) directly. Use only what the tool list and \`# Ops Integrations\` section show as available — if you don't have a path to verify a hypothesis, say so in the report instead of inventing a check.
+
 ### When a cluster connector is attached
 If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_command\` with \`intent="read"\` to inspect cluster state for service-side symptoms — pod status, recent events, logs from suspect pods, etc. Stick to the connector's allowed namespaces. NEVER use \`intent="propose"\` or \`intent="execute_approved"\` from an investigation turn — propose fixes via \`remediation_plan_create\` after the investigation completes.
 


### PR DESCRIPTION
## Summary
When a metric query returns no samples or a flat zero, the auto-investigation agent (especially non-Anthropic models like Gemini / DeepSeek) often concludes \"the monitoring is misconfigured\" instead of the much more common \"the service is down\". Result: investigation closes with a wrong root cause and no remediation plan is produced.

Add a short hypothesis-ordering paragraph in the existing Investigation playbook (packages/agent-core/src/agent/orchestrator-prompt.ts), placed right before the existing \"When a cluster connector is attached\" subsection. It tells the agent:
- Service-down is the most common cause; \"monitoring broken\" is rare and needs positive evidence.
- Disambiguate using whatever the agent actually has access to — up{}, neighbor metrics, changes_list_recent, and the Ops connector if one is listed.
- If a hypothesis can't be verified with the available tools, say so in the report instead of inventing a check.

## Why this approach
- No hardcoded kubectl commands. The \"# Ops Integrations\" section + tool catalog already encode what's available, mirroring Claude Code's MCP pattern (`getMcpInstructionsSection` returns null with no MCPs; tools surface what's reachable).
- Surgical: 5 lines, one location, no behavioral changes for the cases where the agent was already correct.

## Test plan
- [x] No code paths changed; prompt-only change.
- [ ] Manual: scale a monitored deployment to 0 → alert fires → observe agent calls `up{}` or `ops_run_command` to verify service state and emits a remediation plan when a connector is attached.
- [ ] Verify the prompt size grew by ~5 lines (no token-budget regression).

## Out of scope (separate todos already filed)
- Auto-investigation never finalizes — agent doesn't call `investigation_complete` reliably; needs a server-side safety net.
- Dispatcher creates duplicate investigations because it doesn't write back `rule.investigationId`.
- Refresh-schedule timer reset bug in alert-evaluator-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved metric investigation: Agent now provides enhanced root-cause analysis when metrics are missing or zero-valued, with better guidance on diagnosing likely causes and transparent reporting when verification isn't possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->