### PR TITLE
Finalize auto-investigation row + link it back to the rule

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -147,6 +147,11 @@ The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not
 - Specific numbers inline: not "high", but "120ms vs <50ms baseline".
 - Complete paragraphs, not bullet lists.
 
+### When the metric is absent, zero, or near-zero
+A drop to zero (or no samples) is ambiguous. By base rate the cause is usually (a) the service is down, (b) the scrape target moved, (c) the metric was renamed in a recent deploy, or (d) genuinely zero traffic. (a) is the most common; "monitoring is misconfigured" is rare and should NOT be your first conclusion without positive evidence.
+
+Disambiguate with whatever tools your current run has access to: \`up{...}\` and neighbor metrics from the same job will rule (a) in or out from the metrics side; \`changes_list_recent\` covers (c); cluster-side checks via an Ops connector cover (a) directly. Use only what the tool list and \`# Ops Integrations\` section show as available — if you don't have a path to verify a hypothesis, say so in the report instead of inventing a check.
+
 ### When a cluster connector is attached
 If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_command\` with \`intent="read"\` to inspect cluster state for service-side symptoms — pod status, recent events, logs from suspect pods, etc. Stick to the connector's allowed namespaces. NEVER use \`intent="propose"\` or \`intent="execute_approved"\` from an investigation turn — propose fixes via \`remediation_plan_create\` after the investigation completes.
 

--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -127,6 +127,14 @@ export interface MountAlertsDeps {
    */
   subscribeRuleChanges?: (cb: () => void) => void;
   /**
+   * Investigation repository. When provided, AutoInvestigationDispatcher
+   * uses it to finalize the row created by the agent's
+   * `investigation_create` tool — flipping status to `completed` /
+   * `failed` if the model didn't call `investigation_complete`, and
+   * linking the investigation back to the alert rule.
+   */
+  investigations?: import('@agentic-obs/data-layer').IInvestigationRepository;
+  /**
    * QueryClient used to back the leader lock. When provided AND
    * `ALERT_EVALUATOR_HA=true`, the evaluator only runs while it holds
    * the lock. Multi-replica deploys should pass this so two api-gateway
@@ -228,6 +236,8 @@ export async function startAlerts(deps: MountAlertsDeps): Promise<{
         alertEvents: evaluator,
         runner: deps.runner,
         resolveSaIdentity,
+        ...(deps.investigations ? { investigations: deps.investigations } : {}),
+        alertRules: deps.rules,
       });
       dispatcher.subscribe();
       log.info('auto-investigation dispatcher subscribed to alert.fired');

--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -131,9 +131,10 @@ export interface MountAlertsDeps {
    * uses it to finalize the row created by the agent's
    * `investigation_create` tool — flipping status to `completed` /
    * `failed` if the model didn't call `investigation_complete`, and
-   * linking the investigation back to the alert rule.
+   * linking the investigation back to the alert rule. Narrow shape kept
+   * inline so we accept any superset (sqlite / postgres / gateway-ext).
    */
-  investigations?: import('@agentic-obs/data-layer').IInvestigationRepository;
+  investigations?: import('../services/auto-investigation-dispatcher.js').DispatcherInvestigationStore;
   /**
    * QueryClient used to back the leader lock. When provided AND
    * `ALERT_EVALUATOR_HA=true`, the evaluator only runs while it holds

--- a/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
+++ b/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
@@ -59,13 +59,19 @@ function makeApp(opts: {
     create: opts.capturedCreate,
   } as unknown as Parameters<typeof createAlertRulesRouter>[0]['investigationStore'];
 
-  setAuthMiddleware((req, _res, next) => {
+  const app = express();
+  app.use(express.json());
+  // Inject identity per-app before the router. The router's internal
+  // authMiddleware reads a module-level resolvedMiddleware (set in the
+  // beforeAll hook to a passthrough); since req.auth is already populated
+  // here, the passthrough is a no-op and the router proceeds with the
+  // intended identity. This pattern is robust to vitest worker-thread
+  // module sharing — any other test file that mutates the global cannot
+  // strip req.auth that's already set on this request.
+  app.use((req, _res, next) => {
     (req as express.Request & { auth?: Identity }).auth = opts.identity;
     next();
   });
-
-  const app = express();
-  app.use(express.json());
   app.use(
     '/api/alert-rules',
     createAlertRulesRouter({
@@ -80,7 +86,10 @@ function makeApp(opts: {
 
 describe('POST /api/alert-rules/:id/investigate', () => {
   beforeEach(() => {
-    setAuthMiddleware(null);
+    // Replace the global auth middleware with a passthrough so the
+    // router's internal `authMiddleware` call is a no-op and won't
+    // overwrite req.auth that the per-app middleware (in makeApp) sets.
+    setAuthMiddleware((_req, _res, next) => { next(); });
   });
 
   it('passes the rule\'s workspaceId to investigationStore.create', async () => {

--- a/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
+++ b/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
@@ -9,12 +9,25 @@
  * workspaceId through.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import type { AlertRule } from '@agentic-obs/common';
 import type { Identity } from '@agentic-obs/common';
-import { setAuthMiddleware } from '../middleware/auth.js';
+
+// Replace the module-level authMiddleware (which delegates to a global
+// resolvedMiddleware mutable across the process) with a passthrough.
+// vi.mock isolates per-test-file regardless of vitest worker reuse, so
+// other test files that mutate the global cannot strip req.auth that
+// our per-app middleware in makeApp() sets below.
+vi.mock('../middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware/auth.js')>();
+  return {
+    ...actual,
+    authMiddleware: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  };
+});
+
 import { createAlertRulesRouter } from './alert-rules.js';
 
 const ALWAYS_ALLOW: { evaluate: () => Promise<true>; eval: (...a: unknown[]) => unknown } = {
@@ -85,13 +98,6 @@ function makeApp(opts: {
 }
 
 describe('POST /api/alert-rules/:id/investigate', () => {
-  beforeEach(() => {
-    // Replace the global auth middleware with a passthrough so the
-    // router's internal `authMiddleware` call is a no-op and won't
-    // overwrite req.auth that the per-app middleware (in makeApp) sets.
-    setAuthMiddleware((_req, _res, next) => { next(); });
-  });
-
   it('passes the rule\'s workspaceId to investigationStore.create', async () => {
     const create = vi.fn(async (input: { workspaceId?: string }) => ({
       id: 'inv_1',

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -214,6 +214,7 @@ export async function createApp(): Promise<Application> {
     rules: eventAlertRuleStore,
     setupConfig,
     db: persistence.db,
+    investigations: persistence.repos.investigations,
     authRepos: {
       users: bundle.authRepos.users,
       orgUsers: bundle.authRepos.orgUsers,

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
@@ -151,4 +151,99 @@ describe('AutoInvestigationDispatcher', () => {
     await new Promise((r) => setImmediate(r));
     expect(spawn).toHaveBeenCalledTimes(1); // still 1, unsubscribe worked
   });
+
+  describe('finalizeInvestigation', () => {
+    function mkInv(overrides: Partial<{ id: string; status: string; createdAt: string }> = {}) {
+      return {
+        id: overrides.id ?? 'inv-1',
+        status: overrides.status ?? 'planning',
+        createdAt: overrides.createdAt ?? '2026-04-29T00:00:01.000Z',
+      } as unknown as import('@agentic-obs/common').Investigation;
+    }
+
+    function mkRepos(invs: ReturnType<typeof mkInv>[]) {
+      const updateStatus = vi.fn().mockResolvedValue(null);
+      const ruleUpdate = vi.fn().mockResolvedValue(null);
+      const investigations = {
+        findByWorkspace: vi.fn().mockResolvedValue(invs),
+        updateStatus,
+      } as unknown as import('@agentic-obs/data-layer').IInvestigationRepository;
+      const alertRules = {
+        update: ruleUpdate,
+      } as unknown as import('@agentic-obs/data-layer').IAlertRuleRepository;
+      return { investigations, alertRules, updateStatus, ruleUpdate };
+    }
+
+    function mkDispatcherWithRepos(
+      spawn: ReturnType<typeof vi.fn>,
+      repos: ReturnType<typeof mkRepos>,
+    ) {
+      return new AutoInvestigationDispatcher({
+        alertEvents,
+        runner: {
+          saTokens: { validateAndLookup: async () => null },
+          makeOrchestrator: () => ({} as never),
+        },
+        resolveSaIdentity: async () => fakeIdentity,
+        dedupMs: 60_000,
+        clock: () => now,
+        spawnAgent: spawn as unknown as typeof import('@agentic-obs/agent-core').runBackgroundAgent,
+        investigations: repos.investigations,
+        alertRules: repos.alertRules,
+      });
+    }
+
+    it('flips planning → completed when the agent did not call investigation_complete', async () => {
+      const spawn = vi.fn().mockResolvedValue('summary text');
+      const repos = mkRepos([mkInv({ id: 'inv-A', status: 'planning' })]);
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.updateStatus).toHaveBeenCalledWith('inv-A', 'completed');
+    });
+
+    it('flips planning → failed when the agent run threw', async () => {
+      const spawn = vi.fn().mockRejectedValue(new Error('LLM 500'));
+      const repos = mkRepos([mkInv({ id: 'inv-A', status: 'planning' })]);
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.updateStatus).toHaveBeenCalledWith('inv-A', 'failed');
+    });
+
+    it('leaves a terminal status alone (agent already finalized)', async () => {
+      const spawn = vi.fn().mockResolvedValue('ok');
+      const repos = mkRepos([mkInv({ id: 'inv-A', status: 'completed' })]);
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('writes the new investigation id back to the rule so manual Investigate reuses it', async () => {
+      const spawn = vi.fn().mockResolvedValue('ok');
+      const repos = mkRepos([mkInv({ id: 'inv-A', status: 'planning' })]);
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.ruleUpdate).toHaveBeenCalledWith('rule-A', { investigationId: 'inv-A' });
+    });
+
+    it('skips finalize when the agent never created an investigation', async () => {
+      const spawn = vi.fn().mockResolvedValue('agent gave up');
+      const repos = mkRepos([]); // no investigations created
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.updateStatus).not.toHaveBeenCalled();
+      expect(repos.ruleUpdate).not.toHaveBeenCalled();
+    });
+
+    it('only considers investigations created at or after the dispatch start time', async () => {
+      const spawn = vi.fn().mockResolvedValue('ok');
+      // One stale row from before this dispatch, one created during it.
+      const stale = mkInv({ id: 'inv-OLD', status: 'planning', createdAt: '2026-04-28T23:00:00.000Z' });
+      const fresh = mkInv({ id: 'inv-NEW', status: 'planning', createdAt: '2026-04-29T00:00:01.000Z' });
+      const repos = mkRepos([stale, fresh]);
+      const d = mkDispatcherWithRepos(spawn, repos);
+      await d.onAlertFired(basePayload({ ruleId: 'rule-A' }));
+      expect(repos.updateStatus).toHaveBeenCalledWith('inv-NEW', 'completed');
+      expect(repos.ruleUpdate).toHaveBeenCalledWith('rule-A', { investigationId: 'inv-NEW' });
+    });
+  });
 });

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
@@ -34,8 +34,14 @@ import type { AlertFiredPayload } from './alert-evaluator-service.js';
  * the dispatcher decoupled from the bundle's exact intersection type.
  */
 export interface DispatcherInvestigationStore {
-  findByWorkspace(workspaceId: string): Promise<Investigation[]>;
-  updateStatus(id: string, status: InvestigationStatus): Promise<Investigation | null>;
+  // Sync-or-async returns — repository signatures use MaybeAsync, which
+  // resolves identically through `await` regardless of whether the
+  // underlying call is synchronous (sqlite) or async (postgres).
+  findByWorkspace(workspaceId: string): Investigation[] | Promise<Investigation[]>;
+  updateStatus(
+    id: string,
+    status: InvestigationStatus,
+  ): Investigation | null | undefined | Promise<Investigation | null | undefined>;
 }
 
 /**
@@ -43,7 +49,10 @@ export interface DispatcherInvestigationStore {
  * back to its alert rule.
  */
 export interface DispatcherAlertRuleStore {
-  update(id: string, partial: { investigationId?: string }): Promise<unknown>;
+  // Sync-or-async return — matches both sqlite and postgres repository
+  // signatures via the data-layer's MaybeAsync. We don't consume the
+  // result, only `await` it.
+  update(id: string, partial: { investigationId?: string }): unknown;
 }
 
 const log = createLogger('auto-investigation');

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
@@ -19,17 +19,32 @@
  */
 
 import type { EventEmitter } from 'node:events';
-import type { Identity } from '@agentic-obs/common';
+import type { Identity, Investigation, InvestigationStatus } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
 import {
   runBackgroundAgent,
   type BackgroundRunnerDeps,
 } from '@agentic-obs/agent-core';
-import type {
-  IAlertRuleRepository,
-  IInvestigationRepository,
-} from '@agentic-obs/data-layer';
 import type { AlertFiredPayload } from './alert-evaluator-service.js';
+
+/**
+ * Minimum surface the dispatcher needs to finalize an investigation
+ * row. Wider repository interfaces (sqlite / postgres / gateway-extended)
+ * all satisfy this shape; depending on the narrow contract here keeps
+ * the dispatcher decoupled from the bundle's exact intersection type.
+ */
+export interface DispatcherInvestigationStore {
+  findByWorkspace(workspaceId: string): Promise<Investigation[]>;
+  updateStatus(id: string, status: InvestigationStatus): Promise<Investigation | null>;
+}
+
+/**
+ * Minimum surface the dispatcher needs to link the new investigation
+ * back to its alert rule.
+ */
+export interface DispatcherAlertRuleStore {
+  update(id: string, partial: { investigationId?: string }): Promise<unknown>;
+}
 
 const log = createLogger('auto-investigation');
 
@@ -79,14 +94,14 @@ export interface AutoInvestigationDispatcherOptions {
    * transitioned to `completed` (or `failed` on agent error) so the UI
    * detail page renders something instead of spinning at `planning`.
    */
-  investigations?: IInvestigationRepository;
+  investigations?: DispatcherInvestigationStore;
   /**
    * Alert-rule repo. When provided, the dispatcher writes the created
    * investigation's id back to `rule.investigationId` so the manual
    * Investigate button on the Alerts page reuses it instead of creating
    * a duplicate row.
    */
-  alertRules?: IAlertRuleRepository;
+  alertRules?: DispatcherAlertRuleStore;
 }
 
 /**

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
@@ -25,6 +25,10 @@ import {
   runBackgroundAgent,
   type BackgroundRunnerDeps,
 } from '@agentic-obs/agent-core';
+import type {
+  IAlertRuleRepository,
+  IInvestigationRepository,
+} from '@agentic-obs/data-layer';
 import type { AlertFiredPayload } from './alert-evaluator-service.js';
 
 const log = createLogger('auto-investigation');
@@ -68,6 +72,21 @@ export interface AutoInvestigationDispatcherOptions {
    * `runBackgroundAgent`.
    */
   spawnAgent?: typeof runBackgroundAgent;
+  /**
+   * Investigation repo. When provided, the dispatcher post-processes the
+   * investigation row created by the agent's `investigation_create` tool
+   * call: if the agent didn't call `investigation_complete`, the row is
+   * transitioned to `completed` (or `failed` on agent error) so the UI
+   * detail page renders something instead of spinning at `planning`.
+   */
+  investigations?: IInvestigationRepository;
+  /**
+   * Alert-rule repo. When provided, the dispatcher writes the created
+   * investigation's id back to `rule.investigationId` so the manual
+   * Investigate button on the Alerts page reuses it instead of creating
+   * a duplicate row.
+   */
+  alertRules?: IAlertRuleRepository;
 }
 
 /**
@@ -208,8 +227,14 @@ export class AutoInvestigationDispatcher {
     this.recent.set(payload.ruleId, now);
     this.gcRecent(now);
 
+    // Snapshot the dispatch start time so we can find the investigation
+    // row created by the agent's `investigation_create` tool below.
+    const startedAtIso = this.clock().toISOString();
+
+    let reply = '';
+    let agentError: Error | null = null;
     try {
-      const reply = await this.spawnAgent(this.opts.runner, {
+      reply = await this.spawnAgent(this.opts.runner, {
         identity,
         message: buildAlertQuestion(payload),
       });
@@ -218,12 +243,103 @@ export class AutoInvestigationDispatcher {
         'auto-investigation completed',
       );
     } catch (err) {
+      agentError = err instanceof Error ? err : new Error(String(err));
       // Crash isolation: one failed investigation must not stop the
-      // dispatcher from handling future alerts.
+      // dispatcher from handling future alerts. Fall through so the
+      // finalization step still tries to mark whatever the agent created
+      // as failed instead of leaving it stuck at planning.
       log.error(
-        { err: err instanceof Error ? err.message : String(err), ruleId: payload.ruleId },
+        { err: agentError.message, ruleId: payload.ruleId },
         'auto-investigation failed',
       );
+    }
+
+    // Finalize the investigation row + link it to the rule. Best-effort:
+    // missing repos (constructor was wired without them) just skip.
+    await this.finalizeInvestigation(payload, identity, startedAtIso, reply, agentError);
+  }
+
+  /**
+   * After the agent run returns (success or failure), find the investigation
+   * row the agent created via `investigation_create` and:
+   *
+   *   1. If status is still in a pre-terminal state, transition it to
+   *      `completed` (success) or `failed` (agent threw). Models often
+   *      forget to call `investigation_complete`; without this, the row
+   *      sits at `planning` forever and the UI spins.
+   *   2. Write its id back to `rule.investigationId` so the manual
+   *      Investigate button reuses this row instead of creating a
+   *      duplicate one.
+   *
+   * Discovery is by `(workspaceId, createdAt > dispatchStart)` and picks
+   * the most recently created row. There's no investigation→alertRule
+   * foreign key today; if that becomes unreliable in practice the cleaner
+   * fix is to add `alertRuleId` to the Investigation schema.
+   */
+  private async finalizeInvestigation(
+    payload: AlertFiredPayload,
+    identity: Identity,
+    dispatchStartIso: string,
+    _reply: string,
+    agentError: Error | null,
+  ): Promise<void> {
+    const { investigations, alertRules } = this.opts;
+    if (!investigations) return;
+
+    let inv: { id: string; status: string; createdAt: string } | null = null;
+    try {
+      const list = await investigations.findByWorkspace(identity.orgId);
+      // Latest investigation created at or after dispatchStart.
+      const candidates = list
+        .filter((r) => r.createdAt >= dispatchStartIso)
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      inv = candidates[0] ?? null;
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), ruleId: payload.ruleId },
+        'finalize: investigation lookup failed',
+      );
+      return;
+    }
+
+    if (!inv) {
+      // Agent never called investigation_create. Nothing to finalize.
+      // The reply already landed in chat-service logs above; structured
+      // persistence is on the agent.
+      return;
+    }
+
+    // 1. Status transition. Pre-terminal states get flipped; terminal
+    //    states (completed/failed) are left alone — the agent already
+    //    finalized properly.
+    const terminal = inv.status === 'completed' || inv.status === 'failed';
+    if (!terminal) {
+      const nextStatus = agentError ? 'failed' : 'completed';
+      try {
+        await investigations.updateStatus(inv.id, nextStatus);
+        log.info(
+          { investigationId: inv.id, from: inv.status, to: nextStatus, ruleId: payload.ruleId },
+          'finalize: forced status transition (agent did not call investigation_complete)',
+        );
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), investigationId: inv.id },
+          'finalize: updateStatus failed',
+        );
+      }
+    }
+
+    // 2. Link the investigation to the rule so manual re-Investigate
+    //    reuses it. Best-effort; ignore non-fatal errors.
+    if (alertRules) {
+      try {
+        await alertRules.update(payload.ruleId, { investigationId: inv.id });
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), ruleId: payload.ruleId, investigationId: inv.id },
+          'finalize: alertRule.update(investigationId) failed',
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Two long-standing dispatcher bugs that surfaced during E2E demo work:

1. **Investigation status stuck at \`planning\`.** The agent often forgets (or — with non-Anthropic providers — never had a chance) to call \`investigation_complete\`. The row created via \`investigation_create\` then sits at \`planning\` forever, and the InvestigationDetail UI shows an empty / spinning report. The dispatcher now post-processes after the spawn returns: \`planning\` → \`completed\` on success, \`planning\` → \`failed\` when the agent threw. Existing terminal status (\`completed\` / \`failed\`) is left untouched (idempotent).

2. **Manual Investigate clicks created duplicate rows.** \`POST /alert-rules/:id/investigate\` checks \`rule.investigationId\` and creates a new row when it's empty. The dispatcher never wrote the new investigation id back to the rule, so the manual flow couldn't see the auto-created row. Now the dispatcher updates \`rule.investigationId\` after spawn.

Discovery uses \`(workspaceId, createdAt >= dispatchStart)\` ordered desc. There's no \`alertRuleId\` field on Investigation today; if base-rate ambiguity bites in practice, that schema column is the cleaner long-term fix and is noted inline.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1524 / 1543 passing (no regressions); 6 new dispatcher tests for finalize cover (a) planning → completed on success, (b) planning → failed on agent error, (c) terminal status untouched, (d) rule link, (e) no-investigation skip, (f) stale-row exclusion.
- [ ] Manual: trigger an alert, observe investigation transitions to \`completed\` even when the model doesn't call \`investigation_complete\`. Click Investigate from the Alerts page → reuses the dispatcher's row instead of creating a duplicate.

## Out of scope
- Adding \`alertRuleId\` to the Investigation schema (cleaner long-term path).
- Persisting the agent's final reply text as a fallback report section when no \`investigation_add_section\` was called — that's a separate refinement; for now the agent's reply still lands in chat-service logs.
- Improving the prompt so the agent calls \`investigation_complete\` more reliably (PR #127 covered the related "metric drop ambiguity" angle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispatcher finalizes investigations after agent runs, marking them completed/failed and recording investigation IDs on alert rules when available.
  * Alert startup can optionally wire an investigations repository to enable the above behavior.
  * Investigation guidance improved for missing/zero metrics with clearer disambiguation steps and constrained verification checks.

* **Bug Fixes**
  * Prevents investigations from remaining in pre-terminal states after agent errors.

* **Tests**
  * Added tests covering investigation finalization outcomes, state transitions, and auth handling in investigation routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->