### PR TITLE
GitHub change sources + ops-api refactor

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+
+## Never write fallback code
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/demo/openobs-demo.yaml
+++ b/demo/openobs-demo.yaml
@@ -1,0 +1,217 @@
+# OpenObs end-to-end demo workload.
+# 创建一个独立的 namespace 包含：
+#   - prom/prometheus（带 in-cluster pod discovery）
+#   - nginx + nginx-prometheus-exporter（提供可观测指标）
+#   - load-generator deployment（持续打流量，便于触发 alert）
+#
+# 之后用 kubectl port-forward 把 Prometheus 9090 forward 出来，
+# OpenObs 就用 http://localhost:9090 当数据源。
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openobs-demo
+---
+# -- Prometheus -----------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: openobs-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-openobs-demo
+rules:
+  - apiGroups: [""]
+    resources: [pods, services, endpoints]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-openobs-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-openobs-demo
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: openobs-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: openobs-demo
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: openobs-demo-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [openobs-demo]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: openobs-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: prometheus}
+  template:
+    metadata:
+      labels: {app: prometheus}
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.51.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: openobs-demo
+spec:
+  selector: {app: prometheus}
+  ports:
+    - port: 9090
+      targetPort: 9090
+---
+# -- nginx + exporter sidecar --------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: openobs-demo
+data:
+  nginx.conf: |
+    events {}
+    http {
+      log_format main '$remote_addr $status $request';
+      access_log /dev/stdout main;
+      server {
+        listen 80;
+        location /stub_status { stub_status; }
+        location / { return 200 "ok\n"; }
+        location /error { return 500 "boom\n"; }
+        location /slow { return 200 "slow\n"; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: openobs-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: nginx}
+  template:
+    metadata:
+      labels: {app: nginx}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx
+        - name: exporter
+          image: nginx/nginx-prometheus-exporter:1.1.0
+          args: [-nginx.scrape-uri=http://localhost/stub_status]
+          ports:
+            - containerPort: 9113
+      volumes:
+        - name: conf
+          configMap:
+            name: nginx-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: openobs-demo
+spec:
+  selector: {app: nginx}
+  ports:
+    - port: 80
+      targetPort: 80
+---
+# -- background load generator -------------------------------------------
+# Hits / every 0.5s + /error every 5s. Gives you steady traffic + a low
+# baseline error rate. Scale this deploy up / curl manually to spike.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load
+  namespace: openobs-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: load}
+  template:
+    metadata:
+      labels: {app: load}
+    spec:
+      containers:
+        - name: curl
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                wget -q -O- http://nginx.openobs-demo/ >/dev/null
+                wget -q -O- http://nginx.openobs-demo/error >/dev/null 2>&1 || true
+                sleep 0.5
+              done

--- a/docs/design/personal-chat-sessions.md
+++ b/docs/design/personal-chat-sessions.md
@@ -1,0 +1,122 @@
+# Personal Chat Sessions
+
+## Problem
+
+OpenObs chat currently behaves like the conversation is attached to the page
+or resource that the user lands on after an agent action. That creates two UX
+and security problems:
+
+- A dashboard, investigation, or alert is often shared inside an org, but the
+  conversation that created it is personal working context.
+- A home-page conversation can disappear from the user's point of view when a
+  tab changes or the agent navigates to the created resource.
+
+The product model should make chat history durable and private by default.
+
+## Model
+
+Chat is a first-class personal object:
+
+```text
+User -> ChatSession -> ChatSessionContext -> Dashboard | Investigation | Alert
+```
+
+Rules:
+
+- `chat_sessions` are scoped by `org_id` and `owner_user_id`.
+- `chat_messages` and `chat_session_events` are reachable only through an
+  authorized session owned by the current user.
+- A resource may be linked to many personal sessions, but a resource never
+  owns or exposes those sessions by default.
+- Shared/team-visible chat can be added later with an explicit `visibility`
+  field. The default and only v1 behavior is private.
+
+## API Shape
+
+`POST /api/chat`
+
+- Without `sessionId`, creates a private session for the current user.
+- With `sessionId`, continues only if the session belongs to the current user.
+- Accepts optional `pageContext` as a prompt and context-link hint.
+- Returns the durable `sessionId` in the SSE `done` event.
+
+`GET /api/chat/sessions`
+
+- Lists only the current user's sessions in the current org.
+- Supports `limit`.
+- Future filter: `resourceType/resourceId`.
+
+`GET /api/chat/sessions/:id/messages`
+
+- Returns messages and persisted step events only if the session belongs to
+  the current user.
+
+`GET /api/chat/:sessionId`
+
+- Legacy route should be removed once the web client uses the canonical
+  `/sessions/:id/messages` route everywhere.
+
+## Resource Contexts
+
+Add `chat_session_contexts`:
+
+```text
+id
+session_id
+org_id
+owner_user_id
+resource_type     dashboard | investigation | alert
+resource_id
+relation          created_from_chat | viewed_with_chat | referenced
+created_at
+```
+
+The chat service records a context when:
+
+- a page sends `pageContext.kind/id`
+- the agent returns a navigation target for a created dashboard,
+  investigation, or alert
+
+This table is not an access-control grant. It is an index for "my chats about
+this resource".
+
+## Frontend UX
+
+Home:
+
+- Starting a chat creates a durable personal session as soon as the first
+  message is sent.
+- The returned `sessionId` is stored in the global chat context and can also
+  be represented in the URL as `?chat=<id>` when useful.
+- Home shows a "My conversations" list from `GET /api/chat/sessions`.
+
+Resource pages:
+
+- If the URL has `?chat=<id>`, load that session after ownership validation.
+- If no chat id exists, the page may offer "New chat" and "Continue recent
+  chat" from the current user's resource-linked sessions.
+- Opening a shared dashboard never reveals another user's conversations.
+
+Navigation:
+
+- Agent-created resources should navigate with the session id preserved:
+  `/dashboards/<id>?chat=<sessionId>`.
+- The global chat context should not rely on tab-local state as the source of
+  truth. Server state is canonical.
+
+## Migration
+
+1. Add nullable `owner_user_id` and default private metadata to chat sessions.
+2. Backfill existing sessions conservatively:
+   - sessions created by authenticated traffic should receive the stored user
+     when available
+   - otherwise they remain visible only to admins or are hidden from normal
+     user lists until claimed by a migration path
+3. Remove resource-owned chat loading from dashboards/investigations.
+4. Remove the legacy `GET /api/chat/:sessionId` route after frontend cutover.
+
+## Non-Goals
+
+- Team-visible shared chat threads.
+- Resource-level chat audit export.
+- Cross-user handoff of active chat sessions.

--- a/packages/adapters/src/change-event/adapter.ts
+++ b/packages/adapters/src/change-event/adapter.ts
@@ -2,6 +2,7 @@
 
 import type { Change } from '@agentic-obs/common';
 import type { DataAdapter } from '../adapter.js';
+import type { ChangeRecord, ChangesListInput, IChangesAdapter } from '../interfaces.js';
 import type {
   Capabilities,
   SemanticQuery,
@@ -20,7 +21,7 @@ export interface ChangeEventAdapterConfig {
   maxEvents?: number;
 }
 
-export class ChangeEventAdapter implements DataAdapter {
+export class ChangeEventAdapter implements DataAdapter, IChangesAdapter {
   readonly name: string;
   readonly description = 'In-memory change event adapter (deploy, config, scale, feature flags)';
 
@@ -110,6 +111,17 @@ export class ChangeEventAdapter implements DataAdapter {
     };
   }
 
+  async listRecent(input: ChangesListInput): Promise<ChangeRecord[]> {
+    const endTime = new Date();
+    const startTime = new Date(endTime.getTime() - input.windowMinutes * 60_000);
+    return this.store.query({
+      serviceId: input.service,
+      startTime,
+      endTime,
+      limit: 100,
+    }).map(toChangeRecord);
+  }
+
   // -- Webhook ingestion --
 
   /**
@@ -156,4 +168,26 @@ export class ChangeEventAdapter implements DataAdapter {
   get changeStore(): ChangeEventStore {
     return this.store;
   }
+}
+
+const CHANGE_KIND: Record<Change['type'], ChangeRecord['kind']> = {
+  deploy: 'deploy',
+  config: 'config',
+  scale: 'config',
+  feature_flag: 'feature-flag',
+};
+
+function toChangeRecord(change: Change): ChangeRecord {
+  return {
+    id: change.id,
+    service: change.serviceId,
+    kind: CHANGE_KIND[change.type] ?? 'other',
+    summary: change.description,
+    at: change.timestamp,
+    metadata: {
+      author: change.author,
+      ...(change.version ? { version: change.version } : {}),
+      ...(change.diff ? { diff: change.diff } : {}),
+    },
+  };
 }

--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -36,6 +36,7 @@ import type { Persistence } from './persistence.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
+import type { GitHubChangeSourceRegistry } from '../services/github-change-source-service.js';
 
 const NOOP_CONVERSATION_STORE: IAgentConversationStore = {
   getMessages: async () => [],
@@ -53,6 +54,8 @@ export interface BackgroundOrchestratorFactoryDeps {
   audit?: AuditWriter;
   /** Optional folder backend — enables folder.create / folder.list tools. */
   folderRepository?: IFolderRepository;
+  /** In-process GitHub/change sources. */
+  githubChangeSources?: GitHubChangeSourceRegistry;
 }
 
 export type MakeBackgroundOrchestrator = (overrides: {
@@ -79,7 +82,10 @@ export function buildBackgroundOrchestratorFactory(
     }
     const datasources = await deps.setupConfig.listDatasources({ orgId: identity.orgId });
     const gateway = createLlmGateway(llm);
-    const adapters = buildAdapterRegistry(datasources);
+    const adapters = buildAdapterRegistry(
+      datasources,
+      deps.githubChangeSources ? await deps.githubChangeSources.listAdapters(identity.orgId) : [],
+    );
 
     const opsCommandRunner = deps.persistence.repos.opsConnectors && deps.persistence.repos.approvals
       ? new OpsCommandRunnerService({

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -47,6 +47,7 @@ import { createVersionRouter } from '../routes/versions.js';
 import { createSearchRouter } from '../routes/search.js';
 import { createChatRouter } from '../routes/chat.js';
 import { createOpsConnectorsRouter } from '../routes/ops-connectors.js';
+import { createGithubChangeSourcesRouter } from '../routes/github-change-sources.js';
 import { bootstrapAware } from '../middleware/bootstrap-aware.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { createOrgContextMiddleware } from '../middleware/org-context.js';
@@ -55,6 +56,7 @@ import type { AccessControlService } from '../services/accesscontrol-service.js'
 import type { AuthSubsystem } from '../auth/auth-manager.js';
 import type { AuthRepositories } from './auth-routes.js';
 import type { Persistence } from './persistence.js';
+import type { GitHubChangeSourceRegistry } from '../services/github-change-source-service.js';
 
 export interface MountDomainRoutesDeps {
   app: Application;
@@ -74,6 +76,7 @@ export interface MountDomainRoutesDeps {
    * see writes routed through any other wrapper.
    */
   eventAlertRuleStore?: EventEmittingAlertRuleRepository;
+  githubChangeSources?: GitHubChangeSourceRegistry;
 }
 
 export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
@@ -96,6 +99,12 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   app.use('/api/openapi.json', openApiRouter);
   app.use('/api/webhooks', createWebhookRouter({ ac: accessControl }));
   app.use('/api/metrics', metricsRouter);
+  if (deps.githubChangeSources) {
+    app.use('/api/change-sources', createGithubChangeSourcesRouter({
+      registry: deps.githubChangeSources,
+      ac: accessControl,
+    }));
+  }
 
   // Relaxed rate limiter for dashboard query routes — must be on the
   // mount path BEFORE the bootstrap-aware auth chain.
@@ -212,6 +221,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     auditWriter: authSub.audit,
     folderRepository: sharedFolderRepo,
     setupConfig,
+    githubChangeSources: deps.githubChangeSources,
   }));
   app.use('/api/alert-rules', createAlertRulesRouter({
     alertRuleStore: eventAlertRuleStore,

--- a/packages/api-gateway/src/routes/github-change-sources.test.ts
+++ b/packages/api-gateway/src/routes/github-change-sources.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createHmac } from 'node:crypto';
+import express from 'express';
+import request from 'supertest';
+import { sql } from 'drizzle-orm';
+import type { Evaluator, Identity, ResolvedPermission } from '@agentic-obs/common';
+import { setAuthMiddleware, type AuthenticatedRequest } from '../middleware/auth.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import { GitHubChangeSourceRegistry } from '../services/github-change-source-service.js';
+import { createGithubChangeSourcesRouter } from './github-change-sources.js';
+import { createTestDb } from '../../../data-layer/src/test-support/test-db.js';
+import { SqliteChangeSourceRepository } from '../../../data-layer/src/repository/sqlite/change-source.js';
+
+function identity(orgId: string): Identity {
+  return {
+    userId: 'u_1',
+    orgId,
+    orgRole: 'Admin',
+    isServerAdmin: false,
+    authenticatedBy: 'session',
+  };
+}
+
+function makeAccessControl(): AccessControlSurface {
+  return {
+    getUserPermissions: async (): Promise<ResolvedPermission[]> => [],
+    ensurePermissions: async (): Promise<ResolvedPermission[]> => [],
+    evaluate: async (_id: Identity, _evaluator: Evaluator): Promise<boolean> => true,
+    filterByPermission: async <T>(_id: Identity, items: T[]): Promise<T[]> => items,
+  };
+}
+
+function makeApp(orgId = 'org_a') {
+  const db = createTestDb();
+  db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_a', 'Org A', 'now', 'now')`);
+  db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_b', 'Org B', 'now', 'now')`);
+  const registry = new GitHubChangeSourceRegistry(new SqliteChangeSourceRepository(db));
+  setAuthMiddleware((req: AuthenticatedRequest, _res, next) => {
+    req.auth = identity(orgId);
+    next();
+  });
+  const app = express();
+  app.use(express.json({
+    verify: (req, _res, buf) => {
+      (req as typeof req & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+    },
+  }));
+  app.use('/api/change-sources', createGithubChangeSourcesRouter({
+    registry,
+    ac: makeAccessControl(),
+  }));
+  return { app, registry };
+}
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(Buffer.from(body)).digest('hex')}`;
+}
+
+function githubDeploymentBody(): string {
+  return JSON.stringify({
+    deployment: {
+      id: 1,
+      ref: 'main',
+      sha: 'abc123',
+      environment: 'production',
+      description: 'Deploy main',
+      created_at: new Date().toISOString(),
+      creator: { login: 'octocat' },
+    },
+    repository: { full_name: 'openobs/openobs' },
+  });
+}
+
+describe('GitHub change source routes', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-github-change-routes-xxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  afterEach(() => {
+    setAuthMiddleware(null);
+  });
+
+  it('creates and lists GitHub sources in the authenticated org', async () => {
+    const { app } = makeApp('org_a');
+
+    const created = await request(app)
+      .post('/api/change-sources/github')
+      .send({
+        name: 'Prod deploys',
+        owner: 'openobs',
+        repo: 'openobs',
+        secret: 'super-secret',
+      })
+      .expect(201);
+
+    expect(created.body.source.orgId).toBe('org_a');
+    expect(created.body.source.secret).toBe('super-secret');
+    expect(created.body.source.secretMasked).toBe('••••••cret');
+
+    const listed = await request(app).get('/api/change-sources/github').expect(200);
+    expect(listed.body.sources).toHaveLength(1);
+    expect(listed.body.sources[0].secret).toBeUndefined();
+  });
+
+  it('verifies GitHub signatures and ingests deployment events', async () => {
+    const { app, registry } = makeApp('org_a');
+    const source = await registry.create({
+      orgId: 'org_a',
+      name: 'Prod deploys',
+      secret: 'webhook-secret',
+    });
+    const body = githubDeploymentBody();
+
+    await request(app)
+      .post(`/api/change-sources/github/${source.id}/webhook`)
+      .set('X-GitHub-Event', 'deployment')
+      .set('X-Hub-Signature-256', sign(body, 'webhook-secret'))
+      .set('Content-Type', 'application/json')
+      .send(body)
+      .expect(200);
+
+    const records = await (await registry.listAdapters('org_a'))[0]!.adapter.listRecent({ windowMinutes: 60 });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ service: 'openobs/openobs', kind: 'deploy' });
+  });
+
+  it('rejects webhook requests with invalid signatures', async () => {
+    const { app, registry } = makeApp('org_a');
+    const source = await registry.create({
+      orgId: 'org_a',
+      name: 'Prod deploys',
+      secret: 'webhook-secret',
+    });
+
+    await request(app)
+      .post(`/api/change-sources/github/${source.id}/webhook`)
+      .set('X-GitHub-Event', 'deployment')
+      .set('X-Hub-Signature-256', 'sha256=deadbeef')
+      .set('Content-Type', 'application/json')
+      .send(githubDeploymentBody())
+      .expect(401);
+  });
+});

--- a/packages/api-gateway/src/routes/github-change-sources.ts
+++ b/packages/api-gateway/src/routes/github-change-sources.ts
@@ -1,0 +1,142 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { Router, raw as expressRaw } from 'express';
+import type { Request, Response } from 'express';
+import { ACTIONS, ac } from '@agentic-obs/common';
+import { authMiddleware, type AuthenticatedRequest } from '../middleware/auth.js';
+import { createRequirePermission } from '../middleware/require-permission.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { GitHubChangeSourceRegistry } from '../services/github-change-source-service.js';
+
+export interface GithubChangeSourcesRouterDeps {
+  registry: GitHubChangeSourceRegistry;
+  ac: AccessControlSurface;
+}
+
+interface CreateGithubSourceBody {
+  name?: string;
+  owner?: string;
+  repo?: string;
+  events?: string[];
+  secret?: string;
+  active?: boolean;
+}
+
+function orgIdFromReq(req: Request): string | null {
+  return (req as AuthenticatedRequest).auth?.orgId ?? null;
+}
+
+function requireOrg(req: Request, res: Response): string | null {
+  const orgId = orgIdFromReq(req);
+  if (!orgId) {
+    res.status(403).json({ error: { code: 'FORBIDDEN', message: 'org context is required' } });
+    return null;
+  }
+  return orgId;
+}
+
+function verifyGitHubSignature(payload: Buffer, signature: string | undefined, secret: string): boolean {
+  if (!signature?.startsWith('sha256=')) return false;
+  const actual = Buffer.from(signature.slice('sha256='.length), 'hex');
+  const expected = Buffer.from(createHmac('sha256', secret).update(payload).digest('hex'), 'hex');
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
+
+export function createGithubChangeSourcesRouter(deps: GithubChangeSourcesRouterDeps): Router {
+  const router = Router();
+  const requirePermission = createRequirePermission(deps.ac);
+  const requireRead = requirePermission(() =>
+    ac.any(
+      ac.eval(ACTIONS.DatasourcesRead, 'datasources:*'),
+      ac.eval(ACTIONS.InstanceConfigRead),
+    ),
+  );
+  const requireWrite = requirePermission(() =>
+    ac.any(
+      ac.eval(ACTIONS.DatasourcesWrite, 'datasources:*'),
+      ac.eval(ACTIONS.InstanceConfigWrite),
+    ),
+  );
+
+  router.post(
+    '/github/:id/webhook',
+    expressRaw({ type: () => true }),
+    async (req: Request, res: Response) => {
+      const id = req.params['id'] ?? '';
+      const secret = await deps.registry.getSecret(id);
+      if (!secret) {
+        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'GitHub change source not found' } });
+        return;
+      }
+      const rawBody = Buffer.isBuffer(req.body)
+        ? req.body
+        : ((req as Request & { rawBody?: Buffer }).rawBody ?? Buffer.from(JSON.stringify(req.body ?? '')));
+      const signature = req.headers['x-hub-signature-256'] as string | undefined;
+      if (!verifyGitHubSignature(rawBody, signature, secret)) {
+        res.status(401).json({ error: { code: 'INVALID_SIGNATURE', message: 'Signature mismatch' } });
+        return;
+      }
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(rawBody.toString('utf8'));
+      } catch {
+        res.status(400).json({ error: { code: 'INVALID_JSON', message: 'Webhook body must be JSON' } });
+        return;
+      }
+
+      const eventName = req.headers['x-github-event'] as string | undefined;
+      if (!eventName) {
+        res.status(400).json({ error: { code: 'MISSING_EVENT', message: 'X-GitHub-Event is required' } });
+        return;
+      }
+      const result = await deps.registry.ingestGitHubWebhook(id, eventName, payload);
+      if (!result.ok) {
+        res.status(result.status).json({ error: { code: 'INGEST_FAILED', message: result.message } });
+        return;
+      }
+      res.json({ received: true, ignored: result.ignored, record: result.record ?? null });
+    },
+  );
+
+  router.use(authMiddleware);
+
+  router.get('/github', requireRead, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    res.json({ sources: await deps.registry.list(orgId) });
+  });
+
+  router.post('/github', requireWrite, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const body = req.body as CreateGithubSourceBody;
+    if (!body?.name?.trim()) {
+      res.status(400).json({ error: { code: 'VALIDATION', message: 'name is required' } });
+      return;
+    }
+    const source = await deps.registry.create({
+      orgId,
+      name: body.name.trim(),
+      owner: body.owner?.trim() || undefined,
+      repo: body.repo?.trim() || undefined,
+      events: body.events?.filter((event) => typeof event === 'string' && event.trim()).map((event) => event.trim()),
+      secret: body.secret?.trim() || undefined,
+      active: body.active,
+    });
+    res.status(201).json({ source });
+  });
+
+  router.delete('/github/:id', requireWrite, async (req: Request, res: Response) => {
+    const orgId = requireOrg(req, res);
+    if (!orgId) return;
+    const deleted = await deps.registry.delete(orgId, req.params['id'] ?? '');
+    if (!deleted) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'GitHub change source not found' } });
+      return;
+    }
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -40,6 +40,7 @@ import { mountDomainRoutes } from './app/domain-routes.js';
 import { startAlerts } from './app/alerts-boot.js';
 import { EventEmittingAlertRuleRepository } from '@agentic-obs/data-layer';
 import { buildBackgroundOrchestratorFactory } from './app/agent-factory.js';
+import { GitHubChangeSourceRegistry } from './services/github-change-source-service.js';
 import { createShutdownHooks } from './app/lifecycle.js';
 import type { WebSocketGatewayDeps } from './websocket/gateway.js';
 
@@ -107,7 +108,11 @@ function mountGlobalMiddleware(app: Application): void {
     }),
   );
 
-  app.use(express.json());
+  app.use(express.json({
+    verify: (req, _res, buf) => {
+      (req as typeof req & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+    },
+  }));
   app.use(requestLogger);
   app.use(cors);
   // CSRF — double-submit cookie. Mounts BEFORE auth middleware so we can
@@ -191,6 +196,7 @@ export async function createApp(): Promise<Application> {
   const eventAlertRuleStore = new EventEmittingAlertRuleRepository(
     persistence.repos.alertRules,
   );
+  const githubChangeSources = new GitHubChangeSourceRegistry(persistence.repos.changeSources);
 
   // -- W6 business routes + bootstrap-aware mounts ----------------------
   mountDomainRoutes({
@@ -204,6 +210,7 @@ export async function createApp(): Promise<Application> {
     userRateLimiter,
     queryRateLimiter,
     eventAlertRuleStore,
+    githubChangeSources,
   });
 
   // Start the periodic alert evaluator (Phase 0.5 boot path). Behind
@@ -231,6 +238,7 @@ export async function createApp(): Promise<Application> {
         accessControl,
         audit: bundle.authSub.audit,
         folderRepository: sharedFolderRepo,
+        githubChangeSources,
       }),
     },
   });

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -16,6 +16,7 @@ import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
 import type { IGatewayDashboardStore } from '../repositories/types.js';
 import type { IInvestigationReportRepository, IAlertRuleRepository, IGatewayInvestigationStore, IChatSessionRepository, IChatMessageRepository, IChatSessionEventRepository, IOpsConnectorRepository, IApprovalRequestRepository } from '@agentic-obs/data-layer';
+import type { GitHubChangeSourceRegistry } from './github-change-source-service.js';
 
 const log = createLogger('chat-service');
 
@@ -83,6 +84,8 @@ export interface ChatServiceDeps {
   folderRepository?: import('@agentic-obs/common').IFolderRepository;
   /** W2 / T2.4 — LLM + datasource config source. */
   setupConfig: SetupConfigService;
+  /** In-process change sources such as GitHub webhooks. */
+  githubChangeSources?: GitHubChangeSourceRegistry;
 }
 
 /**
@@ -193,7 +196,10 @@ export class ChatService {
 
     const gateway = createLlmGateway(llm);
     const model = llm.model;
-    const adapters = buildAdapterRegistry(datasources);
+    const adapters = buildAdapterRegistry(
+      datasources,
+      this.deps.githubChangeSources ? await this.deps.githubChangeSources.listAdapters(identity.orgId) : [],
+    );
     const opsCommandRunner = this.deps.opsConnectorStore && this.deps.approvalStore
       ? new OpsCommandRunnerService({
           connectors: this.deps.opsConnectorStore,

--- a/packages/api-gateway/src/services/dashboard-service.ts
+++ b/packages/api-gateway/src/services/dashboard-service.ts
@@ -1,6 +1,7 @@
 import type { InstanceDatasource } from '@agentic-obs/common';
 import { AdapterRegistry } from '@agentic-obs/agent-core';
 import { PrometheusMetricsAdapter, LokiLogsAdapter } from '@agentic-obs/adapters';
+import type { IChangesAdapter } from '@agentic-obs/adapters';
 
 /**
  * Convert InstanceDatasource[] to the narrower `DatasourceConfig[]`
@@ -71,7 +72,16 @@ export function datasourceHeaders(ds: InstanceDatasource): Record<string, string
  * we don't have an adapter for yet; those just won't be queryable by the
  * agent until an adapter lands).
  */
-export function buildAdapterRegistry(datasources: InstanceDatasource[]): AdapterRegistry {
+export interface ChangeAdapterRegistration {
+  id: string;
+  name: string;
+  adapter: IChangesAdapter;
+}
+
+export function buildAdapterRegistry(
+  datasources: InstanceDatasource[],
+  changeAdapters: ChangeAdapterRegistration[] = [],
+): AdapterRegistry {
   const registry = new AdapterRegistry();
   for (const ds of datasources) {
     const headers = datasourceHeaders(ds);
@@ -87,6 +97,12 @@ export function buildAdapterRegistry(datasources: InstanceDatasource[]): Adapter
       });
     }
     // elasticsearch / clickhouse / tempo / jaeger / otel: adapters not yet implemented
+  }
+  for (const source of changeAdapters) {
+    registry.register({
+      info: { id: source.id, name: source.name, type: 'github', signalType: 'changes' },
+      changes: source.adapter,
+    });
   }
   return registry;
 }
@@ -110,4 +126,3 @@ export async function withDashboardLock<T>(dashboardId: string, fn: () => Promis
     }
   }
 }
-

--- a/packages/api-gateway/src/services/github-change-source-service.test.ts
+++ b/packages/api-gateway/src/services/github-change-source-service.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { SqliteClient } from '../../../data-layer/src/db/sqlite-client.js';
+import { createTestDb } from '../../../data-layer/src/test-support/test-db.js';
+import { SqliteChangeSourceRepository } from '../../../data-layer/src/repository/sqlite/change-source.js';
+import { GitHubChangeSourceRegistry } from './github-change-source-service.js';
+
+function deploymentPayload(patch: Record<string, unknown> = {}) {
+  return {
+    deployment: {
+      id: 123,
+      ref: 'main',
+      sha: 'abc123',
+      environment: 'production',
+      description: 'Deploy main to production',
+      created_at: new Date().toISOString(),
+      creator: { login: 'octocat' },
+    },
+    repository: { full_name: 'openobs/openobs' },
+    ...patch,
+  };
+}
+
+describe('GitHubChangeSourceRegistry', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+  let db: SqliteClient;
+  let registry: GitHubChangeSourceRegistry;
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-github-change-service-xxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_a', 'Org A', 'now', 'now')`);
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_b', 'Org B', 'now', 'now')`);
+    registry = new GitHubChangeSourceRegistry(new SqliteChangeSourceRepository(db));
+  });
+
+  it('creates org-scoped GitHub sources with a one-time plain secret', async () => {
+    const source = await registry.create({
+      orgId: 'org_a',
+      name: 'Prod deploys',
+      owner: 'openobs',
+      repo: 'openobs',
+      secret: 'super-secret',
+    });
+
+    expect(source.orgId).toBe('org_a');
+    expect(source.secret).toBe('super-secret');
+    expect(source.secretMasked).toBe('••••••cret');
+    expect(source.webhookPath).toBe(`/api/change-sources/github/${source.id}/webhook`);
+    await expect(registry.list('org_a')).resolves.toHaveLength(1);
+    await expect(registry.list('org_b')).resolves.toEqual([]);
+    expect((await registry.list('org_a'))[0]).not.toHaveProperty('secret');
+  });
+
+  it('ingests GitHub deployment webhooks into a queryable changes adapter', async () => {
+    const source = await registry.create({ orgId: 'org_a', name: 'Prod deploys' });
+
+    const result = await registry.ingestGitHubWebhook(source.id, 'deployment', deploymentPayload());
+
+    expect(result).toMatchObject({
+      ok: true,
+      ignored: false,
+      record: {
+        service: 'openobs/openobs',
+        kind: 'deploy',
+        summary: 'Deploy main to production',
+      },
+    });
+
+    const adapters = await registry.listAdapters('org_a');
+    expect(adapters).toHaveLength(1);
+    const records = await adapters[0]!.adapter.listRecent({ windowMinutes: 60 });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      service: 'openobs/openobs',
+      metadata: { author: 'octocat', version: 'abc123' },
+    });
+  });
+
+  it('ignores disabled event types and foreign org deletes', async () => {
+    const source = await registry.create({
+      orgId: 'org_a',
+      name: 'Prod deploys',
+      events: ['deployment'],
+    });
+
+    await expect(
+      registry.ingestGitHubWebhook(source.id, 'deployment_status', deploymentPayload()),
+    ).resolves.toMatchObject({ ok: true, ignored: true });
+    await expect(registry.delete('org_b', source.id)).resolves.toBe(false);
+    await expect(registry.list('org_a')).resolves.toHaveLength(1);
+  });
+});

--- a/packages/api-gateway/src/services/github-change-source-service.ts
+++ b/packages/api-gateway/src/services/github-change-source-service.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from 'node:crypto';
+import { normalizeWebhook, type GitHubDeploymentPayload } from '@agentic-obs/adapters';
+import type { ChangeRecord, IChangesAdapter } from '@agentic-obs/adapters';
+import type { Change } from '@agentic-obs/common';
+import type {
+  ChangeEvent,
+  ChangeSource,
+  IChangeSourceRepository,
+  NewChangeSource,
+  PublicChangeSource,
+} from '@agentic-obs/data-layer';
+
+export type GitHubChangeSource = ChangeSource;
+
+export interface NewGitHubChangeSource {
+  orgId: string;
+  name: string;
+  owner?: string;
+  repo?: string;
+  events?: string[];
+  secret?: string;
+  active?: boolean;
+}
+
+export type PublicGitHubChangeSource = PublicChangeSource & {
+  webhookPath: string;
+};
+
+export type CreatedGitHubChangeSource = PublicGitHubChangeSource & {
+  secret: string;
+};
+
+const DEFAULT_GITHUB_EVENTS = ['deployment', 'deployment_status'];
+
+export class GitHubChangeSourceRegistry {
+  constructor(private readonly repo: IChangeSourceRepository) {}
+
+  async list(orgId: string): Promise<PublicGitHubChangeSource[]> {
+    const sources = await this.repo.listSources(orgId, { masked: true });
+    return sources.map(toPublicSource);
+  }
+
+  async get(orgId: string, id: string): Promise<PublicGitHubChangeSource | null> {
+    const source = await this.repo.findSourceByIdInOrg(orgId, id, { masked: true });
+    return source ? toPublicSource(source) : null;
+  }
+
+  async getSecret(id: string): Promise<string | null> {
+    return (await this.repo.findSourceById(id))?.secret ?? null;
+  }
+
+  async create(input: NewGitHubChangeSource): Promise<CreatedGitHubChangeSource> {
+    const secret = input.secret?.trim() || randomUUID();
+    const source = await this.repo.createSource(toRepoInput(input, secret));
+    return { ...toPublicSource({ ...source, secret: maskSecret(secret) }), secret };
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    return this.repo.deleteSource(orgId, id);
+  }
+
+  async ingestGitHubWebhook(
+    sourceId: string,
+    eventName: string,
+    payload: unknown,
+  ): Promise<{ ok: true; ignored: boolean; record?: ChangeRecord } | { ok: false; status: number; message: string }> {
+    const source = await this.repo.findSourceById(sourceId);
+    if (!source || !source.active) {
+      return { ok: false, status: 404, message: `GitHub change source "${sourceId}" not found` };
+    }
+    if (!source.events.includes(eventName)) {
+      return { ok: true, ignored: true };
+    }
+    const normalized = toGitHubDeploymentPayload(eventName, payload);
+    if (!normalized) {
+      return { ok: true, ignored: true };
+    }
+    const change = normalizeWebhook({ source: 'github', payload: normalized });
+    if (!change) return { ok: true, ignored: true };
+    const saved = await this.repo.addEvent({
+      orgId: source.orgId,
+      sourceId: source.id,
+      serviceId: change.serviceId,
+      type: change.type,
+      timestamp: change.timestamp,
+      author: change.author,
+      description: change.description,
+      diff: change.diff,
+      version: change.version,
+      payload: payload as Record<string, unknown>,
+    });
+    return { ok: true, ignored: false, record: eventToChangeRecord(saved) };
+  }
+
+  async listAdapters(orgId: string): Promise<Array<{ id: string; name: string; adapter: IChangesAdapter }>> {
+    const sources = await this.repo.listSources(orgId, { masked: true });
+    return sources
+      .filter((source) => source.active)
+      .map((source) => ({
+        id: source.id,
+        name: source.name,
+        adapter: new RepositoryChangesAdapter(this.repo, orgId, source.id),
+      }));
+  }
+}
+
+class RepositoryChangesAdapter implements IChangesAdapter {
+  constructor(
+    private readonly repo: IChangeSourceRepository,
+    private readonly orgId: string,
+    private readonly sourceId: string,
+  ) {}
+
+  async listRecent(input: { service?: string; windowMinutes: number }): Promise<ChangeRecord[]> {
+    const end = new Date();
+    const start = new Date(end.getTime() - input.windowMinutes * 60_000);
+    const events = await this.repo.listEvents({
+      orgId: this.orgId,
+      sourceId: this.sourceId,
+      serviceId: input.service,
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      limit: 100,
+    });
+    return events.map(eventToChangeRecord);
+  }
+}
+
+function toRepoInput(input: NewGitHubChangeSource, secret: string): NewChangeSource {
+  return {
+    orgId: input.orgId,
+    type: 'github',
+    name: input.name,
+    owner: input.owner ?? null,
+    repo: input.repo ?? null,
+    events: input.events?.length ? input.events : DEFAULT_GITHUB_EVENTS,
+    secret,
+    active: input.active ?? true,
+  };
+}
+
+function toGitHubDeploymentPayload(eventName: string, payload: unknown): GitHubDeploymentPayload | null {
+  const body = payload as Partial<GitHubDeploymentPayload> | undefined;
+  if (!body || typeof body !== 'object') return null;
+  if (eventName === 'deployment') {
+    return {
+      ...body,
+      action: 'created',
+    } as GitHubDeploymentPayload;
+  }
+  if (eventName === 'deployment_status') {
+    const state = (body as { deployment_status?: { state?: string } }).deployment_status?.state;
+    const action = state === 'success' ? 'success'
+      : state === 'failure' || state === 'error' ? 'failure'
+        : 'pending';
+    return {
+      ...body,
+      action,
+    } as GitHubDeploymentPayload;
+  }
+  return null;
+}
+
+const CHANGE_KIND: Record<Change['type'], ChangeRecord['kind']> = {
+  deploy: 'deploy',
+  config: 'config',
+  scale: 'config',
+  feature_flag: 'feature-flag',
+};
+
+function eventToChangeRecord(change: ChangeEvent): ChangeRecord {
+  return {
+    id: change.id,
+    service: change.serviceId,
+    kind: CHANGE_KIND[change.type] ?? 'other',
+    summary: change.description,
+    at: change.timestamp,
+    metadata: {
+      author: change.author,
+      ...(change.version ? { version: change.version } : {}),
+      ...(change.diff ? { diff: change.diff } : {}),
+    },
+  };
+}
+
+function toPublicSource(source: ChangeSource): PublicGitHubChangeSource {
+  const { secret: _secret, ...rest } = source;
+  return {
+    ...rest,
+    webhookPath: `/api/change-sources/github/${source.id}/webhook`,
+    secretMasked: source.secret,
+  };
+}
+
+function maskSecret(secret: string): string {
+  return secret.length <= 4 ? '••••••' : `••••••${secret.slice(-4)}`;
+}

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -768,6 +768,54 @@ CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_id   ON ops_connectors(o
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_type ON ops_connectors(org_id, type);
 
 -- ============================================================================
+-- Change sources and events (GitHub deployments, releases, etc.)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS change_sources (
+  id               TEXT PRIMARY KEY,
+  org_id           TEXT NOT NULL,
+  type             TEXT NOT NULL CHECK (type = 'github'),
+  name             TEXT NOT NULL,
+  owner            TEXT NULL,
+  repo             TEXT NULL,
+  events_json      TEXT NOT NULL DEFAULT '[]',
+  encrypted_secret TEXT NULL,
+  active           INTEGER NOT NULL DEFAULT 1,
+  created_at       TEXT NOT NULL,
+  updated_at       TEXT NOT NULL,
+  last_event_at    TEXT NULL,
+  FOREIGN KEY (org_id) REFERENCES org(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_change_sources_org_name ON change_sources(org_id, name);
+CREATE INDEX        IF NOT EXISTS ix_change_sources_org_id   ON change_sources(org_id);
+CREATE INDEX        IF NOT EXISTS ix_change_sources_org_type ON change_sources(org_id, type);
+
+CREATE TABLE IF NOT EXISTS change_events (
+  id           TEXT PRIMARY KEY,
+  org_id       TEXT NOT NULL,
+  source_id    TEXT NOT NULL,
+  service_id   TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  timestamp    TEXT NOT NULL,
+  author       TEXT NOT NULL,
+  description  TEXT NOT NULL,
+  diff         TEXT NULL,
+  version      TEXT NULL,
+  payload_json TEXT NULL,
+  created_at   TEXT NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES org(id) ON DELETE CASCADE,
+  FOREIGN KEY (source_id) REFERENCES change_sources(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS ix_change_events_org_time
+  ON change_events(org_id, timestamp);
+CREATE INDEX IF NOT EXISTS ix_change_events_source_time
+  ON change_events(source_id, timestamp);
+CREATE INDEX IF NOT EXISTS ix_change_events_service_time
+  ON change_events(org_id, service_id, timestamp);
+
+-- ============================================================================
 -- Remediation plans (Phase 3 of docs/design/auto-remediation.md)
 -- ============================================================================
 

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -51,6 +51,7 @@ import { InstanceConfigRepository } from './sqlite/instance-config.js';
 import { DatasourceRepository } from './sqlite/datasource.js';
 import { NotificationChannelRepository } from './sqlite/notification-channel.js';
 import { OpsConnectorRepository } from './sqlite/ops-connector.js';
+import { SqliteChangeSourceRepository } from './sqlite/change-source.js';
 import { PostgresInvestigationRepository } from './postgres/investigation.js';
 import { PostgresIncidentRepository } from './postgres/incident.js';
 import { PostgresFeedItemRepository } from './postgres/feed.js';
@@ -70,9 +71,11 @@ import { PostgresInstanceConfigRepository } from './postgres/instance-config.js'
 import { PostgresDatasourceRepository } from './postgres/datasource.js';
 import { PostgresNotificationChannelRepository } from './postgres/notification-channel.js';
 import { PostgresOpsConnectorRepository } from './postgres/ops-connector.js';
+import { PostgresChangeSourceRepository } from './postgres/change-source.js';
 import { SqliteRemediationPlanRepository } from './sqlite/remediation-plan.js';
 import { PostgresRemediationPlanRepository } from './postgres/remediation-plan.js';
 import type { IRemediationPlanRepository } from './types/remediation-plan.js';
+import type { IChangeSourceRepository } from './types/change-source.js';
 
 /**
  * Complete repository bundle available behind every persistence backend.
@@ -104,6 +107,7 @@ export interface RepositoryBundle {
   datasources: IDatasourceRepository;
   notificationChannels: INotificationChannelRepository;
   opsConnectors: IOpsConnectorRepository;
+  changeSources: IChangeSourceRepository;
   remediationPlans: IRemediationPlanRepository;
 }
 
@@ -128,6 +132,7 @@ export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
     datasources: new DatasourceRepository(db),
     notificationChannels: new NotificationChannelRepository(db),
     opsConnectors: new OpsConnectorRepository(db),
+    changeSources: new SqliteChangeSourceRepository(db),
     remediationPlans: new SqliteRemediationPlanRepository(db),
   };
 }
@@ -154,6 +159,7 @@ export function createPostgresRepositories(db: DbClient): RepositoryBundle {
     datasources: new PostgresDatasourceRepository(queryClient),
     notificationChannels: new PostgresNotificationChannelRepository(queryClient),
     opsConnectors: new PostgresOpsConnectorRepository(db),
+    changeSources: new PostgresChangeSourceRepository(queryClient),
     remediationPlans: new PostgresRemediationPlanRepository(db),
   };
 }

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -53,6 +53,17 @@ export type {
 } from './types/ops-connector.js';
 
 export type {
+  ChangeEvent,
+  ChangeSource,
+  ChangeSourceType,
+  IChangeSourceRepository,
+  ListChangeEventsOptions,
+  NewChangeEvent,
+  NewChangeSource,
+  PublicChangeSource,
+} from './types/change-source.js';
+
+export type {
   IRemediationPlanRepository,
   ListRemediationPlansOptions,
   NewRemediationPlan,

--- a/packages/data-layer/src/repository/postgres/change-source.ts
+++ b/packages/data-layer/src/repository/postgres/change-source.ts
@@ -1,0 +1,194 @@
+import { sql } from 'drizzle-orm';
+import { pgAll, pgRun } from './pg-helpers.js';
+import { decryptSecret, encryptSecret, maskSecret, nowIso, uid } from '../sqlite/instance-shared.js';
+import type { QueryClient } from '../../db/query-client.js';
+import type {
+  ChangeEvent,
+  ChangeSource,
+  IChangeSourceRepository,
+  ListChangeEventsOptions,
+  NewChangeEvent,
+  NewChangeSource,
+} from '../types/change-source.js';
+
+interface ChangeSourceRow {
+  id: string;
+  org_id: string;
+  type: string;
+  name: string;
+  owner: string | null;
+  repo: string | null;
+  events_json: string;
+  encrypted_secret: string | null;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+  last_event_at: string | null;
+}
+
+interface ChangeEventRow {
+  id: string;
+  org_id: string;
+  source_id: string;
+  service_id: string;
+  type: ChangeEvent['type'];
+  timestamp: string;
+  author: string;
+  description: string;
+  diff: string | null;
+  version: string | null;
+  payload_json: string | null;
+  created_at: string;
+}
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  return JSON.parse(raw) as T;
+}
+
+function sourceFromRow(row: ChangeSourceRow, opts: { masked?: boolean } = {}): ChangeSource {
+  const secret = decryptSecret(row.encrypted_secret);
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    type: 'github',
+    name: row.name,
+    owner: row.owner,
+    repo: row.repo,
+    events: parseJson<string[]>(row.events_json, []),
+    secret: opts.masked ? maskSecret(secret) : secret,
+    active: row.active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastEventAt: row.last_event_at,
+  };
+}
+
+function eventFromRow(row: ChangeEventRow): ChangeEvent {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    sourceId: row.source_id,
+    serviceId: row.service_id,
+    type: row.type,
+    timestamp: row.timestamp,
+    author: row.author,
+    description: row.description,
+    diff: row.diff ?? undefined,
+    version: row.version ?? undefined,
+    payload: parseJson<Record<string, unknown> | null>(row.payload_json, null),
+    createdAt: row.created_at,
+  };
+}
+
+export class PostgresChangeSourceRepository implements IChangeSourceRepository {
+  constructor(private readonly db: QueryClient) {}
+
+  async listSources(orgId: string, opts: { masked?: boolean } = {}): Promise<ChangeSource[]> {
+    const rows = await pgAll<ChangeSourceRow>(this.db, sql`
+      SELECT * FROM change_sources
+      WHERE org_id = ${orgId}
+      ORDER BY name
+    `);
+    return rows.map((row) => sourceFromRow(row, opts));
+  }
+
+  async findSourceById(id: string, opts: { masked?: boolean } = {}): Promise<ChangeSource | null> {
+    const rows = await pgAll<ChangeSourceRow>(this.db, sql`
+      SELECT * FROM change_sources
+      WHERE id = ${id}
+    `);
+    return rows[0] ? sourceFromRow(rows[0], opts) : null;
+  }
+
+  async findSourceByIdInOrg(orgId: string, id: string, opts: { masked?: boolean } = {}): Promise<ChangeSource | null> {
+    const rows = await pgAll<ChangeSourceRow>(this.db, sql`
+      SELECT * FROM change_sources
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    return rows[0] ? sourceFromRow(rows[0], opts) : null;
+  }
+
+  async createSource(input: NewChangeSource): Promise<ChangeSource> {
+    const id = input.id ?? `gh_${uid()}`;
+    const now = nowIso();
+    await pgRun(this.db, sql`
+      INSERT INTO change_sources (
+        id, org_id, type, name, owner, repo, events_json, encrypted_secret,
+        active, created_at, updated_at, last_event_at
+      ) VALUES (
+        ${id},
+        ${input.orgId},
+        ${input.type},
+        ${input.name},
+        ${input.owner ?? null},
+        ${input.repo ?? null},
+        ${JSON.stringify(input.events ?? [])},
+        ${encryptSecret(input.secret ?? null)},
+        ${input.active ?? true},
+        ${now},
+        ${now},
+        ${null}
+      )
+    `);
+    const saved = await this.findSourceByIdInOrg(input.orgId, id);
+    if (!saved) throw new Error(`[ChangeSourceRepository] create: row ${id} not found after insert`);
+    return saved;
+  }
+
+  async deleteSource(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.findSourceByIdInOrg(orgId, id);
+    if (!existing) return false;
+    await pgRun(this.db, sql`DELETE FROM change_sources WHERE org_id = ${orgId} AND id = ${id}`);
+    return true;
+  }
+
+  async addEvent(input: NewChangeEvent): Promise<ChangeEvent> {
+    const id = input.id ?? `chg_${uid()}`;
+    const now = nowIso();
+    await pgRun(this.db, sql`
+      INSERT INTO change_events (
+        id, org_id, source_id, service_id, type, timestamp, author, description,
+        diff, version, payload_json, created_at
+      ) VALUES (
+        ${id},
+        ${input.orgId},
+        ${input.sourceId},
+        ${input.serviceId},
+        ${input.type},
+        ${input.timestamp},
+        ${input.author},
+        ${input.description},
+        ${input.diff ?? null},
+        ${input.version ?? null},
+        ${input.payload ? JSON.stringify(input.payload) : null},
+        ${now}
+      )
+    `);
+    await pgRun(this.db, sql`
+      UPDATE change_sources
+      SET last_event_at = ${now}, updated_at = ${now}
+      WHERE org_id = ${input.orgId} AND id = ${input.sourceId}
+    `);
+    const rows = await pgAll<ChangeEventRow>(this.db, sql`
+      SELECT * FROM change_events WHERE id = ${id}
+    `);
+    if (!rows[0]) throw new Error(`[ChangeSourceRepository] addEvent: row ${id} not found after insert`);
+    return eventFromRow(rows[0]);
+  }
+
+  async listEvents(opts: ListChangeEventsOptions): Promise<ChangeEvent[]> {
+    const limit = opts.limit ?? 100;
+    const rows = await pgAll<ChangeEventRow>(this.db, sql`
+      SELECT * FROM change_events
+      WHERE org_id = ${opts.orgId}
+        AND timestamp >= ${opts.startTime}
+        AND timestamp <= ${opts.endTime}
+        AND (${opts.sourceId ?? null} IS NULL OR source_id = ${opts.sourceId ?? null})
+        AND (${opts.serviceId ?? null} IS NULL OR service_id = ${opts.serviceId ?? null})
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    `);
+    return rows.map(eventFromRow);
+  }
+}

--- a/packages/data-layer/src/repository/postgres/index.ts
+++ b/packages/data-layer/src/repository/postgres/index.ts
@@ -20,6 +20,7 @@ export { PostgresInstanceConfigRepository } from './instance-config.js';
 export { PostgresDatasourceRepository } from './datasource.js';
 export { PostgresNotificationChannelRepository } from './notification-channel.js';
 export { PostgresOpsConnectorRepository } from './ops-connector.js';
+export { PostgresChangeSourceRepository } from './change-source.js';
 export { applyPostgresSchema } from './schema-applier.js';
 
 export { PostgresRemediationPlanRepository } from './remediation-plan.js';

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -761,6 +761,54 @@ CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_id   ON ops_connectors(o
 CREATE INDEX        IF NOT EXISTS ix_ops_connectors_org_type ON ops_connectors(org_id, type);
 
 -- ============================================================================
+-- Change sources and events (GitHub deployments, releases, etc.)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS change_sources (
+  id               TEXT PRIMARY KEY,
+  org_id           TEXT NOT NULL,
+  type             TEXT NOT NULL CHECK (type = 'github'),
+  name             TEXT NOT NULL,
+  owner            TEXT NULL,
+  repo             TEXT NULL,
+  events_json      TEXT NOT NULL DEFAULT '[]',
+  encrypted_secret TEXT NULL,
+  active           BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at       TEXT NOT NULL,
+  updated_at       TEXT NOT NULL,
+  last_event_at    TEXT NULL,
+  FOREIGN KEY (org_id) REFERENCES org(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_change_sources_org_name ON change_sources(org_id, name);
+CREATE INDEX        IF NOT EXISTS ix_change_sources_org_id   ON change_sources(org_id);
+CREATE INDEX        IF NOT EXISTS ix_change_sources_org_type ON change_sources(org_id, type);
+
+CREATE TABLE IF NOT EXISTS change_events (
+  id           TEXT PRIMARY KEY,
+  org_id       TEXT NOT NULL,
+  source_id    TEXT NOT NULL,
+  service_id   TEXT NOT NULL,
+  type         TEXT NOT NULL,
+  timestamp    TEXT NOT NULL,
+  author       TEXT NOT NULL,
+  description  TEXT NOT NULL,
+  diff         TEXT NULL,
+  version      TEXT NULL,
+  payload_json TEXT NULL,
+  created_at   TEXT NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES org(id) ON DELETE CASCADE,
+  FOREIGN KEY (source_id) REFERENCES change_sources(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS ix_change_events_org_time
+  ON change_events(org_id, timestamp);
+CREATE INDEX IF NOT EXISTS ix_change_events_source_time
+  ON change_events(source_id, timestamp);
+CREATE INDEX IF NOT EXISTS ix_change_events_service_time
+  ON change_events(org_id, service_id, timestamp);
+
+-- ============================================================================
 -- Remediation plans (Phase 3 of docs/design/auto-remediation.md)
 -- ============================================================================
 

--- a/packages/data-layer/src/repository/sqlite/change-source.test.ts
+++ b/packages/data-layer/src/repository/sqlite/change-source.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { createTestDb } from '../../test-support/test-db.js';
+import { SqliteChangeSourceRepository } from './change-source.js';
+
+describe('SqliteChangeSourceRepository', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+  let db: SqliteClient;
+  let repo: SqliteChangeSourceRepository;
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-change-source-repository-xxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_a', 'Org A', 'now', 'now')`);
+    db.run(sql`INSERT INTO org (id, name, created, updated) VALUES ('org_b', 'Org B', 'now', 'now')`);
+    repo = new SqliteChangeSourceRepository(db);
+  });
+
+  it('creates and lists GitHub change sources by org with masked secrets', async () => {
+    await repo.createSource({
+      id: 'gh-a',
+      orgId: 'org_a',
+      type: 'github',
+      name: 'Prod deploys',
+      owner: 'openobs',
+      repo: 'openobs',
+      events: ['deployment'],
+      secret: 'super-secret',
+    });
+    await repo.createSource({
+      id: 'gh-b',
+      orgId: 'org_b',
+      type: 'github',
+      name: 'Other deploys',
+    });
+
+    const orgA = await repo.listSources('org_a', { masked: true });
+    expect(orgA).toHaveLength(1);
+    expect(orgA[0]).toMatchObject({
+      id: 'gh-a',
+      orgId: 'org_a',
+      owner: 'openobs',
+      repo: 'openobs',
+      events: ['deployment'],
+      secret: '••••••cret',
+    });
+    expect(await repo.findSourceByIdInOrg('org_b', 'gh-a')).toBeNull();
+  });
+
+  it('persists change events and filters by org source service and time', async () => {
+    await repo.createSource({
+      id: 'gh-a',
+      orgId: 'org_a',
+      type: 'github',
+      name: 'Prod deploys',
+    });
+    await repo.addEvent({
+      id: 'chg-a',
+      orgId: 'org_a',
+      sourceId: 'gh-a',
+      serviceId: 'openobs/openobs',
+      type: 'deploy',
+      timestamp: '2026-04-30T10:00:00.000Z',
+      author: 'octocat',
+      description: 'Deploy main',
+      version: 'abc123',
+      payload: { action: 'created' },
+    });
+
+    const events = await repo.listEvents({
+      orgId: 'org_a',
+      sourceId: 'gh-a',
+      serviceId: 'openobs/openobs',
+      startTime: '2026-04-30T09:00:00.000Z',
+      endTime: '2026-04-30T11:00:00.000Z',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: 'chg-a',
+      orgId: 'org_a',
+      sourceId: 'gh-a',
+      serviceId: 'openobs/openobs',
+      version: 'abc123',
+      payload: { action: 'created' },
+    });
+    expect((await repo.findSourceByIdInOrg('org_a', 'gh-a'))!.lastEventAt).toBeTruthy();
+    expect(await repo.listEvents({
+      orgId: 'org_b',
+      startTime: '2026-04-30T09:00:00.000Z',
+      endTime: '2026-04-30T11:00:00.000Z',
+    })).toEqual([]);
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/change-source.ts
+++ b/packages/data-layer/src/repository/sqlite/change-source.ts
@@ -1,0 +1,193 @@
+import { sql } from 'drizzle-orm';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { decryptSecret, encryptSecret, maskSecret, nowIso, uid } from './instance-shared.js';
+import type {
+  ChangeEvent,
+  ChangeSource,
+  IChangeSourceRepository,
+  ListChangeEventsOptions,
+  NewChangeEvent,
+  NewChangeSource,
+} from '../types/change-source.js';
+
+interface ChangeSourceRow {
+  id: string;
+  org_id: string;
+  type: string;
+  name: string;
+  owner: string | null;
+  repo: string | null;
+  events_json: string;
+  encrypted_secret: string | null;
+  active: number;
+  created_at: string;
+  updated_at: string;
+  last_event_at: string | null;
+}
+
+interface ChangeEventRow {
+  id: string;
+  org_id: string;
+  source_id: string;
+  service_id: string;
+  type: ChangeEvent['type'];
+  timestamp: string;
+  author: string;
+  description: string;
+  diff: string | null;
+  version: string | null;
+  payload_json: string | null;
+  created_at: string;
+}
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  return JSON.parse(raw) as T;
+}
+
+function sourceFromRow(row: ChangeSourceRow, opts: { masked?: boolean } = {}): ChangeSource {
+  const secret = decryptSecret(row.encrypted_secret);
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    type: 'github',
+    name: row.name,
+    owner: row.owner,
+    repo: row.repo,
+    events: parseJson<string[]>(row.events_json, []),
+    secret: opts.masked ? maskSecret(secret) : secret,
+    active: Boolean(row.active),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastEventAt: row.last_event_at,
+  };
+}
+
+function eventFromRow(row: ChangeEventRow): ChangeEvent {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    sourceId: row.source_id,
+    serviceId: row.service_id,
+    type: row.type,
+    timestamp: row.timestamp,
+    author: row.author,
+    description: row.description,
+    diff: row.diff ?? undefined,
+    version: row.version ?? undefined,
+    payload: parseJson<Record<string, unknown> | null>(row.payload_json, null),
+    createdAt: row.created_at,
+  };
+}
+
+export class SqliteChangeSourceRepository implements IChangeSourceRepository {
+  constructor(private readonly db: SqliteClient) {}
+
+  async listSources(orgId: string, opts: { masked?: boolean } = {}): Promise<ChangeSource[]> {
+    const rows = this.db.all<ChangeSourceRow>(sql`
+      SELECT * FROM change_sources
+      WHERE org_id = ${orgId}
+      ORDER BY name
+    `);
+    return rows.map((row) => sourceFromRow(row, opts));
+  }
+
+  async findSourceById(id: string, opts: { masked?: boolean } = {}): Promise<ChangeSource | null> {
+    const rows = this.db.all<ChangeSourceRow>(sql`
+      SELECT * FROM change_sources
+      WHERE id = ${id}
+    `);
+    return rows[0] ? sourceFromRow(rows[0], opts) : null;
+  }
+
+  async findSourceByIdInOrg(orgId: string, id: string, opts: { masked?: boolean } = {}): Promise<ChangeSource | null> {
+    const rows = this.db.all<ChangeSourceRow>(sql`
+      SELECT * FROM change_sources
+      WHERE org_id = ${orgId} AND id = ${id}
+    `);
+    return rows[0] ? sourceFromRow(rows[0], opts) : null;
+  }
+
+  async createSource(input: NewChangeSource): Promise<ChangeSource> {
+    const id = input.id ?? `gh_${uid()}`;
+    const now = nowIso();
+    this.db.run(sql`
+      INSERT INTO change_sources (
+        id, org_id, type, name, owner, repo, events_json, encrypted_secret,
+        active, created_at, updated_at, last_event_at
+      ) VALUES (
+        ${id},
+        ${input.orgId},
+        ${input.type},
+        ${input.name},
+        ${input.owner ?? null},
+        ${input.repo ?? null},
+        ${JSON.stringify(input.events ?? [])},
+        ${encryptSecret(input.secret ?? null)},
+        ${input.active ?? true ? 1 : 0},
+        ${now},
+        ${now},
+        ${null}
+      )
+    `);
+    const saved = await this.findSourceByIdInOrg(input.orgId, id);
+    if (!saved) throw new Error(`[ChangeSourceRepository] create: row ${id} not found after insert`);
+    return saved;
+  }
+
+  async deleteSource(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.findSourceByIdInOrg(orgId, id);
+    if (!existing) return false;
+    this.db.run(sql`DELETE FROM change_sources WHERE org_id = ${orgId} AND id = ${id}`);
+    return true;
+  }
+
+  async addEvent(input: NewChangeEvent): Promise<ChangeEvent> {
+    const id = input.id ?? `chg_${uid()}`;
+    const now = nowIso();
+    this.db.run(sql`
+      INSERT INTO change_events (
+        id, org_id, source_id, service_id, type, timestamp, author, description,
+        diff, version, payload_json, created_at
+      ) VALUES (
+        ${id},
+        ${input.orgId},
+        ${input.sourceId},
+        ${input.serviceId},
+        ${input.type},
+        ${input.timestamp},
+        ${input.author},
+        ${input.description},
+        ${input.diff ?? null},
+        ${input.version ?? null},
+        ${input.payload ? JSON.stringify(input.payload) : null},
+        ${now}
+      )
+    `);
+    this.db.run(sql`
+      UPDATE change_sources
+      SET last_event_at = ${now}, updated_at = ${now}
+      WHERE org_id = ${input.orgId} AND id = ${input.sourceId}
+    `);
+    const rows = this.db.all<ChangeEventRow>(sql`
+      SELECT * FROM change_events WHERE id = ${id}
+    `);
+    if (!rows[0]) throw new Error(`[ChangeSourceRepository] addEvent: row ${id} not found after insert`);
+    return eventFromRow(rows[0]);
+  }
+
+  async listEvents(opts: ListChangeEventsOptions): Promise<ChangeEvent[]> {
+    const limit = opts.limit ?? 100;
+    const rows = this.db.all<ChangeEventRow>(sql`
+      SELECT * FROM change_events
+      WHERE org_id = ${opts.orgId}
+        AND timestamp >= ${opts.startTime}
+        AND timestamp <= ${opts.endTime}
+        AND (${opts.sourceId ?? null} IS NULL OR source_id = ${opts.sourceId ?? null})
+        AND (${opts.serviceId ?? null} IS NULL OR service_id = ${opts.serviceId ?? null})
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    `);
+    return rows.map(eventFromRow);
+  }
+}

--- a/packages/data-layer/src/repository/sqlite/index.ts
+++ b/packages/data-layer/src/repository/sqlite/index.ts
@@ -22,5 +22,6 @@ export { InstanceConfigRepository } from './instance-config.js';
 export { DatasourceRepository } from './datasource.js';
 export { NotificationChannelRepository } from './notification-channel.js';
 export { OpsConnectorRepository } from './ops-connector.js';
+export { SqliteChangeSourceRepository } from './change-source.js';
 
 export { SqliteRemediationPlanRepository } from './remediation-plan.js';

--- a/packages/data-layer/src/repository/types/change-source.ts
+++ b/packages/data-layer/src/repository/types/change-source.ts
@@ -1,0 +1,74 @@
+import type { Change } from '@agentic-obs/common';
+
+export type ChangeSourceType = 'github';
+
+export interface ChangeSource {
+  id: string;
+  orgId: string;
+  type: ChangeSourceType;
+  name: string;
+  owner: string | null;
+  repo: string | null;
+  events: string[];
+  secret: string | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastEventAt: string | null;
+}
+
+export interface PublicChangeSource extends Omit<ChangeSource, 'secret'> {
+  secretMasked: string | null;
+}
+
+export interface NewChangeSource {
+  id?: string;
+  orgId: string;
+  type: ChangeSourceType;
+  name: string;
+  owner?: string | null;
+  repo?: string | null;
+  events?: string[];
+  secret?: string | null;
+  active?: boolean;
+}
+
+export interface ChangeEvent extends Change {
+  orgId: string;
+  sourceId: string;
+  payload: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface NewChangeEvent {
+  id?: string;
+  orgId: string;
+  sourceId: string;
+  serviceId: string;
+  type: Change['type'];
+  timestamp: string;
+  author: string;
+  description: string;
+  diff?: string | null;
+  version?: string | null;
+  payload?: Record<string, unknown> | null;
+}
+
+export interface ListChangeEventsOptions {
+  orgId: string;
+  sourceId?: string;
+  serviceId?: string;
+  startTime: string;
+  endTime: string;
+  limit?: number;
+}
+
+export interface IChangeSourceRepository {
+  listSources(orgId: string, opts?: { masked?: boolean }): Promise<ChangeSource[]>;
+  findSourceById(id: string, opts?: { masked?: boolean }): Promise<ChangeSource | null>;
+  findSourceByIdInOrg(orgId: string, id: string, opts?: { masked?: boolean }): Promise<ChangeSource | null>;
+  createSource(input: NewChangeSource): Promise<ChangeSource>;
+  deleteSource(orgId: string, id: string): Promise<boolean>;
+  addEvent(input: NewChangeEvent): Promise<ChangeEvent>;
+  listEvents(opts: ListChangeEventsOptions): Promise<ChangeEvent[]>;
+}

--- a/packages/web/src/api/github-change-sources-api.ts
+++ b/packages/web/src/api/github-change-sources-api.ts
@@ -1,0 +1,44 @@
+import { apiClient } from './rest-api.js';
+
+export interface GitHubChangeSource {
+  id: string;
+  orgId: string;
+  name: string;
+  owner?: string;
+  repo?: string;
+  events: string[];
+  active: boolean;
+  createdAt: string;
+  lastEventAt: string | null;
+  webhookPath: string;
+  secretMasked: string;
+  secret?: string;
+}
+
+export interface CreateGitHubChangeSourceInput {
+  name: string;
+  owner?: string;
+  repo?: string;
+  events: string[];
+  secret?: string;
+  active?: boolean;
+}
+
+export const githubChangeSourcesApi = {
+  async list(): Promise<GitHubChangeSource[]> {
+    const res = await apiClient.get<{ sources: GitHubChangeSource[] }>('/change-sources/github');
+    if (res.error) throw new Error(res.error.message ?? 'Failed to load GitHub sources');
+    return res.data.sources ?? [];
+  },
+
+  async create(input: CreateGitHubChangeSourceInput): Promise<GitHubChangeSource> {
+    const res = await apiClient.post<{ source: GitHubChangeSource }>('/change-sources/github', input);
+    if (res.error) throw new Error(res.error.message ?? 'Failed to create GitHub source');
+    return res.data.source;
+  },
+
+  async delete(id: string): Promise<void> {
+    const res = await apiClient.delete<{ ok: boolean }>(`/change-sources/github/${encodeURIComponent(id)}`);
+    if (res.error) throw new Error(res.error.message ?? 'Failed to delete GitHub source');
+  },
+};

--- a/packages/web/src/api/ops-api.test.ts
+++ b/packages/web/src/api/ops-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildOpsConnectorInput, parseNamespaceList } from './ops-api.js';
+import { buildOpsConnectorInput, inspectKubeconfigMetadata, parseNamespaceList } from './ops-api.js';
 
 const baseForm = {
   name: '',
@@ -26,6 +26,80 @@ describe('ops-api helpers', () => {
       'payments',
       'ops',
     ]);
+  });
+
+  it('detects current-context and maps it to the matching cluster server/name', () => {
+    const metadata = inspectKubeconfigMetadata(`
+apiVersion: v1
+kind: Config
+current-context: prod-admin
+clusters:
+- name: dev
+  cluster:
+    server: https://dev.example.com
+- name: prod
+  cluster:
+    server: https://prod.example.com:6443
+contexts:
+- name: dev-admin
+  context:
+    cluster: dev
+- name: prod-admin
+  context:
+    cluster: prod
+users: []
+`);
+
+    expect(metadata).toEqual({
+      apiServer: 'https://prod.example.com:6443',
+      clusterName: 'prod',
+      context: 'prod-admin',
+      serverIsLocalhost: false,
+      unreachableFromGateway: false,
+    });
+  });
+
+  it('falls back to the first context and its cluster when current-context is absent', () => {
+    const metadata = inspectKubeconfigMetadata(`
+clusters:
+- name: staging
+  cluster:
+    server: "https://staging.example.com"
+contexts:
+- name: staging-admin
+  context:
+    cluster: staging
+`);
+
+    expect(metadata).toMatchObject({
+      apiServer: 'https://staging.example.com',
+      clusterName: 'staging',
+      context: 'staging-admin',
+      serverIsLocalhost: false,
+      unreachableFromGateway: false,
+    });
+  });
+
+  it('detects localhost API servers as unreachable from the gateway', () => {
+    const metadata = inspectKubeconfigMetadata(`
+current-context: local
+clusters:
+- name: docker-desktop
+  cluster:
+    server: https://127.0.0.1:6443 # local tunnel
+contexts:
+- name: local
+  context:
+    cluster: docker-desktop
+`);
+
+    expect(metadata).toMatchObject({
+      apiServer: 'https://127.0.0.1:6443',
+      clusterName: 'docker-desktop',
+      context: 'local',
+      serverIsLocalhost: true,
+      unreachableFromGateway: true,
+    });
   });
 
   it('kubeconfig mode: forwards pasted YAML as `secret`', () => {

--- a/packages/web/src/api/ops-api.ts
+++ b/packages/web/src/api/ops-api.ts
@@ -57,6 +57,140 @@ export function parseNamespaceList(value: string): string[] {
     .filter(Boolean);
 }
 
+export interface KubeconfigMetadata {
+  apiServer?: string;
+  clusterName?: string;
+  context?: string;
+  serverIsLocalhost: boolean;
+  unreachableFromGateway: boolean;
+}
+
+interface ParsedKubeconfigCluster {
+  name?: string;
+  server?: string;
+}
+
+interface ParsedKubeconfigContext {
+  name?: string;
+  cluster?: string;
+}
+
+function stripYamlComment(value: string): string {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value[i];
+    if ((ch === '"' || ch === "'") && (i === 0 || value[i - 1] !== '\\')) {
+      quote = quote === ch ? null : quote ?? ch;
+      continue;
+    }
+    if (ch === '#' && quote === null && (i === 0 || /\s/.test(value[i - 1] ?? ''))) {
+      return value.slice(0, i).trim();
+    }
+  }
+  return value.trim();
+}
+
+function parseYamlScalar(value: string): string | undefined {
+  const trimmed = stripYamlComment(value).trim();
+  if (!trimmed) return undefined;
+  const quote = trimmed[0];
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function readYamlKey(line: string, key: string): string | undefined {
+  const match = line.match(new RegExp(`^\\s*${key}:\\s*(.*)$`));
+  return match ? parseYamlScalar(match[1] ?? '') : undefined;
+}
+
+export function isLocalhostApiServer(server: string | undefined): boolean {
+  if (!server) return false;
+  let host = server.trim();
+  try {
+    host = new URL(host).hostname;
+  } catch {
+    // Some pasted values are bare hosts. Match those directly.
+  }
+  host = host.toLowerCase().replace(/^\[|\]$/g, '');
+  return host === '127.0.0.1'
+    || host === 'localhost'
+    || host === '::1'
+    || host === 'host.docker.internal';
+}
+
+export function inspectKubeconfigMetadata(yaml: string): KubeconfigMetadata {
+  const clusters: ParsedKubeconfigCluster[] = [];
+  const contexts: ParsedKubeconfigContext[] = [];
+  let currentContext: string | undefined;
+  let section: 'clusters' | 'contexts' | undefined;
+  let activeCluster: ParsedKubeconfigCluster | undefined;
+  let activeContext: ParsedKubeconfigContext | undefined;
+
+  for (const rawLine of yaml.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trimStart().startsWith('#')) continue;
+
+    const topLevel = rawLine.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+    if (topLevel) {
+      activeCluster = undefined;
+      activeContext = undefined;
+      if (topLevel[1] === 'current-context') {
+        currentContext = parseYamlScalar(topLevel[2] ?? '');
+      }
+      section = topLevel[1] === 'clusters' || topLevel[1] === 'contexts'
+        ? topLevel[1]
+        : undefined;
+      continue;
+    }
+
+    const listItem = rawLine.match(/^\s*-\s*(.*)$/);
+    if (listItem) {
+      if (section === 'clusters') {
+        activeCluster = {};
+        activeContext = undefined;
+        clusters.push(activeCluster);
+        const name = readYamlKey(listItem[1] ?? '', 'name');
+        if (name) activeCluster.name = name;
+      } else if (section === 'contexts') {
+        activeContext = {};
+        activeCluster = undefined;
+        contexts.push(activeContext);
+        const name = readYamlKey(listItem[1] ?? '', 'name');
+        if (name) activeContext.name = name;
+      }
+      continue;
+    }
+
+    if (section === 'clusters' && activeCluster) {
+      const name = readYamlKey(rawLine, 'name');
+      if (name) activeCluster.name = name;
+      const server = readYamlKey(rawLine, 'server');
+      if (server) activeCluster.server = server;
+    } else if (section === 'contexts' && activeContext) {
+      const name = readYamlKey(rawLine, 'name');
+      if (name) activeContext.name = name;
+      const cluster = readYamlKey(rawLine, 'cluster');
+      if (cluster) activeContext.cluster = cluster;
+    }
+  }
+
+  const selectedContext = contexts.find((ctx) => ctx.name === currentContext) ?? contexts[0];
+  const selectedClusterName = selectedContext?.cluster ?? clusters[0]?.name;
+  const selectedCluster = clusters.find((cluster) => cluster.name === selectedClusterName) ?? clusters[0];
+  const apiServer = selectedCluster?.server;
+  const context = currentContext ?? selectedContext?.name;
+  const serverIsLocalhost = isLocalhostApiServer(apiServer);
+
+  return {
+    ...(apiServer ? { apiServer } : {}),
+    ...(selectedCluster?.name ? { clusterName: selectedCluster.name } : {}),
+    ...(context ? { context } : {}),
+    serverIsLocalhost,
+    unreachableFromGateway: serverIsLocalhost,
+  };
+}
+
 export interface OpsConnectorFormValue {
   mode: OpsConnectorMode;
   name: string;

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -1,6 +1,16 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { apiClient } from '../api/client.js';
-import { buildOpsConnectorInput, opsApi, type OpsCapability, type OpsConnector, type OpsConnectorMode } from '../api/ops-api.js';
+import {
+  buildOpsConnectorInput,
+  inspectKubeconfigMetadata,
+  isLocalhostApiServer,
+  opsApi,
+  type KubeconfigMetadata,
+  type OpsCapability,
+  type OpsConnector,
+  type OpsConnectorMode,
+} from '../api/ops-api.js';
+import { githubChangeSourcesApi, type GitHubChangeSource } from '../api/github-change-sources-api.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import { datasourceUrlPlaceholder, llmBaseUrlPlaceholder } from '../constants/placeholders.js';
 import { DATASOURCE_TYPES, datasourceInfo } from '../constants/datasource-types.js';
@@ -44,7 +54,7 @@ interface DsFormState {
 
 interface TestResult { ok: boolean; message: string; version?: string; }
 
-type SettingsTab = 'datasources' | 'ops' | 'llm' | 'notifications' | 'danger';
+type SettingsTab = 'datasources' | 'github' | 'ops' | 'llm' | 'notifications' | 'danger';
 
 // ─── Constants ───
 
@@ -64,7 +74,11 @@ const TABS: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
     icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><ellipse cx="12" cy="6" rx="8" ry="3" /><path d="M4 6v6c0 1.657 3.582 3 8 3s8-1.343 8-3V6" /><path d="M4 12v6c0 1.657 3.582 3 8 3s8-1.343 8-3v-6" /></svg>,
   },
   {
-    id: 'ops', label: 'Ops Integrations',
+    id: 'github', label: 'GitHub',
+    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h6m-6 4h10M5 4h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /></svg>,
+  },
+  {
+    id: 'ops', label: 'Kubernetes',
     icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M7 7v10a2 2 0 002 2h6a2 2 0 002-2V7M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2M9 12h6M9 15h4" /></svg>,
   },
   {
@@ -470,43 +484,220 @@ function EditFormWrapper({ initial, onSave, onCancel, onDelete, readOnly = false
   return <DatasourceForm value={form} onChange={setForm} onSave={() => void handleSave()} onCancel={onCancel} onDelete={onDelete} saving={saving} isNew={false} readOnly={readOnly} />;
 }
 
-// ─── Ops Integrations Tab ───
+// ─── GitHub Change Sources Tab ───
 
-/**
- * Returns true when the URL or kubeconfig server field points to a host that
- * is only reachable from the operator's local machine. The gateway runs in a
- * container or in-cluster, so 127.0.0.1 / localhost / ::1 / host.docker.internal
- * will never resolve to anything useful from there.
- */
-export function isLocalhostServer(server: string): boolean {
-  if (!server) return false;
-  let host = server.trim();
-  try {
-    host = new URL(host).hostname;
-  } catch {
-    // not a URL — fall through and match against the raw string
+const GITHUB_EVENTS = [
+  { id: 'deployment', label: 'Deployments' },
+  { id: 'deployment_status', label: 'Deployment status' },
+];
+
+function GitHubChangeSourcesTab({ canWrite }: { canWrite: boolean }) {
+  const [sources, setSources] = useState<GitHubChangeSource[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<GitHubChangeSource | null>(null);
+  const [form, setForm] = useState({
+    name: '',
+    owner: '',
+    repo: '',
+    secret: '',
+    events: { deployment: true, deployment_status: true } as Record<string, boolean>,
+  });
+
+  const loadSources = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      setSources(await githubChangeSourcesApi.list());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load GitHub sources');
+      setSources([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadSources(); }, [loadSources]);
+
+  const webhookUrl = (path: string) => `${window.location.origin}${path}`;
+
+  const handleCreate = async () => {
+    setSaving(true); setError(null); setCreated(null);
+    try {
+      const source = await githubChangeSourcesApi.create({
+        name: form.name.trim(),
+        owner: form.owner.trim() || undefined,
+        repo: form.repo.trim() || undefined,
+        secret: form.secret.trim() || undefined,
+        events: GITHUB_EVENTS.filter((event) => form.events[event.id]).map((event) => event.id),
+      });
+      setSources((prev) => [...prev, source]);
+      setCreated(source);
+      setShowForm(false);
+      setForm({
+        name: '',
+        owner: '',
+        repo: '',
+        secret: '',
+        events: { deployment: true, deployment_status: true },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create GitHub source');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setError(null);
+    try {
+      await githubChangeSourcesApi.delete(id);
+      setSources((prev) => prev.filter((source) => source.id !== id));
+      if (created?.id === id) setCreated(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete GitHub source');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <span className="inline-block w-6 h-6 border-2 border-[var(--color-outline-variant)] border-t-[var(--color-primary)] rounded-full animate-spin" />
+      </div>
+    );
   }
-  host = host.toLowerCase().replace(/^\[|\]$/g, '');
-  return host === '127.0.0.1'
-    || host === 'localhost'
-    || host === '::1'
-    || host === 'host.docker.internal';
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-[var(--color-on-surface-variant)]">
+            {sources.length > 0 ? `${sources.length} GitHub source${sources.length === 1 ? '' : 's'} connected` : 'No GitHub sources connected'}
+          </p>
+          <p className="text-xs text-[var(--color-outline)] mt-0.5">
+            Deployment webhooks become change events the agent can correlate during investigations.
+          </p>
+        </div>
+        {!showForm && canWrite && (
+          <button type="button" onClick={() => setShowForm(true)} className={btnPrimary}>
+            Connect GitHub
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-[#EF4444]/25 bg-[#EF4444]/10 px-3 py-2 text-sm text-[#EF4444]">
+          {error}
+        </div>
+      )}
+
+      {created && (
+        <div className="rounded-lg border border-[#22C55E]/20 bg-[#22C55E]/10 px-3 py-3">
+          <p className="text-sm font-medium text-[#22C55E]">GitHub source created</p>
+          <div className="mt-2 grid gap-2 text-xs">
+            <div>
+              <span className="text-[var(--color-outline)]">Webhook URL</span>
+              <div className="mt-1 font-mono text-[var(--color-on-surface)] break-all">{webhookUrl(created.webhookPath)}</div>
+            </div>
+            {created.secret && (
+              <div>
+                <span className="text-[var(--color-outline)]">Webhook secret</span>
+                <div className="mt-1 font-mono text-[var(--color-on-surface)] break-all">{created.secret}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {showForm && canWrite && (
+        <div className="space-y-4 p-4 bg-[var(--color-surface-highest)] rounded-xl border border-[var(--color-outline-variant)]">
+          <div>
+            <h3 className="text-sm font-semibold text-[var(--color-on-surface)]">Connect GitHub deployments</h3>
+            <p className="text-xs text-[var(--color-on-surface-variant)] mt-0.5">
+              Create a webhook endpoint, then paste the URL and secret into a GitHub repository webhook.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Field label="Name">
+              <input type="text" value={form.name} onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))} placeholder="Prod deploys" className={inputCls} />
+            </Field>
+            <Field label="Owner" hint="Optional">
+              <input type="text" value={form.owner} onChange={(e) => setForm((prev) => ({ ...prev, owner: e.target.value }))} placeholder="openobs" className={inputCls} />
+            </Field>
+            <Field label="Repository" hint="Optional">
+              <input type="text" value={form.repo} onChange={(e) => setForm((prev) => ({ ...prev, repo: e.target.value }))} placeholder="openobs" className={inputCls} />
+            </Field>
+            <Field label="Webhook secret" hint="Leave blank to generate one.">
+              <input type="password" value={form.secret} onChange={(e) => setForm((prev) => ({ ...prev, secret: e.target.value }))} placeholder="Generated if blank" className={inputCls} />
+            </Field>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[var(--color-on-surface)] mb-2">Events</label>
+            <div className="flex flex-wrap gap-3">
+              {GITHUB_EVENTS.map((event) => (
+                <label key={event.id} className="flex items-center gap-2 text-sm text-[var(--color-on-surface-variant)]">
+                  <input
+                    type="checkbox"
+                    checked={form.events[event.id]}
+                    onChange={(e) => setForm((prev) => ({ ...prev, events: { ...prev.events, [event.id]: e.target.checked } }))}
+                    className="w-3.5 h-3.5 rounded accent-[var(--color-primary)]"
+                  />
+                  {event.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--color-outline-variant)]/30">
+            <button type="button" onClick={() => setShowForm(false)} className="px-2.5 py-1.5 rounded-lg text-xs text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-high)] transition-colors">Cancel</button>
+            <button type="button" onClick={() => void handleCreate()} disabled={saving || !form.name.trim()} className={btnPrimary + ' !py-1.5 !px-3 !text-xs'}>
+              {saving ? 'Connecting...' : 'Create webhook'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {sources.map((source) => (
+        <div key={source.id} className="rounded-xl border border-[var(--color-outline-variant)] px-4 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-[var(--color-on-surface)]">{source.name}</span>
+                <span className="px-1.5 py-0.5 rounded bg-[var(--color-primary)]/10 text-[var(--color-primary)] text-[10px] font-medium">changes</span>
+                {source.lastEventAt && <span className="text-[10px] text-[var(--color-outline)]">last event {new Date(source.lastEventAt).toLocaleString()}</span>}
+              </div>
+              <p className="mt-1 text-xs text-[var(--color-outline)] font-mono break-all">{webhookUrl(source.webhookPath)}</p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {source.owner && <span className="px-1.5 py-0.5 rounded bg-[var(--color-surface-high)] text-[10px] text-[var(--color-on-surface-variant)]">{source.owner}{source.repo ? `/${source.repo}` : ''}</span>}
+                {source.events.map((event) => (
+                  <span key={event} className="px-1.5 py-0.5 rounded bg-[var(--color-surface-high)] text-[10px] text-[var(--color-on-surface-variant)]">{event}</span>
+                ))}
+                <span className="px-1.5 py-0.5 rounded bg-[var(--color-surface-high)] text-[10px] text-[var(--color-on-surface-variant)]">{source.secretMasked}</span>
+              </div>
+            </div>
+            {canWrite && (
+              <button type="button" onClick={() => void handleDelete(source.id)} className="px-3 py-1.5 rounded-lg text-xs text-[#EF4444] hover:bg-[#EF4444]/10 transition-colors">
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
-/**
- * Look for a `server: ...` line in a pasted kubeconfig and report whether it
- * is localhost. We don't fully parse YAML here — a substring match against
- * the canonical line is enough for the warning.
- */
-export function kubeconfigServerIsLocalhost(yaml: string): boolean {
-  const m = yaml.match(/server:\s*(\S+)/i);
-  return m ? isLocalhostServer(m[1]!) : false;
+// ─── Ops Integrations Tab ───
+
+function inspectPastedKubeconfig(yaml: string): KubeconfigMetadata | null {
+  if (!yaml.trim()) return null;
+  return inspectKubeconfigMetadata(yaml);
 }
 
 const OPS_CAPABILITIES: { id: OpsCapability; label: string }[] = [
-  { id: 'read', label: 'Read' },
-  { id: 'propose', label: 'Propose' },
-  { id: 'execute_approved', label: 'Execute approved' },
+  { id: 'read', label: 'Run diagnostics' },
+  { id: 'propose', label: 'Draft remediation plans' },
+  { id: 'execute_approved', label: 'Execute approved changes' },
 ];
 
 function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
@@ -557,6 +748,17 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
   useEffect(() => { void loadConnectors(); }, [loadConnectors]);
 
   const updateForm = (patch: Partial<typeof form>) => setForm((prev) => ({ ...prev, ...patch }));
+  const kubeconfigPreview = inspectPastedKubeconfig(form.kubeconfig);
+
+  const updateKubeconfig = (value: string) => {
+    const preview = inspectPastedKubeconfig(value);
+    updateForm({
+      kubeconfig: value,
+      ...(preview?.clusterName && !form.clusterName ? { clusterName: preview.clusterName } : {}),
+      ...(preview?.context && !form.context ? { context: preview.context } : {}),
+      ...(preview?.apiServer ? { apiServer: preview.apiServer } : {}),
+    });
+  };
 
   const handleCreate = async () => {
     setSaving(true); setError(null);
@@ -643,8 +845,20 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
       )}
 
       {showForm && canWrite && (
-        <div className="space-y-3 p-4 bg-[var(--color-surface-highest)] rounded-xl border border-[var(--color-outline-variant)]">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-5 p-4 bg-[var(--color-surface-highest)] rounded-xl border border-[var(--color-outline-variant)]">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--color-on-surface)]">Connect Kubernetes</h3>
+              <p className="text-xs text-[var(--color-on-surface-variant)] mt-0.5">
+                Choose how OpenObs should reach the cluster, then restrict what the agent may do.
+              </p>
+            </div>
+            <span className="px-2 py-1 rounded bg-[var(--color-primary)]/10 text-[var(--color-primary)] text-[10px] font-semibold shrink-0">
+              guided setup
+            </span>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1">
             <Field label="Name">
               <input type="text" value={form.name} onChange={(e) => updateForm({ name: e.target.value })} placeholder="Production Kubernetes" className={inputCls} />
             </Field>
@@ -654,59 +868,70 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-[var(--color-on-surface)] mb-2">Connection mode</label>
-            <div className="space-y-2">
+            <label className="block text-xs font-semibold text-[var(--color-on-surface)] mb-2">1. Connection method</label>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
               {inClusterAvailable && (
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                <label className={`rounded-lg border p-3 cursor-pointer transition-colors ${form.mode === 'in-cluster' ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/10' : 'border-[var(--color-outline-variant)] hover:border-[var(--color-outline)]'}`}>
                   <input
                     type="radio"
                     name="ops-mode"
                     checked={form.mode === 'in-cluster'}
                     onChange={() => updateForm({ mode: 'in-cluster' })}
-                    className="mt-1 accent-[var(--color-primary)]"
+                    className="sr-only"
                   />
-                  <span>
-                    <span className="font-medium text-[var(--color-on-surface)]">In-cluster</span>
-                    <span className="ml-2 px-1.5 py-0.5 rounded bg-[#22C55E]/10 text-[#22C55E] text-[10px] font-semibold">recommended</span>
-                    <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-0.5">Use the gateway pod's service-account token. No credentials to paste.</span>
-                  </span>
+                  <span className="block text-sm font-medium text-[var(--color-on-surface)]">In-cluster</span>
+                  <span className="inline-block mt-1 px-1.5 py-0.5 rounded bg-[#22C55E]/10 text-[#22C55E] text-[10px] font-semibold">recommended</span>
+                  <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-2">Use the gateway pod's service account. No credentials to paste.</span>
                 </label>
               )}
-              <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <label className={`rounded-lg border p-3 cursor-pointer transition-colors ${form.mode === 'kubeconfig' ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/10' : 'border-[var(--color-outline-variant)] hover:border-[var(--color-outline)]'}`}>
                 <input
                   type="radio"
                   name="ops-mode"
                   checked={form.mode === 'kubeconfig'}
                   onChange={() => updateForm({ mode: 'kubeconfig' })}
-                  className="mt-1 accent-[var(--color-primary)]"
+                  className="sr-only"
                 />
-                <span>
-                  <span className="font-medium text-[var(--color-on-surface)]">Kubeconfig</span>
-                  <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-0.5">Paste a kubeconfig YAML.</span>
-                </span>
+                <span className="block text-sm font-medium text-[var(--color-on-surface)]">Paste kubeconfig</span>
+                <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-2">Best when you already have a service-account kubeconfig.</span>
               </label>
-              <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <label className={`rounded-lg border p-3 cursor-pointer transition-colors ${form.mode === 'manual' ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/10' : 'border-[var(--color-outline-variant)] hover:border-[var(--color-outline)]'}`}>
                 <input
                   type="radio"
                   name="ops-mode"
                   checked={form.mode === 'manual'}
                   onChange={() => updateForm({ mode: 'manual' })}
-                  className="mt-1 accent-[var(--color-primary)]"
+                  className="sr-only"
                 />
-                <span>
-                  <span className="font-medium text-[var(--color-on-surface)]">Manual</span>
-                  <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-0.5">API server URL + bearer token. Backend builds the kubeconfig.</span>
-                </span>
+                <span className="block text-sm font-medium text-[var(--color-on-surface)]">API server + token</span>
+                <span className="block text-[11px] text-[var(--color-on-surface-variant)] mt-2">Advanced path for manually issued bearer tokens.</span>
               </label>
             </div>
           </div>
 
           {form.mode === 'kubeconfig' && (
-            <>
+            <div className="space-y-3">
+              <label className="block text-xs font-semibold text-[var(--color-on-surface)]">2. Import kubeconfig</label>
               <Field label="Kubeconfig">
-                <textarea value={form.kubeconfig} onChange={(e) => updateForm({ kubeconfig: e.target.value })} rows={6} placeholder="apiVersion: v1&#10;kind: Config&#10;clusters: ..." className={inputCls + ' resize-y font-mono text-xs'} />
+                <textarea value={form.kubeconfig} onChange={(e) => updateKubeconfig(e.target.value)} rows={7} placeholder="apiVersion: v1&#10;kind: Config&#10;clusters: ..." className={inputCls + ' resize-y font-mono text-xs'} />
               </Field>
-              {kubeconfigServerIsLocalhost(form.kubeconfig) && (
+              {kubeconfigPreview && (
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)]/50 p-3">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-[var(--color-outline)]">Cluster</div>
+                    <div className="text-xs text-[var(--color-on-surface)] truncate">{kubeconfigPreview.clusterName ?? 'Not detected'}</div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-[var(--color-outline)]">Context</div>
+                    <div className="text-xs text-[var(--color-on-surface)] truncate">{kubeconfigPreview.context ?? 'Not detected'}</div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-[var(--color-outline)]">API server</div>
+                    <div className="text-xs text-[var(--color-on-surface)] truncate">{kubeconfigPreview.apiServer ?? 'Not detected'}</div>
+                  </div>
+                </div>
+              )}
+              {kubeconfigPreview?.unreachableFromGateway && (
                 <p className="text-xs text-[#F59E0B] bg-[#F59E0B]/10 border border-[#F59E0B]/20 rounded px-3 py-2">
                   This address is only reachable from your machine. The openobs gateway runs in a container/cluster and cannot reach it. Use <code className="font-mono">kubectl config view --flatten --minify</code> from a reachable jump host, or use In-cluster mode.
                 </p>
@@ -714,15 +939,16 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
               <Field label="Context" hint="Optional. Leave blank to use the kubeconfig's current-context.">
                 <input type="text" value={form.context} onChange={(e) => updateForm({ context: e.target.value })} placeholder="prod-admin" className={inputCls} />
               </Field>
-            </>
+            </div>
           )}
 
           {form.mode === 'manual' && (
-            <>
+            <div className="space-y-3">
+              <label className="block text-xs font-semibold text-[var(--color-on-surface)]">2. Cluster credentials</label>
               <Field label="API Server URL">
                 <input type="url" value={form.apiServer} onChange={(e) => updateForm({ apiServer: e.target.value })} placeholder="https://kubernetes.example.com:6443" className={inputCls} />
               </Field>
-              {isLocalhostServer(form.apiServer) && (
+              {isLocalhostApiServer(form.apiServer) && (
                 <p className="text-xs text-[#F59E0B] bg-[#F59E0B]/10 border border-[#F59E0B]/20 rounded px-3 py-2">
                   This address is only reachable from your machine. The openobs gateway runs in a container/cluster and cannot reach it. Use <code className="font-mono">kubectl config view --flatten --minify</code> from a reachable jump host, or use In-cluster mode.
                 </p>
@@ -737,34 +963,51 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
                 <input type="checkbox" checked={form.insecureSkipTlsVerify} onChange={(e) => updateForm({ insecureSkipTlsVerify: e.target.checked })} className="w-3.5 h-3.5 rounded accent-[var(--color-primary)]" />
                 Skip TLS verify (insecure — only for dev/lab clusters)
               </label>
-            </>
+            </div>
           )}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Field label="Cluster name" hint="Optional label.">
-              <input type="text" value={form.clusterName} onChange={(e) => updateForm({ clusterName: e.target.value })} placeholder="prod-east" className={inputCls} />
-            </Field>
-            <Field label="Namespaces" hint="Comma or newline separated. Leave blank for any.">
-              <input type="text" value={form.namespaces} onChange={(e) => updateForm({ namespaces: e.target.value })} placeholder="default, api, payments" className={inputCls} />
-            </Field>
-          </div>
+          {form.mode === 'in-cluster' && (
+            <div className="rounded-lg border border-[#22C55E]/20 bg-[#22C55E]/10 px-3 py-2">
+              <p className="text-xs text-[#22C55E] font-medium">Service account detected</p>
+              <p className="text-xs text-[var(--color-on-surface-variant)] mt-0.5">
+                OpenObs will build a kubeconfig from the gateway pod's mounted token and certificate.
+              </p>
+            </div>
+          )}
 
-          <div>
-            <label className="block text-xs font-medium text-[var(--color-on-surface)] mb-2">Capabilities</label>
-            <div className="flex flex-wrap gap-3">
-              {OPS_CAPABILITIES.map((capability) => (
-                <label key={capability.id} className="flex items-center gap-2 text-sm text-[var(--color-on-surface-variant)]">
-                  <input
-                    type="checkbox"
-                    checked={form.capabilities[capability.id]}
-                    onChange={(e) => updateForm({ capabilities: { ...form.capabilities, [capability.id]: e.target.checked } })}
-                    className="w-3.5 h-3.5 rounded accent-[var(--color-primary)]"
-                  />
-                  {capability.label}
-                </label>
-              ))}
+          <div className="space-y-3">
+            <label className="block text-xs font-semibold text-[var(--color-on-surface)]">3. Access boundary</label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Field label="Cluster name" hint="Shown to the agent and operators.">
+                <input type="text" value={form.clusterName} onChange={(e) => updateForm({ clusterName: e.target.value })} placeholder="prod-east" className={inputCls} />
+              </Field>
+              <Field label="Namespaces" hint="Comma or newline separated. Blank allows cluster-scoped reads; writes still require an explicit namespace.">
+                <input type="text" value={form.namespaces} onChange={(e) => updateForm({ namespaces: e.target.value })} placeholder="default, api, payments" className={inputCls} />
+              </Field>
+            </div>
+            <div className="rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)]/40 p-3">
+              <label className="block text-xs font-medium text-[var(--color-on-surface)] mb-2">Agent permissions</label>
+              <div className="space-y-2">
+                {OPS_CAPABILITIES.map((capability) => (
+                  <label key={capability.id} className="flex items-start gap-2 text-sm text-[var(--color-on-surface-variant)]">
+                    <input
+                      type="checkbox"
+                      checked={form.capabilities[capability.id]}
+                      onChange={(e) => updateForm({ capabilities: { ...form.capabilities, [capability.id]: e.target.checked } })}
+                      className="mt-0.5 w-3.5 h-3.5 rounded accent-[var(--color-primary)]"
+                    />
+                    <span>
+                      <span className="text-[var(--color-on-surface)]">{capability.label}</span>
+                      {capability.id === 'execute_approved' && (
+                        <span className="block text-[11px] text-[var(--color-outline)]">Requires the existing approval workflow before any write command runs.</span>
+                      )}
+                    </span>
+                  </label>
+                ))}
+              </div>
             </div>
           </div>
+
           <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--color-outline-variant)]/30">
             <button type="button" onClick={() => setShowForm(false)} className="px-2.5 py-1.5 rounded-lg text-xs text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-high)] transition-colors">Cancel</button>
             <button
@@ -778,7 +1021,7 @@ function OpsIntegrationsTab({ canWrite }: { canWrite: boolean }) {
               }
               className={btnPrimary + ' !py-1.5 !px-3 !text-xs'}
             >
-              {saving ? 'Connecting...' : 'Save connector'}
+              {saving ? 'Connecting...' : 'Connect cluster'}
             </button>
           </div>
         </div>
@@ -1132,6 +1375,11 @@ export default function Settings() {
   const canCreateDs = !!user && (user.isServerAdmin || hasPermission('datasources:create'));
   const canWriteDs = !!user && (user.isServerAdmin || hasPermission('datasources:write'));
   const canDeleteDs = !!user && (user.isServerAdmin || hasPermission('datasources:delete'));
+  const canWriteChangeSources = !!user && (
+    user.isServerAdmin ||
+    hasPermission('datasources:write') ||
+    hasPermission('instance.config:write')
+  );
   // LLM / Notifications / Danger reset: gated by the canonical
   // `instance.config:write` action (granted to Admin+ via
   // ADMIN_ONLY_PERMISSIONS in roles-def.ts). Matches the backend enforcement
@@ -1175,7 +1423,8 @@ export default function Settings() {
           </h2>
           <p className="text-sm text-[var(--color-on-surface-variant)] mb-6">
             {tab === 'datasources' && 'Connect to Prometheus, Loki, Elasticsearch and other data sources.'}
-            {tab === 'ops' && 'Connect Kubernetes and operational command integrations.'}
+            {tab === 'github' && 'Ingest deployments from GitHub as change events for investigations.'}
+            {tab === 'ops' && 'Connect Kubernetes clusters for diagnostics and approved remediation.'}
             {tab === 'llm' && 'Configure the AI model used for investigations and analysis.'}
             {tab === 'notifications' && 'Set up alert delivery channels.'}
             {tab === 'danger' && 'Irreversible actions for your OpenObs instance.'}
@@ -1184,6 +1433,7 @@ export default function Settings() {
           {tab === 'datasources' && (
             <DataSourcesTab canCreate={canCreateDs} canWrite={canWriteDs} canDelete={canDeleteDs} />
           )}
+          {tab === 'github' && <GitHubChangeSourcesTab canWrite={canWriteChangeSources} />}
           {tab === 'ops' && <OpsIntegrationsTab canWrite={canOpsWrite} />}
           {tab === 'llm' && <LlmTab canWrite={canAdminWrite} />}
           {tab === 'notifications' && <NotificationsTab canWrite={canAdminWrite} />}


### PR DESCRIPTION
## Summary
Codex-authored WIP picked up onto latest main (the previous \`codex/fix-audit-findings\` branch was 4 commits behind after #126/#127/#128/#129 landed). Bundled into a single follow-up branch for review.

Two features:

1. **GitHub change sources** — a new connector/source kind that ingests deploys & releases from GitHub.
   - Backend: \`api-gateway/src/routes/github-change-sources.ts\` + \`services/github-change-source-service.ts\` + tests.
   - Persistence: \`data-layer/src/repository/sqlite/change-source.ts\` + postgres counterpart + type contract + schema rows.
   - Web: \`web/src/api/github-change-sources-api.ts\`.
   - Wires into the existing \`changes_list_recent\` adapter so investigations see GitHub deploys alongside other change-event sources.

2. **Ops connector / settings UI** — Settings.tsx +424/-95 and ops-api.ts +134 reshape for the three-mode connector pattern landed in #120, plus the GitHub source form.

Plus:
- Design doc \`docs/design/personal-chat-sessions.md\`
- Self-contained \`demo/openobs-demo.yaml\` manifest

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1573/1593 (1 pre-existing flake in alert-rules-investigate.test.ts being chased on a separate branch)
- [ ] Manual: configure a GitHub change source, deploy in that repo, observe \`changes_list_recent\` in chat surfaces the deploy
- [ ] Manual: walk through Settings ops connector with each of the three modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)