### PR TITLE
Show in-progress investigation indicator on firing alerts

### DIFF
--- a/packages/web/src/hooks/useInvestigationStatuses.ts
+++ b/packages/web/src/hooks/useInvestigationStatuses.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+import { apiClient } from '../api/client.js';
+import type { Investigation } from '../api/types.js';
+import {
+  IN_PROGRESS_INVESTIGATION_STATUSES,
+  nextPollIntervalMs,
+} from '../pages/alerts-investigation-status.js';
+
+/**
+ * Polls /api/investigations/:id for each id in `ids` so the Alerts page can
+ * surface live status next to each rule. Cadence is 5s while any tracked
+ * investigation is in progress, 30s otherwise, and pauses when the document
+ * is hidden.
+ */
+export function useInvestigationStatuses(ids: string[]): Map<string, Investigation> {
+  const [statuses, setStatuses] = useState<Map<string, Investigation>>(new Map());
+  // Stable string key so the effect only re-runs when the set of ids changes.
+  const key = [...ids].sort().join(',');
+  // Snapshot the latest list inside a ref so the effect closure does not
+  // capture stale ids when the key happens to be equal.
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
+
+  useEffect(() => {
+    if (!key) {
+      setStatuses(new Map());
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function tick() {
+      if (cancelled) return;
+      const visible =
+        typeof document === 'undefined' || document.visibilityState !== 'hidden';
+      if (!visible) {
+        timer = setTimeout(tick, nextPollIntervalMs({ anyActive: false, visible: false }));
+        return;
+      }
+      const current = idsRef.current;
+      const results = await Promise.all(
+        current.map(async (id) => {
+          const res = await apiClient.get<Investigation>(`/investigations/${id}`);
+          return res.error ? null : res.data;
+        }),
+      );
+      if (cancelled) return;
+      setStatuses(() => {
+        const next = new Map<string, Investigation>();
+        for (const inv of results) {
+          if (inv) next.set(inv.id, inv);
+        }
+        return next;
+      });
+      const anyActive = results.some(
+        (inv) => inv != null && IN_PROGRESS_INVESTIGATION_STATUSES.has(inv.status),
+      );
+      timer = setTimeout(tick, nextPollIntervalMs({ anyActive, visible: true }));
+    }
+
+    void tick();
+
+    const onVisibility = () => {
+      if (cancelled) return;
+      if (document.visibilityState === 'visible') {
+        if (timer) clearTimeout(timer);
+        void tick();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [key]);
+
+  return statuses;
+}

--- a/packages/web/src/pages/Alerts.tsx
+++ b/packages/web/src/pages/Alerts.tsx
@@ -4,6 +4,12 @@ import { apiClient, plansApi } from '../api/client.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import { relativeTime } from '../utils/time.js';
 import { useAuth } from '../contexts/AuthContext.js';
+import { useInvestigationStatuses } from '../hooks/useInvestigationStatuses.js';
+import {
+  classifyInvestigation,
+  type InvestigationIndicator,
+} from './alerts-investigation-status.js';
+import { getInvestigationStatusStyle } from '../constants/status-styles.js';
 
 // Types
 
@@ -74,6 +80,67 @@ const SEVERITY_STYLES: Record<AlertSeverity, string> = {
 };
 
 
+// Spinner used to signal an in-progress investigation
+function Spinner() {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block w-3 h-3 border-2 border-[var(--color-primary)]/30 border-t-[var(--color-primary)] rounded-full animate-spin"
+    />
+  );
+}
+
+/**
+ * Read-only chip rendered inside the row's summary <button>. Shows the
+ * current investigation indicator without introducing a nested <button>
+ * (clicking the row expands it; the actions row inside has clickable
+ * variants).
+ */
+function InvestigationSummaryChip({ indicator }: { indicator: InvestigationIndicator }) {
+  if (indicator.kind === 'idle') return null;
+  if (indicator.kind === 'in_progress') {
+    const style = getInvestigationStatusStyle(indicator.status);
+    return (
+      <span
+        title={style.description}
+        className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${style.bg} ${style.text} shrink-0`}
+      >
+        <Spinner />
+        Investigating…
+      </span>
+    );
+  }
+  if (indicator.kind === 'completed_with_plan') {
+    return (
+      <span
+        title="Plan ready for review"
+        className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-[var(--color-primary)]/15 text-[var(--color-primary)] shrink-0"
+      >
+        Plan ready
+      </span>
+    );
+  }
+  if (indicator.kind === 'failed') {
+    return (
+      <span
+        title="Investigation failed"
+        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#EF4444]/10 text-[#EF4444] shrink-0"
+      >
+        Failed
+      </span>
+    );
+  }
+  // completed (no plan): subdued
+  return (
+    <span
+      title="Investigation done — no action needed"
+      className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-surface-high)] text-[var(--color-outline)] shrink-0"
+    >
+      Done
+    </span>
+  );
+}
+
 // Expandable Rule Row
 
 function AlertRuleRow({
@@ -89,6 +156,7 @@ function AlertRuleRow({
   canWrite,
   canDelete,
   pendingPlanId,
+  indicator,
 }: {
   rule: AlertRule;
   expanded: boolean;
@@ -102,15 +170,17 @@ function AlertRuleRow({
   canWrite: boolean;
   canDelete: boolean;
   pendingPlanId?: string;
+  indicator: InvestigationIndicator;
 }) {
   const stateStyle = STATE_STYLES[rule.state];
   const isDisabled = rule.state === 'disabled';
   const dashboardId = rule.labels?.dashboardId;
+  const isInvestigating = indicator.kind === 'in_progress';
 
   return (
     <div className={`rounded-xl border transition-all ${
       rule.state === 'firing'
-        ? 'bg-[var(--color-surface-highest)] border-[#EF4444]/30'
+        ? `bg-[var(--color-surface-highest)] border-[#EF4444]/30${isInvestigating ? ' animate-pulse' : ''}`
         : rule.state === 'pending'
         ? 'bg-[var(--color-surface-highest)] border-[#F59E0B]/30'
         : 'bg-[var(--color-surface-highest)] border-[var(--color-outline-variant)] hover:border-[#36364E]'
@@ -134,6 +204,9 @@ function AlertRuleRow({
         <span className="text-sm font-medium text-[var(--color-on-surface)] truncate flex-1">
           {humanizeName(rule.name)}
         </span>
+
+        {/* Investigation indicator (read-only in summary; row click expands) */}
+        <InvestigationSummaryChip indicator={indicator} />
 
         {/* Severity */}
         <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase border ${SEVERITY_STYLES[rule.severity]} shrink-0`}>
@@ -224,7 +297,7 @@ function AlertRuleRow({
               Dashboard
             </button>
 
-            {(rule.state === 'firing' || rule.state === 'pending') && !rule.investigationId && (
+            {(rule.state === 'firing' || rule.state === 'pending') && indicator.kind === 'idle' && (
               <button
                 type="button"
                 onClick={onInvestigate}
@@ -235,27 +308,61 @@ function AlertRuleRow({
               </button>
             )}
 
-            {rule.investigationId && (
+            {indicator.kind === 'in_progress' && (
               <button
                 type="button"
-                onClick={() => navigate(`/investigations/${rule.investigationId}`)}
+                onClick={() => navigate(`/investigations/${indicator.investigationId}`)}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-[var(--color-primary)]/10 text-[var(--color-primary)] hover:bg-[var(--color-primary)]/20 transition-colors"
               >
-                View Investigation
+                <Spinner />
+                Investigating…
               </button>
             )}
 
-            {pendingPlanId && (
+            {indicator.kind === 'completed_with_plan' && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/plans/${indicator.planId}`)}
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-[var(--color-primary)] text-on-primary-fixed hover:opacity-90 transition-opacity"
+                >
+                  Review plan →
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/investigations/${indicator.investigationId}`)}
+                  className="px-2.5 py-1.5 rounded-lg text-xs text-[var(--color-outline)] hover:text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-high)] transition-colors"
+                >
+                  View Investigation
+                </button>
+              </>
+            )}
+
+            {indicator.kind === 'completed' && (
               <button
                 type="button"
-                onClick={() => navigate(`/plans/${pendingPlanId}`)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-[var(--color-primary)] text-on-primary-fixed hover:opacity-90 transition-opacity"
+                onClick={() => navigate(`/investigations/${indicator.investigationId}`)}
+                title="Investigation done — no action needed"
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-[var(--color-outline)] hover:text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-high)] transition-colors"
               >
-                Review plan →
+                <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--color-outline)]" />
+                Investigation done — no action needed
               </button>
             )}
 
-            {(rule.state === 'firing' || rule.state === 'pending') && (
+            {indicator.kind === 'failed' && (
+              <button
+                type="button"
+                onClick={() => navigate(`/investigations/${indicator.investigationId}`)}
+                title="Investigation failed"
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-[#EF4444]/10 text-[#EF4444] hover:bg-[#EF4444]/20 transition-colors"
+              >
+                <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#EF4444]" />
+                Investigation failed
+              </button>
+            )}
+
+            {(rule.state === 'firing' || rule.state === 'pending') && indicator.kind !== 'idle' && indicator.kind !== 'in_progress' && (
               <button
                 type="button"
                 onClick={onInvestigate}
@@ -334,6 +441,14 @@ export default function Alerts() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [investigatingId, setInvestigatingId] = useState<string | null>(null);
   const [pendingPlanByInvestigation, setPendingPlanByInvestigation] = useState<Record<string, string>>({});
+  // Poll status for any rule that already has an investigation attached so the
+  // row can show a live "Investigating…" / "Done" / "Failed" indicator without
+  // requiring the operator to click through.
+  const trackedInvestigationIds = useMemo(
+    () => rules.map((r) => r.investigationId).filter((id): id is string => !!id),
+    [rules],
+  );
+  const investigationStatuses = useInvestigationStatuses(trackedInvestigationIds);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Keyboard shortcut: / to focus search
@@ -633,6 +748,11 @@ export default function Alerts() {
                       canWrite={canWriteRule}
                       canDelete={canDeleteRule}
                       pendingPlanId={rule.investigationId ? pendingPlanByInvestigation[rule.investigationId] : undefined}
+                      indicator={classifyInvestigation({
+                        investigationId: rule.investigationId,
+                        status: rule.investigationId ? investigationStatuses.get(rule.investigationId)?.status : undefined,
+                        pendingPlanId: rule.investigationId ? pendingPlanByInvestigation[rule.investigationId] : undefined,
+                      })}
                     />
                   ))}
                 </div>

--- a/packages/web/src/pages/alerts-investigation-status.test.ts
+++ b/packages/web/src/pages/alerts-investigation-status.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyInvestigation,
+  IN_PROGRESS_INVESTIGATION_STATUSES,
+  nextPollIntervalMs,
+} from './alerts-investigation-status.js';
+
+describe('classifyInvestigation', () => {
+  it('returns idle when no investigation has been kicked off', () => {
+    expect(classifyInvestigation({})).toEqual({ kind: 'idle' });
+  });
+
+  it('returns in_progress for active statuses', () => {
+    for (const status of IN_PROGRESS_INVESTIGATION_STATUSES) {
+      expect(classifyInvestigation({ investigationId: 'i1', status })).toEqual({
+        kind: 'in_progress',
+        status,
+        investigationId: 'i1',
+      });
+    }
+  });
+
+  it('returns failed for failed investigations', () => {
+    expect(classifyInvestigation({ investigationId: 'i1', status: 'failed' })).toEqual({
+      kind: 'failed',
+      investigationId: 'i1',
+    });
+  });
+
+  it('returns completed_with_plan when a pending plan exists', () => {
+    expect(
+      classifyInvestigation({ investigationId: 'i1', status: 'completed', pendingPlanId: 'p1' }),
+    ).toEqual({ kind: 'completed_with_plan', investigationId: 'i1', planId: 'p1' });
+  });
+
+  it('returns completed when finished without a plan', () => {
+    expect(classifyInvestigation({ investigationId: 'i1', status: 'completed' })).toEqual({
+      kind: 'completed',
+      investigationId: 'i1',
+    });
+  });
+
+  it('falls back to in_progress when status is not yet loaded but id exists', () => {
+    expect(classifyInvestigation({ investigationId: 'i1' })).toEqual({
+      kind: 'in_progress',
+      status: 'planning',
+      investigationId: 'i1',
+    });
+  });
+});
+
+describe('nextPollIntervalMs', () => {
+  it('uses 5s while a visible page has any active investigation', () => {
+    expect(nextPollIntervalMs({ anyActive: true, visible: true })).toBe(5_000);
+  });
+
+  it('backs off to 30s when nothing is active', () => {
+    expect(nextPollIntervalMs({ anyActive: false, visible: true })).toBe(30_000);
+  });
+
+  it('backs off when the document is hidden, even with active work', () => {
+    expect(nextPollIntervalMs({ anyActive: true, visible: false })).toBe(30_000);
+  });
+});

--- a/packages/web/src/pages/alerts-investigation-status.ts
+++ b/packages/web/src/pages/alerts-investigation-status.ts
@@ -1,0 +1,44 @@
+import type { InvestigationStatus } from '../api/types.js';
+
+export const IN_PROGRESS_INVESTIGATION_STATUSES: ReadonlySet<InvestigationStatus> = new Set([
+  'planning',
+  'investigating',
+  'evidencing',
+  'explaining',
+  'acting',
+  'verifying',
+]);
+
+export type InvestigationIndicator =
+  | { kind: 'idle' }
+  | { kind: 'in_progress'; status: InvestigationStatus; investigationId: string }
+  | { kind: 'completed_with_plan'; investigationId: string; planId: string }
+  | { kind: 'completed'; investigationId: string }
+  | { kind: 'failed'; investigationId: string };
+
+export function classifyInvestigation(args: {
+  investigationId?: string;
+  status?: InvestigationStatus;
+  pendingPlanId?: string;
+}): InvestigationIndicator {
+  const { investigationId, status, pendingPlanId } = args;
+  if (!investigationId) return { kind: 'idle' };
+  if (status && IN_PROGRESS_INVESTIGATION_STATUSES.has(status)) {
+    return { kind: 'in_progress', status, investigationId };
+  }
+  if (status === 'failed') return { kind: 'failed', investigationId };
+  if (pendingPlanId) return { kind: 'completed_with_plan', investigationId, planId: pendingPlanId };
+  if (status === 'completed') return { kind: 'completed', investigationId };
+  // Status unknown yet (still loading) but we have an investigationId: treat as in-progress
+  // so the UI shows the spinner rather than nothing.
+  return { kind: 'in_progress', status: status ?? 'planning', investigationId };
+}
+
+/**
+ * 5s while any investigation is active, 30s otherwise. Hidden documents
+ * use the larger interval to avoid background work.
+ */
+export function nextPollIntervalMs(args: { anyActive: boolean; visible: boolean }): number {
+  if (!args.visible) return 30_000;
+  return args.anyActive ? 5_000 : 30_000;
+}


### PR DESCRIPTION
## Summary
A firing alert with an auto-investigation in flight now shows an animated \"Investigating…\" pill on the Alerts row so operators see the agent is working without clicking Investigate.

- New \`useInvestigationStatuses\` hook polls \`/api/investigations\` for the current rules' investigationIds. 5s cadence while any rule is firing with an active investigation, 30s otherwise; pauses when the document is hidden.
- \`AlertRuleRow\` renders the indicator when \`state==='firing'\` and the associated investigation status is non-terminal (planning / investigating / evidencing / explaining / acting / verifying). Click still routes to \`/investigations/:id\` for parity with the Investigate button.
- Pure logic extracted to \`alerts-investigation-status.ts\` with 9 unit tests covering polling cadence, status mapping, and visibility behavior.

## Why
Operators couldn't tell from the Alerts page whether the dispatcher had picked up a firing alert and started analyzing. They'd click Investigate to learn, which felt redundant once #124 made that route show the live progress view.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] New tests pass (9/9)
- [ ] Manual: trigger an alert, see firing badge + pulsing \"Investigating…\" pill while planning, transition once status reaches \`completed\`/\`failed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live investigation status polling on alerts page displays current progress in real-time
  * Visual indicators show investigation states: Investigating, Done, Failed, and Plan ready

* **Improvements**
  * Investigation action buttons now intelligently adapt based on investigation status
  * Streamlined re-investigation workflow logic

* **Tests**
  * Added test suite for investigation status classification and polling interval logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->