### PR TITLE
Implement personal chat sessions

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -214,6 +214,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     chatSessionStore: repos.chatSessions,
     chatMessageStore: repos.chatMessages,
     chatEventStore: repos.chatSessionEvents,
+    chatSessionContextStore: repos.chatSessionContexts,
     opsConnectorStore: repos.opsConnectors,
     approvalStore: repos.approvals,
     remediationPlanStore: repos.remediationPlans,

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -422,7 +422,7 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         const workspaceId = rule.workspaceId ?? resolveOrgId(req);
         const investigation = await deps.investigationStore.create({
           question,
-          sessionId: `ses_alert_${Date.now()}`,
+          sessionId: `inv_alert_${Date.now()}`,
           userId: 'alert-system',
           workspaceId,
         });

--- a/packages/api-gateway/src/routes/chat.ts
+++ b/packages/api-gateway/src/routes/chat.ts
@@ -1,5 +1,10 @@
 import { Router } from 'express';
-import type { Router as ExpressRouter, Request, Response, NextFunction } from 'express';
+import type {
+  Router as ExpressRouter,
+  Request,
+  Response,
+  NextFunction,
+} from 'express';
 import { createLogger } from '@agentic-obs/common/logging';
 import type { DashboardSseEvent } from '@agentic-obs/common';
 import { ac, ACTIONS } from '@agentic-obs/common';
@@ -7,7 +12,14 @@ import { authMiddleware } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import { ChatService } from '../services/chat-service.js';
-import type { ChatServiceDeps } from '../services/chat-service.js';
+import {
+  findOwnedChatSession,
+  listOwnedChatSessions,
+} from '../services/chat-service.js';
+import type {
+  ChatServiceDeps,
+  ChatSessionOwnerScope,
+} from '../services/chat-service.js';
 
 const log = createLogger('chat-router');
 
@@ -15,17 +27,17 @@ function sendSseEvent(res: Response, event: DashboardSseEvent): void {
   res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
 }
 
-function orgIdFromReq(req: Request): string | undefined {
-  return (req as AuthenticatedRequest).auth?.orgId;
-}
-
 async function ensureSessionInOrg(
   deps: ChatServiceDeps,
   sessionId: string,
-  orgId: string | undefined,
+  scope: ChatSessionOwnerScope | undefined,
 ): Promise<boolean> {
-  if (!orgId || !deps.chatSessionStore) return false;
-  const session = await deps.chatSessionStore.findById(sessionId, { orgId });
+  if (!scope || !deps.chatSessionStore) return false;
+  const session = await findOwnedChatSession(
+    deps.chatSessionStore,
+    sessionId,
+    scope,
+  );
   return Boolean(session);
 }
 
@@ -44,7 +56,9 @@ async function handleChatStream(
   // req.auth is guaranteed by authMiddleware above — if it's missing, the
   // middleware already short-circuited with 401 and we would not be here.
   if (!req.auth) {
-    res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+    res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'authentication required' },
+    });
     return;
   }
 
@@ -75,7 +89,9 @@ async function handleChatStream(
     const result = await service.handleMessage(
       message,
       sessionId,
-      (event) => { if (!closed) sendSseEvent(res, event); },
+      (event) => {
+        if (!closed) sendSseEvent(res, event);
+      },
       req.auth,
       pageContext,
       abortController.signal,
@@ -106,7 +122,9 @@ async function handleChatStream(
       log.error({ err }, 'chat handler error');
       const errMsg = err instanceof Error ? err.message : 'Internal error';
       if (!closed) {
-        res.write(`event: error\ndata: ${JSON.stringify({ type: 'error', message: errMsg })}\n\n`);
+        res.write(
+          `event: error\ndata: ${JSON.stringify({ type: 'error', message: errMsg })}\n\n`,
+        );
       }
     }
   } finally {
@@ -122,99 +140,130 @@ export function createChatRouter(deps: ChatServiceDeps): ExpressRouter {
   router.use(authMiddleware);
 
   // POST /chat — unified session-based chat endpoint (SSE streaming)
-  router.post('/', requirePermission(() => ac.eval(ACTIONS.ChatUse)), async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    try {
-      const body = req.body as { message?: string; sessionId?: string; pageContext?: { kind: string; id?: string; timeRange?: string } };
-      if (typeof body.message !== 'string' || body.message.trim() === '') {
-        res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'message is required and must be a non-empty string' } });
-        return;
-      }
+  router.post(
+    '/',
+    requirePermission(() => ac.eval(ACTIONS.ChatUse)),
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+      try {
+        const body = req.body as {
+          message?: string;
+          sessionId?: string;
+          pageContext?: { kind: string; id?: string; timeRange?: string };
+        };
+        if (typeof body.message !== 'string' || body.message.trim() === '') {
+          res.status(400).json({
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'message is required and must be a non-empty string',
+            },
+          });
+          return;
+        }
 
-      const message = body.message.trim();
-      const sessionId = typeof body.sessionId === 'string' && body.sessionId.trim()
-        ? body.sessionId.trim()
-        : undefined;
-      const pageContext = body.pageContext ?? undefined;
-      if (sessionId && !await ensureSessionInOrg(deps, sessionId, orgIdFromReq(req))) {
-        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Chat session not found' } });
-        return;
-      }
+        const message = body.message.trim();
+        const sessionId =
+          typeof body.sessionId === 'string' && body.sessionId.trim()
+            ? body.sessionId.trim()
+            : undefined;
+        const pageContext = body.pageContext ?? undefined;
+        const ownerScope = req.auth
+          ? { orgId: req.auth.orgId, ownerUserId: req.auth.userId }
+          : undefined;
+        if (
+          sessionId &&
+          !(await ensureSessionInOrg(deps, sessionId, ownerScope))
+        ) {
+          res.status(404).json({
+            error: { code: 'NOT_FOUND', message: 'Chat session not found' },
+          });
+          return;
+        }
 
-      await handleChatStream(req, res, message, sessionId, pageContext, deps);
-    } catch (err) {
-      next(err);
-    }
-  });
+        await handleChatStream(req, res, message, sessionId, pageContext, deps);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
 
   // GET /chat/sessions — list recent chat sessions
-  router.get('/sessions', requirePermission(() => ac.eval(ACTIONS.ChatUse)), async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      if (!deps.chatSessionStore) {
-        res.json({ sessions: [] });
-        return;
+  router.get(
+    '/sessions',
+    requirePermission(() => ac.eval(ACTIONS.ChatUse)),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        if (!deps.chatSessionStore) {
+          res.json({ sessions: [] });
+          return;
+        }
+        const auth = (req as AuthenticatedRequest).auth;
+        if (!auth) {
+          res.status(401).json({
+            error: {
+              code: 'UNAUTHORIZED',
+              message: 'authentication required',
+            },
+          });
+          return;
+        }
+        const limit = Math.min(Number(req.query['limit']) || 50, 200);
+        const scope = { orgId: auth.orgId, ownerUserId: auth.userId };
+        const sessions = await listOwnedChatSessions(
+          deps.chatSessionStore,
+          limit,
+          scope,
+        );
+        res.json({ sessions });
+      } catch (err) {
+        next(err);
       }
-      const orgId = orgIdFromReq(req);
-      if (!orgId) {
-        res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
-        return;
-      }
-      const limit = Math.min(Number(req.query['limit']) || 50, 200);
-      const sessions = await deps.chatSessionStore.findAll(limit, { orgId });
-      res.json({ sessions });
-    } catch (err) {
-      next(err);
-    }
-  });
+    },
+  );
 
   // GET /chat/sessions/:id/messages — get messages + persisted step events for
   // a session. The `events` array lets the web client rebuild the full chat
   // panel (agent activity blocks, tool calls, panel-added notices, etc.)
   // exactly as it looked during the live run.
-  router.get('/sessions/:id/messages', requirePermission(() => ac.eval(ACTIONS.ChatUse)), async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const sessionId = req.params['id'] ?? '';
-      if (!sessionId) {
-        res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'session id is required' } });
-        return;
-      }
-      const orgId = orgIdFromReq(req);
-      if (!await ensureSessionInOrg(deps, sessionId, orgId)) {
-        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Chat session not found' } });
-        return;
-      }
+  router.get(
+    '/sessions/:id/messages',
+    requirePermission(() => ac.eval(ACTIONS.ChatUse)),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const sessionId = req.params['id'] ?? '';
+        if (!sessionId) {
+          res.status(400).json({
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'session id is required',
+            },
+          });
+          return;
+        }
+        const auth = (req as AuthenticatedRequest).auth;
+        const ownerScope = auth
+          ? { orgId: auth.orgId, ownerUserId: auth.userId }
+          : undefined;
+        if (!(await ensureSessionInOrg(deps, sessionId, ownerScope))) {
+          res.status(404).json({
+            error: { code: 'NOT_FOUND', message: 'Chat session not found' },
+          });
+          return;
+        }
 
-      const [messages, events] = await Promise.all([
-        deps.chatMessageStore ? deps.chatMessageStore.getMessages(sessionId) : Promise.resolve([]),
-        deps.chatEventStore ? deps.chatEventStore.listBySession(sessionId) : Promise.resolve([]),
-      ]);
-      res.json({ sessionId, messages, events });
-    } catch (err) {
-      next(err);
-    }
-  });
-
-  // GET /chat/:sessionId — retrieve conversation history for a session (legacy)
-  router.get('/:sessionId', requirePermission(() => ac.eval(ACTIONS.ChatUse)), async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const sessionId = req.params['sessionId'] ?? '';
-      if (!sessionId) {
-        res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'sessionId is required' } });
-        return;
+        const [messages, events] = await Promise.all([
+          deps.chatMessageStore
+            ? deps.chatMessageStore.getMessages(sessionId)
+            : Promise.resolve([]),
+          deps.chatEventStore
+            ? deps.chatEventStore.listBySession(sessionId)
+            : Promise.resolve([]),
+        ]);
+        res.json({ sessionId, messages, events });
+      } catch (err) {
+        next(err);
       }
-      const orgId = orgIdFromReq(req);
-      if (!await ensureSessionInOrg(deps, sessionId, orgId)) {
-        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Chat session not found' } });
-        return;
-      }
-
-      const messages = deps.chatMessageStore
-        ? await deps.chatMessageStore.getMessages(sessionId)
-        : [];
-      res.json({ sessionId, messages });
-    } catch (err) {
-      next(err);
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -181,9 +181,6 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         dashboardNotFound(res)
         return
       }
-      // Chat history lives in chat_messages keyed by sessionId and is
-      // intentionally not cascaded — sessions can outlive any single
-      // dashboard (the chat that created it is still useful context).
       res.status(204).send()
     }
     catch (err) {

--- a/packages/api-gateway/src/routes/investigation/openapi.ts
+++ b/packages/api-gateway/src/routes/investigation/openapi.ts
@@ -178,7 +178,6 @@ export const investigationOpenApiSpec = {
         required: ['question'],
         properties: {
           question: { type: 'string', description: 'Natural-language question' },
-          sessionId: { type: 'string' },
           entity: { type: 'string', description: 'Entity hint (e.g. service name)' },
           timeRange: {
             type: 'object',
@@ -198,7 +197,6 @@ export const investigationOpenApiSpec = {
             enum: ['planning', 'investigating', 'evidencing', 'explaining', 'active', 'verifying', 'completed', 'failed'],
           },
           intent: { type: 'string' },
-          sessionId: { type: 'string' },
           userId: { type: 'string' },
           createdAt: { type: 'string', format: 'date-time' },
           updatedAt: { type: 'string', format: 'date-time' },

--- a/packages/api-gateway/src/routes/investigation/router.ts
+++ b/packages/api-gateway/src/routes/investigation/router.ts
@@ -72,7 +72,7 @@ export function createInvestigationRouter(
         const workspaceId = resolveOrgId(req);
         const investigation = await store.create({
           question: body.question.trim(),
-          sessionId: body.sessionId ?? `ses_${Date.now()}`,
+          sessionId: `inv_${Date.now()}`,
           userId: authReq.auth?.userId ?? 'anonymous',
           entity: body.entity,
           timeRange: body.timeRange,

--- a/packages/api-gateway/src/routes/investigation/types.ts
+++ b/packages/api-gateway/src/routes/investigation/types.ts
@@ -7,8 +7,6 @@ import type { Investigation, InvestigationStatus } from '@agentic-obs/common';
 export interface CreateInvestigationBody {
   /** Natural-language question from the user */
   question: string;
-  /** Session to attach the investigation to */
-  sessionId?: string;
   /** Optional entity hint (e.g. "checkout-service") */
   entity?: string;
   /** Optional time range hint (ISO-8601 strings) */
@@ -46,7 +44,6 @@ export interface InvestigationSummary {
   id: string;
   status: InvestigationStatus;
   intent: string;
-  sessionId: string;
   userId: string;
   createdAt: string;
   updatedAt: string;

--- a/packages/api-gateway/src/services/chat-service.test.ts
+++ b/packages/api-gateway/src/services/chat-service.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatSession } from '@agentic-obs/common';
+import type { IChatSessionRepository } from '@agentic-obs/data-layer';
+import { findOwnedChatSession, listOwnedChatSessions } from './chat-service.js';
+
+type OwnedSession = ChatSession & { ownerUserId?: string | null };
+
+function session(
+  id: string,
+  ownerUserId: string,
+  orgId = 'org_a',
+): OwnedSession {
+  return {
+    id,
+    ownerUserId,
+    orgId,
+    title: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeStore(sessions: OwnedSession[]): IChatSessionRepository {
+  return {
+    create: async (input) => session(input.id, '', input.orgId),
+    findById: async (id, scope) =>
+      sessions.find((s) => s.id === id && s.orgId === scope?.orgId),
+    findAll: async (_limit, scope) =>
+      sessions.filter((s) => s.orgId === scope?.orgId),
+    updateTitle: async () => undefined,
+    updateContextSummary: async () => undefined,
+    delete: async () => false,
+  };
+}
+
+describe('chat session ownership helpers', () => {
+  it('requires the persisted owner to match for direct session lookup', async () => {
+    const store = makeStore([session('s_owner', 'u_owner')]);
+
+    await expect(
+      findOwnedChatSession(store, 's_owner', {
+        orgId: 'org_a',
+        ownerUserId: 'u_owner',
+      }),
+    ).resolves.toMatchObject({ id: 's_owner' });
+
+    await expect(
+      findOwnedChatSession(store, 's_owner', {
+        orgId: 'org_a',
+        ownerUserId: 'u_other',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('filters session lists to the authenticated owner', async () => {
+    const store = makeStore([
+      session('s_owner', 'u_owner'),
+      session('s_other', 'u_other'),
+      session('s_other_org', 'u_owner', 'org_b'),
+    ]);
+
+    await expect(
+      listOwnedChatSessions(store, 50, {
+        orgId: 'org_a',
+        ownerUserId: 'u_owner',
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 's_owner' })]);
+  });
+});

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -1,10 +1,28 @@
 import { randomUUID } from 'crypto';
 import { createLogger } from '@agentic-obs/common/logging';
-import type { DashboardMessage, DashboardSseEvent, Identity } from '@agentic-obs/common';
+import type {
+  ChatSession,
+  ChatSessionContextRelation,
+  ChatSessionContextResourceType,
+  DashboardMessage,
+  DashboardSseEvent,
+  Identity,
+} from '@agentic-obs/common';
 import { createLlmGateway } from '../routes/llm-factory.js';
-import { DashboardOrchestratorAgent as OrchestratorAgent, shouldCompact, compactMessages } from '@agentic-obs/agent-core';
-import type { IConversationStore as IAgentConversationStore, IDashboardAlertRuleStore as IAlertRuleStore, IDashboardInvestigationStore as IInvestigationStore } from '@agentic-obs/agent-core';
-import { buildAdapterRegistry, toAgentDatasources } from './dashboard-service.js';
+import {
+  DashboardOrchestratorAgent as OrchestratorAgent,
+  shouldCompact,
+  compactMessages,
+} from '@agentic-obs/agent-core';
+import type {
+  IConversationStore as IAgentConversationStore,
+  IDashboardAlertRuleStore as IAlertRuleStore,
+  IDashboardInvestigationStore as IInvestigationStore,
+} from '@agentic-obs/agent-core';
+import {
+  buildAdapterRegistry,
+  toAgentDatasources,
+} from './dashboard-service.js';
 import { OpsCommandRunnerService } from './ops-command-runner-service.js';
 import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
 
@@ -15,10 +33,122 @@ import type { AccessControlSurface } from './accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
 import type { IGatewayDashboardStore } from '../repositories/types.js';
-import type { IInvestigationReportRepository, IAlertRuleRepository, IGatewayInvestigationStore, IChatSessionRepository, IChatMessageRepository, IChatSessionEventRepository, IOpsConnectorRepository, IApprovalRequestRepository } from '@agentic-obs/data-layer';
+import type {
+  IInvestigationReportRepository,
+  IAlertRuleRepository,
+  IGatewayInvestigationStore,
+  IChatSessionRepository,
+  IChatSessionContextRepository,
+  IChatMessageRepository,
+  IChatSessionEventRepository,
+  IOpsConnectorRepository,
+  IApprovalRequestRepository,
+} from '@agentic-obs/data-layer';
 import type { GitHubChangeSourceRegistry } from './github-change-source-service.js';
 
 const log = createLogger('chat-service');
+
+export interface ChatSessionOwnerScope {
+  orgId: string;
+  ownerUserId: string;
+}
+
+type OwnedChatSession = ChatSession & { ownerUserId?: string | null };
+type ChatSessionScopeInput = Parameters<
+  IChatSessionRepository['findById']
+>[1] & {
+  ownerUserId?: string;
+};
+
+export interface ChatSessionContextInput {
+  id: string;
+  sessionId: string;
+  orgId: string;
+  ownerUserId: string;
+  resourceType: ChatSessionContextResourceType;
+  resourceId: string;
+  relation: ChatSessionContextRelation;
+  createdAt: string;
+}
+
+function hasPersistedOwner(
+  session: ChatSession,
+): session is OwnedChatSession & { ownerUserId: string } {
+  return (
+    typeof (session as OwnedChatSession).ownerUserId === 'string' &&
+    (session as OwnedChatSession).ownerUserId !== ''
+  );
+}
+
+function ownerScope(identity: Identity): ChatSessionOwnerScope {
+  return { orgId: identity.orgId, ownerUserId: identity.userId };
+}
+
+function sessionScope(scope: ChatSessionOwnerScope): ChatSessionScopeInput {
+  return { orgId: scope.orgId, ownerUserId: scope.ownerUserId };
+}
+
+export async function findOwnedChatSession(
+  store: IChatSessionRepository,
+  sessionId: string,
+  scope: ChatSessionOwnerScope,
+): Promise<ChatSession | undefined> {
+  const session = await store.findById(sessionId, sessionScope(scope));
+  if (!session) return undefined;
+  if (hasPersistedOwner(session)) {
+    return session.ownerUserId === scope.ownerUserId ? session : undefined;
+  }
+  return undefined;
+}
+
+export async function listOwnedChatSessions(
+  store: IChatSessionRepository,
+  limit: number,
+  scope: ChatSessionOwnerScope,
+): Promise<ChatSession[]> {
+  const sessions = await store.findAll(limit, sessionScope(scope));
+  return sessions.filter((session) => {
+    if (hasPersistedOwner(session))
+      return session.ownerUserId === scope.ownerUserId;
+    return false;
+  });
+}
+
+function parseResourcePath(
+  path: string,
+):
+  | { resourceType: ChatSessionContextResourceType; resourceId: string }
+  | undefined {
+  const pathname = path.split('?')[0] ?? '';
+  const match = pathname.match(
+    /^\/(dashboards|investigations|alerts|alert-rules)\/([^/?#]+)/,
+  );
+  if (!match) return undefined;
+  const resourceType: ChatSessionContextResourceType =
+    match[1] === 'dashboards'
+      ? 'dashboard'
+      : match[1] === 'investigations'
+        ? 'investigation'
+        : 'alert';
+  return { resourceType, resourceId: decodeURIComponent(match[2] ?? '') };
+}
+
+function resourceFromPageContext(pageContext?: {
+  kind: string;
+  id?: string;
+}):
+  | { resourceType: ChatSessionContextResourceType; resourceId: string }
+  | undefined {
+  if (!pageContext?.id) return undefined;
+  if (
+    pageContext.kind !== 'dashboard' &&
+    pageContext.kind !== 'investigation' &&
+    pageContext.kind !== 'alert'
+  ) {
+    return undefined;
+  }
+  return { resourceType: pageContext.kind, resourceId: pageContext.id };
+}
 
 /**
  * Per-process datasource pin map. Keyed by chat-session id, values are a
@@ -43,8 +173,15 @@ function getSessionDatasourcePins(sessionId: string): Record<string, string> {
  * reuse the same adapter without duplicating the shape. */
 export function toAlertRuleStore(repo: IAlertRuleRepository): IAlertRuleStore {
   return {
-    create: (data) => repo.create(data as Parameters<IAlertRuleRepository['create']>[0]),
-    update: repo.update ? (id, patch) => repo.update(id, patch as Parameters<IAlertRuleRepository['update']>[1]) : undefined,
+    create: (data) =>
+      repo.create(data as Parameters<IAlertRuleRepository['create']>[0]),
+    update: repo.update
+      ? (id, patch) =>
+          repo.update(
+            id,
+            patch as Parameters<IAlertRuleRepository['update']>[1],
+          )
+      : undefined,
     findAll: repo.findAll
       ? async () => {
           const result = await repo.findAll();
@@ -70,6 +207,7 @@ export interface ChatServiceDeps {
   chatSessionStore?: IChatSessionRepository;
   chatMessageStore?: IChatMessageRepository;
   chatEventStore?: IChatSessionEventRepository;
+  chatSessionContextStore?: IChatSessionContextRepository;
   opsConnectorStore?: IOpsConnectorRepository;
   approvalStore?: IApprovalRequestRepository;
   /** P4 — when present, the agent can emit `remediation_plan.create` tools. */
@@ -125,27 +263,74 @@ export interface ChatSessionResult {
 export class ChatService {
   constructor(private deps: ChatServiceDeps) {}
 
+  private async recordSessionContext(
+    sessionId: string,
+    scope: ChatSessionOwnerScope,
+    resource:
+      | { resourceType: ChatSessionContextResourceType; resourceId: string }
+      | undefined,
+    relation: ChatSessionContextRelation,
+  ): Promise<void> {
+    if (!resource?.resourceId || !this.deps.chatSessionContextStore) return;
+    const context: ChatSessionContextInput = {
+      id: randomUUID(),
+      sessionId,
+      orgId: scope.orgId,
+      ownerUserId: scope.ownerUserId,
+      resourceType: resource.resourceType,
+      resourceId: resource.resourceId,
+      relation,
+      createdAt: new Date().toISOString(),
+    };
+
+    try {
+      await this.deps.chatSessionContextStore.create(context);
+    } catch (err) {
+      log.warn(
+        {
+          err,
+          sessionId,
+          resourceType: resource.resourceType,
+          resourceId: resource.resourceId,
+        },
+        'failed to persist chat session context',
+      );
+    }
+  }
+
   async handleMessage(
     message: string,
     sessionId: string | undefined,
     sendEvent: (event: DashboardSseEvent) => void,
     identity: Identity,
-    pageContext?: { kind: string; id?: string; timeRange?: string; clientTimezone?: string },
+    pageContext?: {
+      kind: string;
+      id?: string;
+      timeRange?: string;
+      clientTimezone?: string;
+    },
     signal?: AbortSignal,
   ): Promise<ChatSessionResult> {
     const llm = await this.deps.setupConfig.getLlm();
     if (!llm) {
-      throw new Error('LLM not configured - please complete the Setup Wizard first.');
+      throw new Error(
+        'LLM not configured - please complete the Setup Wizard first.',
+      );
     }
-    const datasources = await this.deps.setupConfig.listDatasources({ orgId: identity.orgId });
+    const datasources = await this.deps.setupConfig.listDatasources({
+      orgId: identity.orgId,
+    });
 
     const resolvedSessionId = sessionId ?? randomUUID();
+    const scope = ownerScope(identity);
 
     // Ensure a chat_sessions record exists for this session
     if (this.deps.chatSessionStore) {
-      const existing = await this.deps.chatSessionStore.findById(resolvedSessionId, {
-        orgId: identity.orgId,
-      });
+      const existing = await findOwnedChatSession(
+        this.deps.chatSessionStore,
+        resolvedSessionId,
+        scope,
+      );
       if (sessionId && !existing) {
         throw new Error('Chat session not found');
       }
@@ -153,9 +338,17 @@ export class ChatService {
         await this.deps.chatSessionStore.create({
           id: resolvedSessionId,
           orgId: identity.orgId,
+          ownerUserId: identity.userId,
         });
       }
     }
+
+    await this.recordSessionContext(
+      resolvedSessionId,
+      scope,
+      resourceFromPageContext(pageContext),
+      'viewed_with_chat',
+    );
 
     // Persist the user message to chat_messages
     const userMsgId = randomUUID();
@@ -189,7 +382,10 @@ export class ChatService {
       };
       persistQueue.push(
         Promise.resolve(eventStore.append(record)).catch((err) => {
-          log.warn({ err, sessionId: resolvedSessionId, kind: event.type }, 'failed to persist chat event');
+          log.warn(
+            { err, sessionId: resolvedSessionId, kind: event.type },
+            'failed to persist chat event',
+          );
         }),
       );
     };
@@ -198,32 +394,49 @@ export class ChatService {
     const model = llm.model;
     const adapters = buildAdapterRegistry(
       datasources,
-      this.deps.githubChangeSources ? await this.deps.githubChangeSources.listAdapters(identity.orgId) : [],
+      this.deps.githubChangeSources
+        ? await this.deps.githubChangeSources.listAdapters(identity.orgId)
+        : [],
     );
-    const opsCommandRunner = this.deps.opsConnectorStore && this.deps.approvalStore
-      ? new OpsCommandRunnerService({
-          connectors: this.deps.opsConnectorStore,
-          approvals: this.deps.approvalStore,
-        }, identity.orgId)
+    const opsCommandRunner =
+      this.deps.opsConnectorStore && this.deps.approvalStore
+        ? new OpsCommandRunnerService(
+            {
+              connectors: this.deps.opsConnectorStore,
+              approvals: this.deps.approvalStore,
+            },
+            identity.orgId,
+          )
+        : undefined;
+    const opsConnectors = opsCommandRunner
+      ? await opsCommandRunner.listConnectors()
       : undefined;
-    const opsConnectors = opsCommandRunner ? await opsCommandRunner.listConnectors() : undefined;
 
     // Parse relative time range (e.g., "1h", "6h", "24h", "7d") to absolute
     // start/end. Carry the client's IANA timezone so the prompt can label
     // both UTC and local time — without that the agent can't reconcile a
     // clock time the user reads off the panel's x-axis.
-    let timeRange: { start: string; end: string; clientTimezone?: string } | undefined;
+    let timeRange:
+      | { start: string; end: string; clientTimezone?: string }
+      | undefined;
     if (pageContext?.timeRange) {
       const now = new Date();
       const match = pageContext.timeRange.match(/^(\d+)([mhd])$/);
       if (match) {
         const amount = Number(match[1]);
         const unit = match[2];
-        const ms = unit === 'm' ? amount * 60_000 : unit === 'h' ? amount * 3_600_000 : amount * 86_400_000;
+        const ms =
+          unit === 'm'
+            ? amount * 60_000
+            : unit === 'h'
+              ? amount * 3_600_000
+              : amount * 86_400_000;
         timeRange = {
           start: new Date(now.getTime() - ms).toISOString(),
           end: now.toISOString(),
-          ...(pageContext.clientTimezone ? { clientTimezone: pageContext.clientTimezone } : {}),
+          ...(pageContext.clientTimezone
+            ? { clientTimezone: pageContext.clientTimezone }
+            : {}),
         };
       }
     }
@@ -236,16 +449,19 @@ export class ChatService {
     // Load existing summary from session, then check if we need to compact further
     let conversationSummary: string | undefined;
     if (this.deps.chatSessionStore) {
-      const session = await this.deps.chatSessionStore.findById(resolvedSessionId, {
-        orgId: identity.orgId,
-      });
+      const session = await findOwnedChatSession(
+        this.deps.chatSessionStore,
+        resolvedSessionId,
+        scope,
+      );
       conversationSummary = session?.contextSummary || undefined;
     }
 
     // Check if chat history is large enough to warrant compaction
     if (this.deps.chatMessageStore) {
-      const allMessages = await this.deps.chatMessageStore.getMessages(resolvedSessionId);
-      const asCompletionMessages = allMessages.map(m => ({
+      const allMessages =
+        await this.deps.chatMessageStore.getMessages(resolvedSessionId);
+      const asCompletionMessages = allMessages.map((m) => ({
         role: m.role as 'user' | 'assistant' | 'system',
         content: m.content,
       }));
@@ -253,8 +469,15 @@ export class ChatService {
       // Estimate system prompt tokens (~4000 is a safe estimate for the static prompt)
       const systemPromptTokenEstimate = 4000;
       if (shouldCompact(systemPromptTokenEstimate, asCompletionMessages)) {
-        log.info({ sessionId: resolvedSessionId, messageCount: allMessages.length }, 'compacting conversation context');
-        const compacted = await compactMessages(gateway, model, asCompletionMessages);
+        log.info(
+          { sessionId: resolvedSessionId, messageCount: allMessages.length },
+          'compacting conversation context',
+        );
+        const compacted = await compactMessages(
+          gateway,
+          model,
+          asCompletionMessages,
+        );
         conversationSummary = compacted.summary || conversationSummary;
 
         // Persist summary for reuse in future turns
@@ -262,7 +485,7 @@ export class ChatService {
           await this.deps.chatSessionStore.updateContextSummary(
             resolvedSessionId,
             conversationSummary,
-            { orgId: identity.orgId },
+            sessionScope(scope),
           );
         }
       }
@@ -273,50 +496,89 @@ export class ChatService {
     // user / assistant turns directly to chat_messages above and below.
     const chatMsgStore = this.deps.chatMessageStore;
     const conversationStoreAdapter = {
-      getMessages: async (key: string) => (chatMsgStore ? await chatMsgStore.getMessages(key) : []),
+      getMessages: async (key: string) =>
+        chatMsgStore ? await chatMsgStore.getMessages(key) : [],
       addMessage: async (_key: string, msg: DashboardMessage) => msg,
-      clearMessages: async () => { /* handled externally */ },
-      deleteConversation: async () => { /* handled externally */ },
+      clearMessages: async () => {
+        /* handled externally */
+      },
+      deleteConversation: async () => {
+        /* handled externally */
+      },
     } as IAgentConversationStore;
 
-    const orchestrator = new OrchestratorAgent({
-      gateway,
-      model,
-      store: this.deps.dashboardStore,
-      conversationStore: conversationStoreAdapter,
-      investigationReportStore: this.deps.investigationReportStore,
-      investigationStore: this.deps.investigationStore as IInvestigationStore | undefined,
-      alertRuleStore: toAlertRuleStore(this.deps.alertRuleStore),
-      ...(this.deps.folderRepository ? { folderRepository: this.deps.folderRepository } : {}),
-      adapters,
-      webSearchAdapter: sharedWebSearchAdapter,
-      allDatasources: toAgentDatasources(datasources),
-      // Live pin bag for this session — the agent mutates it via
-      // datasources.pin/unpin and we read it back across messages.
-      sessionDatasourcePins: getSessionDatasourcePins(resolvedSessionId),
-      ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
-      // P4 — agent can propose remediation plans when these stores are wired.
-      ...(this.deps.remediationPlanStore ? { remediationPlans: this.deps.remediationPlanStore } : {}),
-      ...(this.deps.approvalStore ? { approvalRequests: this.deps.approvalStore } : {}),
-      sendEvent: wrappedSendEvent,
-      timeRange,
-      conversationSummary,
-      identity,
-      accessControl: this.deps.accessControl,
-      ...(this.deps.auditWriter ? { auditWriter: this.deps.auditWriter } : {}),
-      // Page-based specialized agent selection (§D-layer-1). Falls back to
-      // the full orchestrator when the page has no tight capability ceiling.
-      agentType: pickAgentTypeFromContext(pageContext),
-    }, resolvedSessionId);
+    const orchestrator = new OrchestratorAgent(
+      {
+        gateway,
+        model,
+        store: this.deps.dashboardStore,
+        conversationStore: conversationStoreAdapter,
+        investigationReportStore: this.deps.investigationReportStore,
+        investigationStore: this.deps.investigationStore as
+          | IInvestigationStore
+          | undefined,
+        alertRuleStore: toAlertRuleStore(this.deps.alertRuleStore),
+        ...(this.deps.folderRepository
+          ? { folderRepository: this.deps.folderRepository }
+          : {}),
+        adapters,
+        webSearchAdapter: sharedWebSearchAdapter,
+        allDatasources: toAgentDatasources(datasources),
+        // Live pin bag for this session — the agent mutates it via
+        // datasources.pin/unpin and we read it back across messages.
+        sessionDatasourcePins: getSessionDatasourcePins(resolvedSessionId),
+        ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
+        // P4 — agent can propose remediation plans when these stores are wired.
+        ...(this.deps.remediationPlanStore
+          ? { remediationPlans: this.deps.remediationPlanStore }
+          : {}),
+        ...(this.deps.approvalStore
+          ? { approvalRequests: this.deps.approvalStore }
+          : {}),
+        sendEvent: wrappedSendEvent,
+        timeRange,
+        conversationSummary,
+        identity,
+        accessControl: this.deps.accessControl,
+        ...(this.deps.auditWriter
+          ? { auditWriter: this.deps.auditWriter }
+          : {}),
+        // Page-based specialized agent selection (§D-layer-1). Falls back to
+        // the full orchestrator when the page has no tight capability ceiling.
+        agentType: pickAgentTypeFromContext(pageContext),
+      },
+      resolvedSessionId,
+    );
 
     // If the user is viewing a specific dashboard, scope the agent to it
-    const dashboardId = pageContext?.kind === 'dashboard' ? pageContext.id : undefined;
+    const dashboardId =
+      pageContext?.kind === 'dashboard' ? pageContext.id : undefined;
 
-    log.info({ sessionId: resolvedSessionId, dashboardId, message: message.slice(0, 80) }, 'starting session orchestrator');
-    const replyContent = await orchestrator.handleMessage(message, dashboardId, signal);
+    log.info(
+      {
+        sessionId: resolvedSessionId,
+        dashboardId,
+        message: message.slice(0, 80),
+      },
+      'starting session orchestrator',
+    );
+    const replyContent = await orchestrator.handleMessage(
+      message,
+      dashboardId,
+      signal,
+    );
     const assistantActions = orchestrator.consumeConversationActions();
     const navigate = orchestrator.consumeNavigate();
-    log.info({ sessionId: resolvedSessionId, reply: replyContent.slice(0, 100) }, 'session orchestrator done');
+    await this.recordSessionContext(
+      resolvedSessionId,
+      scope,
+      navigate ? parseResourcePath(navigate) : undefined,
+      'created_from_chat',
+    );
+    log.info(
+      { sessionId: resolvedSessionId, reply: replyContent.slice(0, 100) },
+      'session orchestrator done',
+    );
 
     // Wait for all queued event persistence to flush before we finalize the
     // assistant message — guarantees the step trace is fully durable by the
@@ -339,18 +601,28 @@ export class ChatService {
 
     // Update session title from first assistant message if title is empty
     if (this.deps.chatSessionStore) {
-      const session = await this.deps.chatSessionStore.findById(resolvedSessionId, {
-        orgId: identity.orgId,
-      });
+      const session = await findOwnedChatSession(
+        this.deps.chatSessionStore,
+        resolvedSessionId,
+        scope,
+      );
       if (session && !session.title) {
         // Use first ~60 chars of user message as title
-        const autoTitle = message.length > 60 ? message.slice(0, 57) + '...' : message;
-        await this.deps.chatSessionStore.updateTitle(resolvedSessionId, autoTitle, {
-          orgId: identity.orgId,
-        });
+        const autoTitle =
+          message.length > 60 ? message.slice(0, 57) + '...' : message;
+        await this.deps.chatSessionStore.updateTitle(
+          resolvedSessionId,
+          autoTitle,
+          sessionScope(scope),
+        );
       }
     }
 
-    return { sessionId: resolvedSessionId, replyContent, assistantMessageId, navigate };
+    return {
+      sessionId: resolvedSessionId,
+      replyContent,
+      assistantMessageId,
+      navigate,
+    };
   }
 }

--- a/packages/api-gateway/src/services/investigation-workspace-service.test.ts
+++ b/packages/api-gateway/src/services/investigation-workspace-service.test.ts
@@ -65,7 +65,6 @@ describe('InvestigationWorkspaceService', () => {
         id: 'inv_a',
         status: 'planning',
         intent: 'Investigate latency',
-        sessionId: 'ses_1',
         userId: 'u_1',
         createdAt: '2026-04-25T00:00:00.000Z',
         updatedAt: '2026-04-25T00:00:00.000Z',

--- a/packages/api-gateway/src/services/investigation-workspace-service.ts
+++ b/packages/api-gateway/src/services/investigation-workspace-service.ts
@@ -26,7 +26,6 @@ export class InvestigationWorkspaceService {
         id: inv.id,
         status: inv.status,
         intent: inv.intent,
-        sessionId: inv.sessionId,
         userId: inv.userId,
         createdAt: inv.createdAt,
         updatedAt: inv.updatedAt,

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -234,7 +234,6 @@ export interface Dashboard {
   useExistingMetrics: boolean;
   folder?: string;
   workspaceId?: string;
-  sessionId?: string;
   version?: number;
   publishStatus?: PublishStatus;
   createdAt: string;
@@ -248,10 +247,28 @@ export interface ChatSession {
   id: string;
   title: string;
   orgId?: string;
+  ownerUserId?: string | null;
   createdAt: string;
   updatedAt: string;
   /** LLM-generated summary of older conversation turns for context compaction */
   contextSummary?: string;
+}
+
+export type ChatSessionContextResourceType = 'dashboard' | 'investigation' | 'alert';
+export type ChatSessionContextRelation =
+  | 'created_from_chat'
+  | 'viewed_with_chat'
+  | 'referenced';
+
+export interface ChatSessionContext {
+  id: string;
+  sessionId: string;
+  orgId: string;
+  ownerUserId: string;
+  resourceType: ChatSessionContextResourceType;
+  resourceId: string;
+  relation: ChatSessionContextRelation;
+  createdAt: string;
 }
 
 export interface ChatMessage {

--- a/packages/common/src/repositories/dashboard/interfaces.ts
+++ b/packages/common/src/repositories/dashboard/interfaces.ts
@@ -35,7 +35,6 @@ export interface NewDashboardInput {
   useExistingMetrics?: boolean;
   folder?: string;
   workspaceId?: string;
-  sessionId?: string;
 }
 
 /**

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -585,7 +585,6 @@ CREATE TABLE IF NOT EXISTS dashboards (
   folder               TEXT,
   folder_uid           TEXT NULL,
   workspace_id         TEXT,
-  session_id           TEXT,
   version              INTEGER,
   publish_status       TEXT,
   error                TEXT,
@@ -599,6 +598,7 @@ CREATE INDEX IF NOT EXISTS ix_dashboards_folder_uid ON dashboards(org_id, folder
 CREATE TABLE IF NOT EXISTS chat_sessions (
   id              TEXT PRIMARY KEY,
   org_id          TEXT NOT NULL DEFAULT 'org_main',
+  owner_user_id   TEXT,
   title           TEXT NOT NULL DEFAULT '',
   context_summary TEXT,
   created_at      TEXT NOT NULL,
@@ -606,6 +606,21 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS ix_chat_sessions_org_id ON chat_sessions(org_id);
+CREATE INDEX IF NOT EXISTS ix_chat_sessions_owner ON chat_sessions(org_id, owner_user_id);
+
+CREATE TABLE IF NOT EXISTS chat_session_contexts (
+  id              TEXT PRIMARY KEY,
+  session_id      TEXT NOT NULL,
+  org_id          TEXT NOT NULL,
+  owner_user_id   TEXT NOT NULL,
+  resource_type   TEXT NOT NULL,
+  resource_id     TEXT NOT NULL,
+  relation        TEXT NOT NULL,
+  created_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_session ON chat_session_contexts(session_id);
+CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_owner_resource ON chat_session_contexts(org_id, owner_user_id, resource_type, resource_id);
 
 CREATE TABLE IF NOT EXISTS chat_messages (
   id         TEXT PRIMARY KEY,

--- a/packages/data-layer/src/db/sqlite-schema.ts
+++ b/packages/data-layer/src/db/sqlite-schema.ts
@@ -208,7 +208,6 @@ export const dashboards = sqliteTable(
     folder: text('folder'),
     workspaceId: text('workspace_id'),
     orgId: text('org_id').notNull().default('org_main'),
-    sessionId: text('session_id'),
     version: integer('version'),
     publishStatus: text('publish_status'),
     error: text('error'),
@@ -219,14 +218,10 @@ export const dashboards = sqliteTable(
     index('dashboards_user_idx').on(t.userId),
     index('dashboards_workspace_idx').on(t.workspaceId),
     index('dashboards_org_idx').on(t.orgId),
-    index('dashboards_session_idx').on(t.sessionId),
     index('dashboards_status_idx').on(t.status),
     index('dashboards_created_at_idx').on(t.createdAt),
   ],
 );
-
-// `dashboard_messages` removed — see migration 020. Chat history now lives in
-// `chat_messages` (defined further below) keyed by sessionId.
 
 // — alert rules
 
@@ -487,12 +482,39 @@ export const chatSessions = sqliteTable(
     title: text('title').notNull().default(''),
     contextSummary: text('context_summary'),
     orgId: text('org_id').notNull().default('org_main'),
+    ownerUserId: text('owner_user_id'),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },
   (t) => [
     index('chat_sessions_updated_at_idx').on(t.updatedAt),
     index('chat_sessions_org_idx').on(t.orgId),
+    index('chat_sessions_owner_idx').on(t.orgId, t.ownerUserId),
+  ],
+);
+
+export const chatSessionContexts = sqliteTable(
+  'chat_session_contexts',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id').notNull(),
+    orgId: text('org_id').notNull().default('org_main'),
+    ownerUserId: text('owner_user_id').notNull(),
+    resourceType: text('resource_type').notNull(),
+    resourceId: text('resource_id').notNull(),
+    relation: text('relation').notNull(),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    index('chat_session_contexts_session_idx').on(t.sessionId),
+    index('chat_session_contexts_owner_idx').on(t.orgId, t.ownerUserId),
+    index('chat_session_contexts_resource_idx').on(t.orgId, t.resourceType, t.resourceId),
+    uniqueIndex('chat_session_contexts_unique_idx').on(
+      t.sessionId,
+      t.resourceType,
+      t.resourceId,
+      t.relation,
+    ),
   ],
 );
 

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -14,6 +14,7 @@ import type {
   IInvestigationReportRepository,
   IPostMortemRepository,
   IChatSessionRepository,
+  IChatSessionContextRepository,
   IChatMessageRepository,
   IChatSessionEventRepository,
 } from './interfaces.js';
@@ -45,6 +46,7 @@ import { SqliteVersionRepository } from './sqlite/version.js';
 import { SqliteInvestigationReportRepository } from './sqlite/investigation-report.js';
 import { SqlitePostMortemRepository } from './sqlite/post-mortem.js';
 import { SqliteChatSessionRepository } from './sqlite/chat-session.js';
+import { SqliteChatSessionContextRepository } from './sqlite/chat-session-context.js';
 import { SqliteChatMessageRepository } from './sqlite/chat-message.js';
 import { SqliteChatSessionEventRepository } from './sqlite/chat-session-event.js';
 import { InstanceConfigRepository } from './sqlite/instance-config.js';
@@ -65,6 +67,7 @@ import { PostgresVersionRepository } from './postgres/version.js';
 import { PostgresInvestigationReportRepository } from './postgres/investigation-report.js';
 import { PostgresPostMortemRepository } from './postgres/post-mortem.js';
 import { PostgresChatSessionRepository } from './postgres/chat-session.js';
+import { PostgresChatSessionContextRepository } from './postgres/chat-session-context.js';
 import { PostgresChatMessageRepository } from './postgres/chat-message.js';
 import { PostgresChatSessionEventRepository } from './postgres/chat-session-event.js';
 import { PostgresInstanceConfigRepository } from './postgres/instance-config.js';
@@ -100,6 +103,7 @@ export interface RepositoryBundle {
   investigationReports: IInvestigationReportRepository;
   postMortems: IPostMortemRepository;
   chatSessions: IChatSessionRepository;
+  chatSessionContexts: IChatSessionContextRepository;
   chatMessages: IChatMessageRepository;
   chatSessionEvents: IChatSessionEventRepository;
   // W2 / T2.2 — instance-scoped config (replaces setup-config.json).
@@ -126,6 +130,7 @@ export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
     investigationReports: new SqliteInvestigationReportRepository(db),
     postMortems: new SqlitePostMortemRepository(db),
     chatSessions: new SqliteChatSessionRepository(db),
+    chatSessionContexts: new SqliteChatSessionContextRepository(db),
     chatMessages: new SqliteChatMessageRepository(db),
     chatSessionEvents: new SqliteChatSessionEventRepository(db),
     instanceConfig: new InstanceConfigRepository(db),
@@ -153,6 +158,7 @@ export function createPostgresRepositories(db: DbClient): RepositoryBundle {
     investigationReports: new PostgresInvestigationReportRepository(db),
     postMortems: new PostgresPostMortemRepository(db),
     chatSessions: new PostgresChatSessionRepository(db),
+    chatSessionContexts: new PostgresChatSessionContextRepository(db),
     chatMessages: new PostgresChatMessageRepository(db),
     chatSessionEvents: new PostgresChatSessionEventRepository(db),
     instanceConfig: new PostgresInstanceConfigRepository(queryClient),

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -25,8 +25,11 @@ export type {
   IInvestigationReportRepository,
   IPostMortemRepository,
   IChatSessionRepository,
+  IChatSessionContextRepository,
   IChatMessageRepository,
   IChatSessionEventRepository,
+  ChatSessionContextResourceScope,
+  ChatSessionScope,
   ChatSessionEventRecord,
 } from './interfaces.js';
 

--- a/packages/data-layer/src/repository/interfaces.ts
+++ b/packages/data-layer/src/repository/interfaces.ts
@@ -23,6 +23,9 @@ import type {
   SavedInvestigationReport,
   PostMortemReport,
   ChatSession,
+  ChatSessionContext,
+  ChatSessionContextRelation,
+  ChatSessionContextResourceType,
   ChatMessage,
 } from '@agentic-obs/common';
 import type { ExplanationResult } from '@agentic-obs/common';
@@ -377,13 +380,46 @@ export interface IPostMortemRepository {
 
 // — ChatSession
 
+export interface ChatSessionScope {
+  orgId?: string;
+  ownerUserId?: string;
+}
+
 export interface IChatSessionRepository {
-  create(session: { id: string; title?: string; orgId?: string }): MaybeAsync<ChatSession>;
-  findById(id: string, scope?: { orgId?: string }): MaybeAsync<ChatSession | undefined>;
-  findAll(limit?: number, scope?: { orgId?: string }): MaybeAsync<ChatSession[]>;
-  updateTitle(id: string, title: string, scope?: { orgId?: string }): MaybeAsync<ChatSession | undefined>;
-  updateContextSummary(id: string, summary: string, scope?: { orgId?: string }): MaybeAsync<ChatSession | undefined>;
-  delete(id: string): MaybeAsync<boolean>;
+  create(session: {
+    id: string;
+    title?: string;
+    orgId?: string;
+    ownerUserId?: string;
+  }): MaybeAsync<ChatSession>;
+  findById(id: string, scope?: ChatSessionScope): MaybeAsync<ChatSession | undefined>;
+  findAll(limit?: number, scope?: ChatSessionScope): MaybeAsync<ChatSession[]>;
+  updateTitle(id: string, title: string, scope?: ChatSessionScope): MaybeAsync<ChatSession | undefined>;
+  updateContextSummary(id: string, summary: string, scope?: ChatSessionScope): MaybeAsync<ChatSession | undefined>;
+  delete(id: string, scope?: ChatSessionScope): MaybeAsync<boolean>;
+}
+
+// — ChatSessionContext
+
+export interface ChatSessionContextResourceScope extends ChatSessionScope {
+  resourceType: ChatSessionContextResourceType;
+  resourceId: string;
+}
+
+export interface IChatSessionContextRepository {
+  create(context: {
+    id?: string;
+    sessionId: string;
+    orgId: string;
+    ownerUserId: string;
+    resourceType: ChatSessionContextResourceType;
+    resourceId: string;
+    relation: ChatSessionContextRelation;
+    createdAt?: string;
+  }): MaybeAsync<ChatSessionContext>;
+  listBySession(sessionId: string, scope?: ChatSessionScope): MaybeAsync<ChatSessionContext[]>;
+  listByResource(scope: ChatSessionContextResourceScope, limit?: number): MaybeAsync<ChatSessionContext[]>;
+  deleteBySession(sessionId: string, scope?: ChatSessionScope): MaybeAsync<void>;
 }
 
 // — ChatMessage

--- a/packages/data-layer/src/repository/postgres/chat-session-context.ts
+++ b/packages/data-layer/src/repository/postgres/chat-session-context.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from 'node:crypto';
+import { and, desc, eq } from 'drizzle-orm';
+import type { ChatSessionContext } from '@agentic-obs/common';
+import { chatSessionContexts } from '../../db/schema.js';
+import type {
+  ChatSessionContextResourceScope,
+  ChatSessionScope,
+  IChatSessionContextRepository,
+} from '../interfaces.js';
+
+type DbRow = typeof chatSessionContexts.$inferSelect;
+
+function rowToContext(row: DbRow): ChatSessionContext {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    orgId: row.orgId,
+    ownerUserId: row.ownerUserId,
+    resourceType: row.resourceType as ChatSessionContext['resourceType'],
+    resourceId: row.resourceId,
+    relation: row.relation as ChatSessionContext['relation'],
+    createdAt: row.createdAt,
+  };
+}
+
+function sessionWhere(sessionId: string, scope: ChatSessionScope = {}) {
+  return and(
+    eq(chatSessionContexts.sessionId, sessionId),
+    scope.orgId ? eq(chatSessionContexts.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessionContexts.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+function resourceWhere(scope: ChatSessionContextResourceScope) {
+  return and(
+    eq(chatSessionContexts.resourceType, scope.resourceType),
+    eq(chatSessionContexts.resourceId, scope.resourceId),
+    scope.orgId ? eq(chatSessionContexts.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessionContexts.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+export class PostgresChatSessionContextRepository implements IChatSessionContextRepository {
+  constructor(private readonly db: any) {}
+
+  async create(
+    context: Parameters<IChatSessionContextRepository['create']>[0],
+  ): Promise<ChatSessionContext> {
+    const [row] = await this.db
+      .insert(chatSessionContexts)
+      .values({
+        id: context.id ?? `chatctx_${randomUUID()}`,
+        sessionId: context.sessionId,
+        orgId: context.orgId,
+        ownerUserId: context.ownerUserId,
+        resourceType: context.resourceType,
+        resourceId: context.resourceId,
+        relation: context.relation,
+        createdAt: context.createdAt ?? new Date().toISOString(),
+      })
+      .returning();
+    return rowToContext(row!);
+  }
+
+  async listBySession(
+    sessionId: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSessionContext[]> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionContexts)
+      .where(sessionWhere(sessionId, scope))
+      .orderBy(desc(chatSessionContexts.createdAt));
+    return rows.map(rowToContext);
+  }
+
+  async listByResource(
+    scope: ChatSessionContextResourceScope,
+    limit = 50,
+  ): Promise<ChatSessionContext[]> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionContexts)
+      .where(resourceWhere(scope))
+      .orderBy(desc(chatSessionContexts.createdAt))
+      .limit(limit);
+    return rows.map(rowToContext);
+  }
+
+  async deleteBySession(
+    sessionId: string,
+    scope: ChatSessionScope = {},
+  ): Promise<void> {
+    await this.db
+      .delete(chatSessionContexts)
+      .where(sessionWhere(sessionId, scope));
+  }
+}

--- a/packages/data-layer/src/repository/postgres/chat-session.ts
+++ b/packages/data-layer/src/repository/postgres/chat-session.ts
@@ -1,7 +1,10 @@
 import { and, eq, desc } from 'drizzle-orm';
 import type { ChatSession } from '@agentic-obs/common';
 import { chatSessions } from '../../db/schema.js';
-import type { IChatSessionRepository } from '../interfaces.js';
+import type {
+  ChatSessionScope,
+  IChatSessionRepository,
+} from '../interfaces.js';
 
 type DbRow = typeof chatSessions.$inferSelect;
 
@@ -10,16 +13,41 @@ function rowToSession(row: DbRow): ChatSession {
     id: row.id,
     title: row.title,
     orgId: row.orgId,
+    ...(row.ownerUserId ? { ownerUserId: row.ownerUserId } : {}),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(row.contextSummary ? { contextSummary: row.contextSummary } : {}),
   };
 }
 
+function sessionWhere(id: string, scope: ChatSessionScope = {}) {
+  return and(
+    eq(chatSessions.id, id),
+    scope.orgId ? eq(chatSessions.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessions.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+function scopeWhere(scope: ChatSessionScope = {}) {
+  return and(
+    scope.orgId ? eq(chatSessions.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessions.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
 export class PostgresChatSessionRepository implements IChatSessionRepository {
   constructor(private readonly db: any) {}
 
-  async create(session: { id: string; title?: string; orgId?: string }): Promise<ChatSession> {
+  async create(session: {
+    id: string;
+    title?: string;
+    orgId?: string;
+    ownerUserId?: string;
+  }): Promise<ChatSession> {
     const now = new Date().toISOString();
     const [row] = await this.db
       .insert(chatSessions)
@@ -27,6 +55,7 @@ export class PostgresChatSessionRepository implements IChatSessionRepository {
         id: session.id,
         title: session.title ?? '',
         orgId: session.orgId ?? 'org_main',
+        ownerUserId: session.ownerUserId ?? null,
         createdAt: now,
         updatedAt: now,
       })
@@ -34,51 +63,63 @@ export class PostgresChatSessionRepository implements IChatSessionRepository {
     return rowToSession(row!);
   }
 
-  async findById(id: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
-    const [row] = await this.db.select().from(chatSessions).where(where);
+  async findById(
+    id: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(chatSessions)
+      .where(sessionWhere(id, scope));
     return row ? rowToSession(row) : undefined;
   }
 
-  async findAll(limit = 50, scope: { orgId?: string } = {}): Promise<ChatSession[]> {
+  async findAll(
+    limit = 50,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession[]> {
     const base = this.db.select().from(chatSessions);
-    const rows = scope.orgId
+    const where = scopeWhere(scope);
+    const rows = where
       ? await base
-          .where(eq(chatSessions.orgId, scope.orgId))
+          .where(where)
           .orderBy(desc(chatSessions.updatedAt))
           .limit(limit)
       : await base.orderBy(desc(chatSessions.updatedAt)).limit(limit);
     return rows.map(rowToSession);
   }
 
-  async updateTitle(id: string, title: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
+  async updateTitle(
+    id: string,
+    title: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
     const [row] = await this.db
       .update(chatSessions)
       .set({ title, updatedAt: new Date().toISOString() })
-      .where(where)
+      .where(sessionWhere(id, scope))
       .returning();
     return row ? rowToSession(row) : undefined;
   }
 
-  async updateContextSummary(id: string, summary: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
+  async updateContextSummary(
+    id: string,
+    summary: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
     const [row] = await this.db
       .update(chatSessions)
       .set({ contextSummary: summary, updatedAt: new Date().toISOString() })
-      .where(where)
+      .where(sessionWhere(id, scope))
       .returning();
     return row ? rowToSession(row) : undefined;
   }
 
-  async delete(id: string): Promise<boolean> {
-    const result = await this.db.delete(chatSessions).where(eq(chatSessions.id, id)).returning();
+  async delete(id: string, scope: ChatSessionScope = {}): Promise<boolean> {
+    const result = await this.db
+      .delete(chatSessions)
+      .where(sessionWhere(id, scope))
+      .returning();
     return result.length > 0;
   }
 }

--- a/packages/data-layer/src/repository/postgres/dashboard.ts
+++ b/packages/data-layer/src/repository/postgres/dashboard.ts
@@ -65,7 +65,6 @@ interface DashboardRow {
   folder: string | null;
   workspace_id: string | null;
   org_id: string;
-  session_id: string | null;
   version: number | null;
   publish_status: string | null;
   error: string | null;
@@ -115,7 +114,6 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   };
   if (r.folder !== null) base.folder = r.folder;
   if (r.workspace_id !== null) base.workspaceId = r.workspace_id;
-  if (r.session_id !== null) base.sessionId = r.session_id;
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
@@ -140,7 +138,7 @@ export class DashboardRepository implements IDashboardRepository {
       INSERT INTO dashboards (
         id, type, title, description, prompt, user_id, status,
         panels, variables, refresh_interval_sec, datasource_ids,
-        use_existing_metrics, folder, workspace_id, session_id,
+        use_existing_metrics, folder, workspace_id,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -157,7 +155,6 @@ export class DashboardRepository implements IDashboardRepository {
         ${useExistingMetrics},
         ${input.folder ?? null},
         ${input.workspaceId ?? null},
-        ${input.sessionId ?? null},
         ${now},
         ${now}
       )
@@ -322,7 +319,7 @@ export class DashboardRepository implements IDashboardRepository {
         INSERT INTO dashboards (
           id, type, title, description, prompt, user_id, status,
           panels, variables, refresh_interval_sec, datasource_ids,
-          use_existing_metrics, folder, workspace_id, session_id,
+          use_existing_metrics, folder, workspace_id,
           version, publish_status, error, created_at, updated_at
         ) VALUES (
           ${raw.id},
@@ -339,7 +336,6 @@ export class DashboardRepository implements IDashboardRepository {
           ${fromBool(raw.useExistingMetrics, true)},
           ${raw.folder ?? null},
           ${raw.workspaceId ?? null},
-          ${raw.sessionId ?? null},
           ${raw.version ?? null},
           ${raw.publishStatus ?? null},
           ${raw.error ?? null},
@@ -360,7 +356,6 @@ export class DashboardRepository implements IDashboardRepository {
           use_existing_metrics = excluded.use_existing_metrics,
           folder               = excluded.folder,
           workspace_id         = excluded.workspace_id,
-          session_id           = excluded.session_id,
           version              = excluded.version,
           publish_status       = excluded.publish_status,
           error                = excluded.error,

--- a/packages/data-layer/src/repository/postgres/index.ts
+++ b/packages/data-layer/src/repository/postgres/index.ts
@@ -14,6 +14,7 @@ export { PostgresAlertRuleRepository } from './alert-rule.js';
 export { PostgresNotificationRepository } from './notification.js';
 export { PostgresVersionRepository } from './version.js';
 export { PostgresChatSessionRepository } from './chat-session.js';
+export { PostgresChatSessionContextRepository } from './chat-session-context.js';
 export { PostgresChatMessageRepository } from './chat-message.js';
 export { PostgresChatSessionEventRepository } from './chat-session-event.js';
 export { PostgresInstanceConfigRepository } from './instance-config.js';

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -578,7 +578,6 @@ CREATE TABLE IF NOT EXISTS dashboards (
   folder               TEXT,
   folder_uid           TEXT NULL,
   workspace_id         TEXT,
-  session_id           TEXT,
   version              INTEGER,
   publish_status       TEXT,
   error                TEXT,
@@ -592,6 +591,7 @@ CREATE INDEX IF NOT EXISTS ix_dashboards_folder_uid ON dashboards(org_id, folder
 CREATE TABLE IF NOT EXISTS chat_sessions (
   id              TEXT PRIMARY KEY,
   org_id          TEXT NOT NULL DEFAULT 'org_main',
+  owner_user_id   TEXT,
   title           TEXT NOT NULL DEFAULT '',
   context_summary TEXT,
   created_at      TEXT NOT NULL,
@@ -599,6 +599,21 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS ix_chat_sessions_org_id ON chat_sessions(org_id);
+CREATE INDEX IF NOT EXISTS ix_chat_sessions_owner ON chat_sessions(org_id, owner_user_id);
+
+CREATE TABLE IF NOT EXISTS chat_session_contexts (
+  id              TEXT PRIMARY KEY,
+  session_id      TEXT NOT NULL,
+  org_id          TEXT NOT NULL,
+  owner_user_id   TEXT NOT NULL,
+  resource_type   TEXT NOT NULL,
+  resource_id     TEXT NOT NULL,
+  relation        TEXT NOT NULL,
+  created_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_session ON chat_session_contexts(session_id);
+CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_owner_resource ON chat_session_contexts(org_id, owner_user_id, resource_type, resource_id);
 
 CREATE TABLE IF NOT EXISTS chat_messages (
   id         TEXT PRIMARY KEY,

--- a/packages/data-layer/src/repository/postgres/schema.ts
+++ b/packages/data-layer/src/repository/postgres/schema.ts
@@ -209,10 +209,43 @@ export const chatSessions = pgTable(
     title: text('title').notNull().default(''),
     contextSummary: text('context_summary'),
     orgId: text('org_id').notNull().default('org_main'),
+    ownerUserId: text('owner_user_id'),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },
-  (t) => [index('pg_repo_chat_sessions_org_idx').on(t.orgId)],
+  (t) => [
+    index('pg_repo_chat_sessions_org_idx').on(t.orgId),
+    index('pg_repo_chat_sessions_owner_idx').on(t.orgId, t.ownerUserId),
+  ],
+);
+
+export const chatSessionContexts = pgTable(
+  'chat_session_contexts',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id').notNull(),
+    orgId: text('org_id').notNull().default('org_main'),
+    ownerUserId: text('owner_user_id').notNull(),
+    resourceType: text('resource_type').notNull(),
+    resourceId: text('resource_id').notNull(),
+    relation: text('relation').notNull(),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    index('pg_repo_chat_session_contexts_session_idx').on(t.sessionId),
+    index('pg_repo_chat_session_contexts_owner_idx').on(t.orgId, t.ownerUserId),
+    index('pg_repo_chat_session_contexts_resource_idx').on(
+      t.orgId,
+      t.resourceType,
+      t.resourceId,
+    ),
+    uniqueIndex('pg_repo_chat_session_contexts_unique_idx').on(
+      t.sessionId,
+      t.resourceType,
+      t.resourceId,
+      t.relation,
+    ),
+  ],
 );
 
 export const chatMessages = pgTable(

--- a/packages/data-layer/src/repository/sqlite/chat-session-context.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session-context.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from 'node:crypto';
+import { and, desc, eq } from 'drizzle-orm';
+import type { ChatSessionContext } from '@agentic-obs/common';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { chatSessionContexts } from '../../db/sqlite-schema.js';
+import type {
+  ChatSessionContextResourceScope,
+  ChatSessionScope,
+  IChatSessionContextRepository,
+} from '../interfaces.js';
+
+type DbRow = typeof chatSessionContexts.$inferSelect;
+
+function rowToContext(row: DbRow): ChatSessionContext {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    orgId: row.orgId,
+    ownerUserId: row.ownerUserId,
+    resourceType: row.resourceType as ChatSessionContext['resourceType'],
+    resourceId: row.resourceId,
+    relation: row.relation as ChatSessionContext['relation'],
+    createdAt: row.createdAt,
+  };
+}
+
+function sessionWhere(sessionId: string, scope: ChatSessionScope = {}) {
+  return and(
+    eq(chatSessionContexts.sessionId, sessionId),
+    scope.orgId ? eq(chatSessionContexts.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessionContexts.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+function resourceWhere(scope: ChatSessionContextResourceScope) {
+  return and(
+    eq(chatSessionContexts.resourceType, scope.resourceType),
+    eq(chatSessionContexts.resourceId, scope.resourceId),
+    scope.orgId ? eq(chatSessionContexts.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessionContexts.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+export class SqliteChatSessionContextRepository implements IChatSessionContextRepository {
+  constructor(private readonly db: SqliteClient) {}
+
+  async create(
+    context: Parameters<IChatSessionContextRepository['create']>[0],
+  ): Promise<ChatSessionContext> {
+    const [row] = await this.db
+      .insert(chatSessionContexts)
+      .values({
+        id: context.id ?? `chatctx_${randomUUID()}`,
+        sessionId: context.sessionId,
+        orgId: context.orgId,
+        ownerUserId: context.ownerUserId,
+        resourceType: context.resourceType,
+        resourceId: context.resourceId,
+        relation: context.relation,
+        createdAt: context.createdAt ?? new Date().toISOString(),
+      })
+      .returning();
+    return rowToContext(row!);
+  }
+
+  async listBySession(
+    sessionId: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSessionContext[]> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionContexts)
+      .where(sessionWhere(sessionId, scope))
+      .orderBy(desc(chatSessionContexts.createdAt));
+    return rows.map(rowToContext);
+  }
+
+  async listByResource(
+    scope: ChatSessionContextResourceScope,
+    limit = 50,
+  ): Promise<ChatSessionContext[]> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionContexts)
+      .where(resourceWhere(scope))
+      .orderBy(desc(chatSessionContexts.createdAt))
+      .limit(limit);
+    return rows.map(rowToContext);
+  }
+
+  async deleteBySession(
+    sessionId: string,
+    scope: ChatSessionScope = {},
+  ): Promise<void> {
+    await this.db
+      .delete(chatSessionContexts)
+      .where(sessionWhere(sessionId, scope));
+  }
+}

--- a/packages/data-layer/src/repository/sqlite/chat-session.test.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { createTestDb } from '../../test-support/test-db.js';
+import { SqliteChatSessionRepository } from './chat-session.js';
+import { SqliteChatSessionContextRepository } from './chat-session-context.js';
+
+describe('SqliteChatSessionRepository', () => {
+  let db: SqliteClient;
+  let sessions: SqliteChatSessionRepository;
+  let contexts: SqliteChatSessionContextRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    sessions = new SqliteChatSessionRepository(db);
+    contexts = new SqliteChatSessionContextRepository(db);
+  });
+
+  it('scopes sessions by org and owner when requested', async () => {
+    await sessions.create({
+      id: 's-a',
+      orgId: 'org-1',
+      ownerUserId: 'user-a',
+      title: 'A',
+    });
+    await sessions.create({
+      id: 's-b',
+      orgId: 'org-1',
+      ownerUserId: 'user-b',
+      title: 'B',
+    });
+    await sessions.create({
+      id: 's-c',
+      orgId: 'org-2',
+      ownerUserId: 'user-a',
+      title: 'C',
+    });
+
+    expect(
+      await sessions.findById('s-a', { orgId: 'org-1', ownerUserId: 'user-a' }),
+    ).toMatchObject({
+      id: 's-a',
+      ownerUserId: 'user-a',
+    });
+    expect(
+      await sessions.findById('s-a', { orgId: 'org-1', ownerUserId: 'user-b' }),
+    ).toBeUndefined();
+    expect(
+      (
+        await sessions.findAll(10, { orgId: 'org-1', ownerUserId: 'user-a' })
+      ).map((s) => s.id),
+    ).toEqual(['s-a']);
+  });
+
+  it('keeps unowned sessions readable through legacy unscoped lookups', async () => {
+    const created = await sessions.create({ id: 'legacy', orgId: 'org-1' });
+
+    expect(created.ownerUserId).toBeUndefined();
+    expect(await sessions.findById('legacy')).toMatchObject({ id: 'legacy' });
+    expect(
+      await sessions.findById('legacy', {
+        orgId: 'org-1',
+        ownerUserId: 'user-a',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('stores and filters resource contexts by owner', async () => {
+    await sessions.create({ id: 's-a', orgId: 'org-1', ownerUserId: 'user-a' });
+    await sessions.create({ id: 's-b', orgId: 'org-1', ownerUserId: 'user-b' });
+    await contexts.create({
+      id: 'ctx-a',
+      sessionId: 's-a',
+      orgId: 'org-1',
+      ownerUserId: 'user-a',
+      resourceType: 'dashboard',
+      resourceId: 'dash-1',
+      relation: 'created_from_chat',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    await contexts.create({
+      id: 'ctx-b',
+      sessionId: 's-b',
+      orgId: 'org-1',
+      ownerUserId: 'user-b',
+      resourceType: 'dashboard',
+      resourceId: 'dash-1',
+      relation: 'viewed_with_chat',
+      createdAt: '2026-05-01T00:01:00.000Z',
+    });
+
+    expect(
+      (
+        await contexts.listBySession('s-a', {
+          orgId: 'org-1',
+          ownerUserId: 'user-a',
+        })
+      ).map((c) => c.id),
+    ).toEqual(['ctx-a']);
+    expect(
+      (
+        await contexts.listByResource({
+          orgId: 'org-1',
+          ownerUserId: 'user-b',
+          resourceType: 'dashboard',
+          resourceId: 'dash-1',
+        })
+      ).map((c) => c.id),
+    ).toEqual(['ctx-b']);
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/chat-session.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session.ts
@@ -2,7 +2,10 @@ import { and, eq, desc } from 'drizzle-orm';
 import type { ChatSession } from '@agentic-obs/common';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { chatSessions } from '../../db/sqlite-schema.js';
-import type { IChatSessionRepository } from '../interfaces.js';
+import type {
+  ChatSessionScope,
+  IChatSessionRepository,
+} from '../interfaces.js';
 
 type DbRow = typeof chatSessions.$inferSelect;
 
@@ -11,16 +14,41 @@ function rowToSession(row: DbRow): ChatSession {
     id: row.id,
     title: row.title,
     orgId: row.orgId,
+    ...(row.ownerUserId ? { ownerUserId: row.ownerUserId } : {}),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(row.contextSummary ? { contextSummary: row.contextSummary } : {}),
   };
 }
 
+function sessionWhere(id: string, scope: ChatSessionScope = {}) {
+  return and(
+    eq(chatSessions.id, id),
+    scope.orgId ? eq(chatSessions.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessions.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
+function scopeWhere(scope: ChatSessionScope = {}) {
+  return and(
+    scope.orgId ? eq(chatSessions.orgId, scope.orgId) : undefined,
+    scope.ownerUserId
+      ? eq(chatSessions.ownerUserId, scope.ownerUserId)
+      : undefined,
+  );
+}
+
 export class SqliteChatSessionRepository implements IChatSessionRepository {
   constructor(private readonly db: SqliteClient) {}
 
-  async create(session: { id: string; title?: string; orgId?: string }): Promise<ChatSession> {
+  async create(session: {
+    id: string;
+    title?: string;
+    orgId?: string;
+    ownerUserId?: string;
+  }): Promise<ChatSession> {
     const now = new Date().toISOString();
     const [row] = await this.db
       .insert(chatSessions)
@@ -28,6 +56,7 @@ export class SqliteChatSessionRepository implements IChatSessionRepository {
         id: session.id,
         title: session.title ?? '',
         orgId: session.orgId ?? 'org_main',
+        ownerUserId: session.ownerUserId ?? null,
         createdAt: now,
         updatedAt: now,
       })
@@ -35,51 +64,63 @@ export class SqliteChatSessionRepository implements IChatSessionRepository {
     return rowToSession(row!);
   }
 
-  async findById(id: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
-    const [row] = await this.db.select().from(chatSessions).where(where);
+  async findById(
+    id: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(chatSessions)
+      .where(sessionWhere(id, scope));
     return row ? rowToSession(row) : undefined;
   }
 
-  async findAll(limit = 50, scope: { orgId?: string } = {}): Promise<ChatSession[]> {
+  async findAll(
+    limit = 50,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession[]> {
     const base = this.db.select().from(chatSessions);
-    const rows = scope.orgId
+    const where = scopeWhere(scope);
+    const rows = where
       ? await base
-          .where(eq(chatSessions.orgId, scope.orgId))
+          .where(where)
           .orderBy(desc(chatSessions.updatedAt))
           .limit(limit)
       : await base.orderBy(desc(chatSessions.updatedAt)).limit(limit);
     return rows.map(rowToSession);
   }
 
-  async updateTitle(id: string, title: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
+  async updateTitle(
+    id: string,
+    title: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
     const [row] = await this.db
       .update(chatSessions)
       .set({ title, updatedAt: new Date().toISOString() })
-      .where(where)
+      .where(sessionWhere(id, scope))
       .returning();
     return row ? rowToSession(row) : undefined;
   }
 
-  async updateContextSummary(id: string, summary: string, scope: { orgId?: string } = {}): Promise<ChatSession | undefined> {
-    const where = scope.orgId
-      ? and(eq(chatSessions.id, id), eq(chatSessions.orgId, scope.orgId))
-      : eq(chatSessions.id, id);
+  async updateContextSummary(
+    id: string,
+    summary: string,
+    scope: ChatSessionScope = {},
+  ): Promise<ChatSession | undefined> {
     const [row] = await this.db
       .update(chatSessions)
       .set({ contextSummary: summary, updatedAt: new Date().toISOString() })
-      .where(where)
+      .where(sessionWhere(id, scope))
       .returning();
     return row ? rowToSession(row) : undefined;
   }
 
-  async delete(id: string): Promise<boolean> {
-    const result = await this.db.delete(chatSessions).where(eq(chatSessions.id, id)).returning();
+  async delete(id: string, scope: ChatSessionScope = {}): Promise<boolean> {
+    const result = await this.db
+      .delete(chatSessions)
+      .where(sessionWhere(id, scope))
+      .returning();
     return result.length > 0;
   }
 }

--- a/packages/data-layer/src/repository/sqlite/dashboard.test.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard.test.ts
@@ -25,7 +25,6 @@ describe('DashboardRepository', () => {
       useExistingMetrics: false,
       folder: 'prod',
       workspaceId: 'ws-1',
-      sessionId: 'sess-7',
     });
 
     expect(d.id).toMatch(/^[0-9a-f-]{36}$/i);
@@ -38,7 +37,6 @@ describe('DashboardRepository', () => {
     expect(d.useExistingMetrics).toBe(false);
     expect(d.folder).toBe('prod');
     expect(d.workspaceId).toBe('ws-1');
-    expect(d.sessionId).toBe('sess-7');
     expect(d.createdAt).toEqual(d.updatedAt);
 
     const fetched = await repo.findById(d.id);
@@ -58,7 +56,6 @@ describe('DashboardRepository', () => {
     expect(d.datasourceIds).toEqual([]);
     expect(d.folder).toBeUndefined();
     expect(d.workspaceId).toBeUndefined();
-    expect(d.sessionId).toBeUndefined();
   });
 
   // -- missing-id lookup --

--- a/packages/data-layer/src/repository/sqlite/dashboard.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard.ts
@@ -65,7 +65,6 @@ interface DashboardRow {
   folder: string | null;
   workspace_id: string | null;
   org_id: string;
-  session_id: string | null;
   version: number | null;
   publish_status: string | null;
   error: string | null;
@@ -115,7 +114,6 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   };
   if (r.folder !== null) base.folder = r.folder;
   if (r.workspace_id !== null) base.workspaceId = r.workspace_id;
-  if (r.session_id !== null) base.sessionId = r.session_id;
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
@@ -140,7 +138,7 @@ export class DashboardRepository implements IDashboardRepository {
       INSERT INTO dashboards (
         id, type, title, description, prompt, user_id, status,
         panels, variables, refresh_interval_sec, datasource_ids,
-        use_existing_metrics, folder, workspace_id, session_id,
+        use_existing_metrics, folder, workspace_id,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -157,7 +155,6 @@ export class DashboardRepository implements IDashboardRepository {
         ${useExistingMetrics},
         ${input.folder ?? null},
         ${input.workspaceId ?? null},
-        ${input.sessionId ?? null},
         ${now},
         ${now}
       )
@@ -322,7 +319,7 @@ export class DashboardRepository implements IDashboardRepository {
         INSERT INTO dashboards (
           id, type, title, description, prompt, user_id, status,
           panels, variables, refresh_interval_sec, datasource_ids,
-          use_existing_metrics, folder, workspace_id, session_id,
+          use_existing_metrics, folder, workspace_id,
           version, publish_status, error, created_at, updated_at
         ) VALUES (
           ${raw.id},
@@ -339,7 +336,6 @@ export class DashboardRepository implements IDashboardRepository {
           ${fromBool(raw.useExistingMetrics, true)},
           ${raw.folder ?? null},
           ${raw.workspaceId ?? null},
-          ${raw.sessionId ?? null},
           ${raw.version ?? null},
           ${raw.publishStatus ?? null},
           ${raw.error ?? null},
@@ -360,7 +356,6 @@ export class DashboardRepository implements IDashboardRepository {
           use_existing_metrics = excluded.use_existing_metrics,
           folder               = excluded.folder,
           workspace_id         = excluded.workspace_id,
-          session_id           = excluded.session_id,
           version              = excluded.version,
           publish_status       = excluded.publish_status,
           error                = excluded.error,

--- a/packages/data-layer/src/repository/sqlite/index.ts
+++ b/packages/data-layer/src/repository/sqlite/index.ts
@@ -14,6 +14,7 @@ export { SqliteNotificationRepository } from './notification.js';
 export { SqliteVersionRepository } from './version.js';
 export { SqliteCaseRepository } from './case.js';
 export { SqliteChatSessionRepository } from './chat-session.js';
+export { SqliteChatSessionContextRepository } from './chat-session-context.js';
 export { SqliteChatMessageRepository } from './chat-message.js';
 export { SqliteChatSessionEventRepository } from './chat-session-event.js';
 

--- a/packages/data-layer/src/stores/dashboard-store.ts
+++ b/packages/data-layer/src/stores/dashboard-store.ts
@@ -27,7 +27,6 @@ export class DashboardStore implements Persistable {
     useExistingMetrics?: boolean
     folder?: string
     workspaceId?: string
-    sessionId?: string
   }): Dashboard {
     const now = new Date().toISOString()
     const id = uid()
@@ -47,7 +46,6 @@ export class DashboardStore implements Persistable {
       useExistingMetrics: params.useExistingMetrics ?? true,
       ...(params.folder !== undefined ? { folder: params.folder } : {}),
       ...(params.workspaceId !== undefined ? { workspaceId: params.workspaceId } : {}),
-      ...(params.sessionId !== undefined ? { sessionId: params.sessionId } : {}),
       createdAt: now,
       updatedAt: now,
     }

--- a/packages/data-layer/src/stores/interfaces.ts
+++ b/packages/data-layer/src/stores/interfaces.ts
@@ -152,7 +152,6 @@ export interface IGatewayDashboardStore {
     useExistingMetrics?: boolean
     folder?: string
     workspaceId?: string
-    sessionId?: string
   }): MaybeAsync<Dashboard>
   findById(id: string): MaybeAsync<Dashboard | undefined>
   findAll(userId?: string): MaybeAsync<Dashboard[]>

--- a/packages/web/src/api/schemas.ts
+++ b/packages/web/src/api/schemas.ts
@@ -184,7 +184,6 @@ export const DashboardSchema = z
     useExistingMetrics: z.boolean().optional(),
     folder: z.string().optional(),
     workspaceId: z.string().optional(),
-    sessionId: z.string().optional(),
     version: z.number().optional(),
     publishStatus: z.enum(['draft', 'published', 'archived']).optional(),
     createdAt: z.string(),

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import Navigation from './Navigation.js';
 import GlobalSearch from './GlobalSearch.js';
@@ -8,18 +8,71 @@ import { ChatProvider, useGlobalChat } from '../contexts/ChatContext.js';
 function LayoutInner() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { events, isGenerating, sendMessage, stopGeneration, pendingNavigation, clearPendingNavigation, loadError, retryLoadSession } = useGlobalChat();
+  const {
+    events,
+    isGenerating,
+    sendMessage,
+    stopGeneration,
+    pendingNavigation,
+    clearPendingNavigation,
+    loadError,
+    retryLoadSession,
+    loadSession,
+    currentSessionId,
+    startNewSession,
+  } = useGlobalChat();
+  const loadedUrlChatRef = useRef<string | null>(null);
 
   // Hide the global ChatPanel on Home, the top-level list pages
   // (Dashboards / Investigations / Alerts), and configuration surfaces
   // (Settings, Admin). Detail pages keep the panel because that's
   // where a context-specific chat is actually useful.
   const pathname = location.pathname;
-  const chatHiddenExact = new Set(['/', '/dashboards', '/investigations', '/alerts']);
+  const chatHiddenExact = new Set([
+    '/',
+    '/dashboards',
+    '/investigations',
+    '/alerts',
+  ]);
   const chatHiddenPrefix = ['/settings', '/admin'];
   const showChat =
-    !chatHiddenExact.has(pathname)
-    && !chatHiddenPrefix.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+    !chatHiddenExact.has(pathname) &&
+    !chatHiddenPrefix.some(
+      (p) => pathname === p || pathname.startsWith(`${p}/`),
+    );
+
+  // URL chat identity is canonical on resource pages. Loading here keeps
+  // dashboards, investigations, and future resource details on the same path.
+  useEffect(() => {
+    const chatId = new URLSearchParams(location.search).get('chat');
+    if (!chatId) {
+      if (showChat) {
+        loadedUrlChatRef.current = null;
+        startNewSession();
+      }
+      return;
+    }
+    if (loadedUrlChatRef.current === chatId) return;
+    loadedUrlChatRef.current = chatId;
+    void loadSession(chatId);
+  }, [location.search, loadSession, showChat, startNewSession]);
+
+  useEffect(() => {
+    if (!showChat || !currentSessionId) return;
+    const params = new URLSearchParams(location.search);
+    if (params.get('chat') === currentSessionId) return;
+    params.set('chat', currentSessionId);
+    navigate(
+      { pathname: location.pathname, search: `?${params.toString()}` },
+      { replace: true },
+    );
+  }, [
+    currentSessionId,
+    location.pathname,
+    location.search,
+    navigate,
+    showChat,
+  ]);
 
   // Handle agent-initiated navigation
   useEffect(() => {

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -28,9 +28,9 @@ export interface UseChatResult {
   clearPendingNavigation: () => void;
   /** Set the current page context — agent uses this to know which resource the user is viewing. */
   setPageContext: (ctx: PageContext | null) => void;
-  /** Current session ID (readonly). */
+  /** Current durable session ID (readonly). Empty until the server creates one. */
   currentSessionId: string;
-  /** Clear messages/events, generate a new sessionId, persist to localStorage. */
+  /** Clear messages/events and start an unsaved draft session. */
   startNewSession: () => void;
   /** Load a session's messages from the backend. Handles 404 gracefully. */
   loadSession: (sessionId: string) => Promise<void>;
@@ -59,40 +59,65 @@ function payloadToChatEvent(
 ): ChatEvent | null {
   switch (kind) {
     case 'thinking':
-      return { id, kind: 'thinking', content: (payload.content as string) ?? 'Thinking...' };
+      return {
+        id,
+        kind: 'thinking',
+        content: (payload.content as string) ?? 'Thinking...',
+      };
     case 'tool_call':
       return {
         id,
         kind: 'tool_call',
         tool: payload.tool as string | undefined,
-        content: (payload.displayText as string) ?? (payload.content as string) ?? '',
+        content:
+          (payload.displayText as string) ?? (payload.content as string) ?? '',
       };
     case 'tool_result':
       return {
         id,
         kind: 'tool_result',
         tool: payload.tool as string | undefined,
-        content: (payload.summary as string) ?? (payload.content as string) ?? '',
+        content:
+          (payload.summary as string) ?? (payload.content as string) ?? '',
         success: payload.success !== false,
       };
     case 'panel_added':
-      return { id, kind: 'panel_added', panel: payload.panel as ChatEvent['panel'] };
+      return {
+        id,
+        kind: 'panel_added',
+        panel: payload.panel as ChatEvent['panel'],
+      };
     case 'panel_removed':
-      return { id, kind: 'panel_removed', panelId: payload.panelId as string | undefined };
+      return {
+        id,
+        kind: 'panel_removed',
+        panelId: payload.panelId as string | undefined,
+      };
     case 'panel_modified':
-      return { id, kind: 'panel_modified', panelId: payload.panelId as string | undefined };
+      return {
+        id,
+        kind: 'panel_modified',
+        panelId: payload.panelId as string | undefined,
+      };
     case 'ask_user': {
       const { question, options } = parseAskUserPayload(payload);
       return { id, kind: 'ask_user', question, options };
     }
     case 'ds_choice': {
-      const chosenId = typeof payload.chosenId === 'string' ? payload.chosenId : '';
+      const chosenId =
+        typeof payload.chosenId === 'string' ? payload.chosenId : '';
       const chosenName = typeof payload.name === 'string' ? payload.name : '';
-      const chooseReason = typeof payload.reason === 'string' ? payload.reason : '';
-      const confidence = (payload.confidence === 'high' || payload.confidence === 'medium' || payload.confidence === 'low')
-        ? payload.confidence
-        : 'low';
-      const rawAlts = Array.isArray(payload.alternatives) ? payload.alternatives : [];
+      const chooseReason =
+        typeof payload.reason === 'string' ? payload.reason : '';
+      const confidence =
+        payload.confidence === 'high' ||
+        payload.confidence === 'medium' ||
+        payload.confidence === 'low'
+          ? payload.confidence
+          : 'low';
+      const rawAlts = Array.isArray(payload.alternatives)
+        ? payload.alternatives
+        : [];
       const alternatives = rawAlts
         .map((a) => {
           if (!a || typeof a !== 'object') return null;
@@ -100,25 +125,53 @@ function payloadToChatEvent(
           const aid = typeof obj.id === 'string' ? obj.id : '';
           const name = typeof obj.name === 'string' ? obj.name : '';
           if (!aid || !name) return null;
-          const env = typeof obj.environment === 'string' ? obj.environment : undefined;
-          const cluster = typeof obj.cluster === 'string' ? obj.cluster : undefined;
-          return { id: aid, name, ...(env ? { environment: env } : {}), ...(cluster ? { cluster } : {}) };
+          const env =
+            typeof obj.environment === 'string' ? obj.environment : undefined;
+          const cluster =
+            typeof obj.cluster === 'string' ? obj.cluster : undefined;
+          return {
+            id: aid,
+            name,
+            ...(env ? { environment: env } : {}),
+            ...(cluster ? { cluster } : {}),
+          };
         })
         .filter((a): a is NonNullable<typeof a> => a !== null);
-      return { id, kind: 'ds_choice', chosenId, chosenName, chooseReason, confidence, alternatives };
+      return {
+        id,
+        kind: 'ds_choice',
+        chosenId,
+        chosenName,
+        chooseReason,
+        confidence,
+        alternatives,
+      };
     }
     case 'error':
       return {
         id,
         kind: 'error',
         content:
-          (payload.message as string) ?? (payload.content as string) ?? 'An error occurred',
+          (payload.message as string) ??
+          (payload.content as string) ??
+          'An error occurred',
       };
     default:
       // Kinds we intentionally don't replay: variable_added / investigation_report
       // are reflected in dashboard state, not chat history; agent_event /
       // verification_report / approval_required aren't currently rendered.
       return null;
+  }
+}
+
+function withChatQuery(path: string, sessionId: string): string {
+  if (!sessionId || !path.startsWith('/')) return path;
+  try {
+    const url = new URL(path, window.location.origin);
+    url.searchParams.set('chat', sessionId);
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return path;
   }
 }
 
@@ -130,8 +183,12 @@ export function useChat(): UseChatResult {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [events, setEvents] = useState<ChatEvent[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [pendingNavigation, setPendingNavigation] = useState<string | null>(null);
-  const [loadError, setLoadError] = useState<'not-found' | 'network' | null>(null);
+  const [pendingNavigation, setPendingNavigation] = useState<string | null>(
+    null,
+  );
+  const [loadError, setLoadError] = useState<'not-found' | 'network' | null>(
+    null,
+  );
   const lastLoadSessionIdRef = useRef<string | null>(null);
   // Monotonic token bumped on every loadSession() call. A stale completion
   // (slow network) checks this against its captured token and bails if a
@@ -141,14 +198,18 @@ export function useChat(): UseChatResult {
   const pageContextRef = useRef<PageContext | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const [currentSessionId, setCurrentSessionId] = useState<string>(
-    () => localStorage.getItem('chat_session_id') ?? `ses_${crypto.randomUUID()}`,
+    () => localStorage.getItem('chat_session_id') ?? '',
   );
   const sessionIdRef = useRef<string>(currentSessionId);
 
   // Keep ref in sync with state
   useEffect(() => {
     sessionIdRef.current = currentSessionId;
-    localStorage.setItem('chat_session_id', currentSessionId);
+    if (currentSessionId) {
+      localStorage.setItem('chat_session_id', currentSessionId);
+    } else {
+      localStorage.removeItem('chat_session_id');
+    }
   }, [currentSessionId]);
 
   const appendEvent = useCallback((evt: ChatEvent) => {
@@ -190,7 +251,10 @@ export function useChat(): UseChatResult {
             id,
             kind: 'tool_call',
             tool: parsed.tool as string | undefined,
-            content: (parsed.displayText as string) ?? (parsed.content as string) ?? '',
+            content:
+              (parsed.displayText as string) ??
+              (parsed.content as string) ??
+              '',
           });
           break;
         }
@@ -200,31 +264,44 @@ export function useChat(): UseChatResult {
             id,
             kind: 'tool_result',
             tool: parsed.tool as string | undefined,
-            content: (parsed.summary as string) ?? (parsed.content as string) ?? '',
+            content:
+              (parsed.summary as string) ?? (parsed.content as string) ?? '',
             success: parsed.success !== false,
           });
           break;
         }
 
         case 'panel_added': {
-          appendEvent({ id, kind: 'panel_added', panel: parsed.panel as ChatEvent['panel'] });
+          appendEvent({
+            id,
+            kind: 'panel_added',
+            panel: parsed.panel as ChatEvent['panel'],
+          });
           break;
         }
 
         case 'panel_removed': {
-          appendEvent({ id, kind: 'panel_removed', panelId: parsed.panelId as string | undefined });
+          appendEvent({
+            id,
+            kind: 'panel_removed',
+            panelId: parsed.panelId as string | undefined,
+          });
           break;
         }
 
         case 'panel_modified': {
-          appendEvent({ id, kind: 'panel_modified', panelId: parsed.panelId as string | undefined });
+          appendEvent({
+            id,
+            kind: 'panel_modified',
+            panelId: parsed.panelId as string | undefined,
+          });
           break;
         }
 
         case 'navigate': {
           const path = (parsed.path as string) ?? '';
           if (path) {
-            setPendingNavigation(path);
+            setPendingNavigation(withChatQuery(path, sessionIdRef.current));
           }
           break;
         }
@@ -255,10 +332,24 @@ export function useChat(): UseChatResult {
         }
 
         case 'done': {
+          const durableSessionId =
+            typeof parsed.sessionId === 'string' && parsed.sessionId.trim()
+              ? parsed.sessionId.trim()
+              : '';
+          if (durableSessionId && durableSessionId !== sessionIdRef.current) {
+            sessionIdRef.current = durableSessionId;
+            setCurrentSessionId(durableSessionId);
+          }
+
           // Check if done carries a navigate directive as well
           const navigateTo = parsed.navigate as string | undefined;
           if (navigateTo) {
-            setPendingNavigation(navigateTo);
+            setPendingNavigation(
+              withChatQuery(
+                navigateTo,
+                durableSessionId || sessionIdRef.current,
+              ),
+            );
           }
           appendEvent({ id, kind: 'done', content: 'Generation complete' });
           break;
@@ -266,7 +357,9 @@ export function useChat(): UseChatResult {
 
         case 'error': {
           const content =
-            (parsed.message as string) ?? (parsed.content as string) ?? 'An error occurred';
+            (parsed.message as string) ??
+            (parsed.content as string) ??
+            'An error occurred';
           appendEvent({ id, kind: 'error', content });
           break;
         }
@@ -303,11 +396,12 @@ export function useChat(): UseChatResult {
         const ctxWithTz = pageContextRef.current
           ? { ...pageContextRef.current, clientTimezone: tz }
           : { kind: 'home', clientTimezone: tz };
+        const sid = sessionIdRef.current;
         await apiClient.postStream(
           '/chat',
           {
             message: content,
-            sessionId: sessionIdRef.current,
+            ...(sid ? { sessionId: sid } : {}),
             pageContext: ctxWithTz,
           },
           handleSSEEvent,
@@ -357,6 +451,7 @@ export function useChat(): UseChatResult {
   }, [appendEvent]);
 
   const startNewSession = useCallback(() => {
+    loadTokenRef.current += 1;
     abortRef.current?.abort();
     abortRef.current = null;
     setMessages([]);
@@ -367,8 +462,7 @@ export function useChat(): UseChatResult {
     // banner would otherwise sit on top of a fresh empty chat.
     setLoadError(null);
     lastLoadSessionIdRef.current = null;
-    const newId = `ses_${crypto.randomUUID()}`;
-    setCurrentSessionId(newId);
+    setCurrentSessionId('');
   }, []);
 
   const loadSession = useCallback(async (sessionId: string) => {
@@ -390,7 +484,13 @@ export function useChat(): UseChatResult {
       const res = await apiClient.get<{
         sessionId: string;
         messages: ChatMessage[];
-        events?: Array<{ id: string; seq: number; kind: string; payload: Record<string, unknown>; timestamp: string }>;
+        events?: Array<{
+          id: string;
+          seq: number;
+          kind: string;
+          payload: Record<string, unknown>;
+          timestamp: string;
+        }>;
       }>(`/chat/sessions/${sessionId}/messages`);
 
       if (token !== loadTokenRef.current) {
@@ -405,14 +505,17 @@ export function useChat(): UseChatResult {
         // Distinguish 404 (the session genuinely doesn't exist on the server)
         // from any other failure (5xx, transport, etc.) so the UI can render
         // the right empty-state instead of a blank chat with no signal.
-        const errStatus = Number((res.error as unknown as Record<string, unknown>).status);
+        const errStatus = Number(
+          (res.error as unknown as Record<string, unknown>).status,
+        );
         const code = res.error.code ?? '';
         const msg = res.error.message ?? '';
         const is404 =
-          errStatus === 404 ||
-          code === 'NOT_FOUND' ||
-          /not\s*found/i.test(msg);
-        console.error('[useChat] loadSession failed', { sessionId, error: res.error });
+          errStatus === 404 || code === 'NOT_FOUND' || /not\s*found/i.test(msg);
+        console.error('[useChat] loadSession failed', {
+          sessionId,
+          error: res.error,
+        });
         setLoadError(is404 ? 'not-found' : 'network');
         return;
       }
@@ -440,7 +543,14 @@ export function useChat(): UseChatResult {
       }
       for (const raw of res.data.events ?? []) {
         const evt = payloadToChatEvent(raw.id, raw.kind, raw.payload);
-        if (evt) entries.push({ kind: 'evt', ts: raw.timestamp, seq: raw.seq, id: raw.id, evt });
+        if (evt)
+          entries.push({
+            kind: 'evt',
+            ts: raw.timestamp,
+            seq: raw.seq,
+            id: raw.id,
+            evt,
+          });
       }
       entries.sort((a, b) => {
         if (a.ts !== b.ts) return a.ts < b.ts ? -1 : 1;

--- a/packages/web/src/hooks/useDashboardChat.ts
+++ b/packages/web/src/hooks/useDashboardChat.ts
@@ -159,7 +159,6 @@ export function useDashboardChat(
   initialPanels: PanelConfig[],
   initialVariables: DashboardVariable[] = [],
   timeRange = '1h',
-  sessionId?: string,
 ): UseDashboardChatResult {
   const navigate = useNavigate();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -169,7 +168,6 @@ export function useDashboardChat(
   const [panels, setPanels] = useState<PanelConfig[]>(initialPanels);
   const [variables, setVariables] = useState<DashboardVariable[]>(initialVariables);
   const abortRef = useRef<AbortController | null>(null);
-  const historyLoadedRef = useRef(false);
 
   // Track whether SSE has modified panels during this generation cycle
   const sseModifiedRef = useRef(false);
@@ -189,47 +187,14 @@ export function useDashboardChat(
     }
   }, [initialPanels, isGenerating]);
 
-  // Load chat history from the chat-service session messages endpoint on
-  // mount / dashboard change. Without a sessionId there is no history to load,
-  // so the hook initializes empty messages/events for the new dashboard.
+  // Resource pages do not own chat history. The global personal chat loads
+  // history from `?chat=...`; this hook only tracks the live dashboard stream.
   useEffect(() => {
     if (!dashboardId) return;
-    historyLoadedRef.current = false;
     setMessages([]);
     setEvents([]);
     setInvestigationReport(null);
-    let cancelled = false;
-    void (async () => {
-      const chatPromise = sessionId
-        ? apiClient.get<{ messages: ChatMessage[] }>(`/chat/sessions/${sessionId}/messages`)
-        : Promise.resolve({ data: { messages: [] }, error: null } as { data: { messages: ChatMessage[] } | null; error: null | { code: string; message?: string } });
-      const chatRes = await chatPromise;
-      if (cancelled) return;
-      const loadedMessages = chatRes.data?.messages ?? [];
-      if (loadedMessages.length) {
-        setMessages(loadedMessages);
-        setEvents((prev) => {
-          // If events were already added (e.g. initial prompt), prepend history before them
-          if (prev.length > 0) {
-            const existingIds = new Set(prev.map((e) => e.id));
-            const historyEvents = loadedMessages
-              .filter((m) => !existingIds.has(m.id))
-              .map((m) => ({ id: m.id, kind: 'message' as const, message: m }));
-            return [...historyEvents, ...prev];
-          }
-          return loadedMessages.map((m) => ({
-            id: m.id,
-            kind: 'message' as const,
-            message: m,
-          }));
-        });
-      }
-      historyLoadedRef.current = true;
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [dashboardId, sessionId]);
+  }, [dashboardId]);
 
   const appendEvent = useCallback((evt: ChatEvent) => {
     setEvents((prev) => [...prev, evt]);
@@ -425,16 +390,13 @@ export function useDashboardChat(
       setIsGenerating(true);
 
       try {
-        // Route through the canonical chat-service endpoint. The dashboard is
-        // identified through `pageContext` so the orchestrator scopes its
-        // dashboard.* tools to it; the legacy POST /api/dashboards/:id/chat
-        // path was removed.
+        // Route through the canonical personal chat endpoint. The dashboard is
+        // identified through page context only.
         const tr = resolveChatTimeRange(timeRange);
         await apiClient.postStream(
           `/chat`,
           {
             message: content,
-            ...(sessionId ? { sessionId } : {}),
             pageContext: { kind: 'dashboard', id: dashboardId, timeRange },
             timeRange: tr,
           },
@@ -450,7 +412,7 @@ export function useDashboardChat(
         setIsGenerating(false);
       }
     },
-    [dashboardId, sessionId, isGenerating, handleSSEEvent, appendEvent, timeRange],
+    [dashboardId, isGenerating, handleSSEEvent, appendEvent, timeRange],
   );
 
   const stopGeneration = useCallback(() => {

--- a/packages/web/src/pages/DashboardWorkspace.tsx
+++ b/packages/web/src/pages/DashboardWorkspace.tsx
@@ -32,7 +32,6 @@ interface Dashboard {
   createdAt: string;
   updatedAt?: string;
   folder?: string;
-  sessionId?: string;
 }
 
 // Main
@@ -41,7 +40,8 @@ export default function DashboardWorkspace() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const initialPrompt = (location.state as { initialPrompt?: string } | null)?.initialPrompt;
+  const initialPrompt = (location.state as { initialPrompt?: string } | null)
+    ?.initialPrompt;
   const initialPromptSent = useRef(false);
 
   const { user, hasPermission } = useAuth();
@@ -51,22 +51,31 @@ export default function DashboardWorkspace() {
   // check shape (`dashboards:uid:<id>`) so UI hides what the server would
   // 403 anyway.
   const canEditDashboard =
-    !!user
-    && (user.isServerAdmin
-      || hasPermission('dashboards:write', id ? `dashboards:uid:${id}` : undefined)
-      || hasPermission('dashboards:write'));
+    !!user &&
+    (user.isServerAdmin ||
+      hasPermission(
+        'dashboards:write',
+        id ? `dashboards:uid:${id}` : undefined,
+      ) ||
+      hasPermission('dashboards:write'));
   const canDeleteDashboard =
-    !!user
-    && (user.isServerAdmin
-      || hasPermission('dashboards:delete', id ? `dashboards:uid:${id}` : undefined)
-      || hasPermission('dashboards:delete'));
+    !!user &&
+    (user.isServerAdmin ||
+      hasPermission(
+        'dashboards:delete',
+        id ? `dashboards:uid:${id}` : undefined,
+      ) ||
+      hasPermission('dashboards:delete'));
   // Managing per-dashboard ACLs requires `dashboards.permissions:read` (to open
   // the dialog) — Admin-only grant. Hide the button for everyone below.
   const canManagePermissions =
-    !!user
-    && (user.isServerAdmin
-      || hasPermission('dashboards.permissions:read', id ? `dashboards:uid:${id}` : undefined)
-      || hasPermission('dashboards.permissions:read'));
+    !!user &&
+    (user.isServerAdmin ||
+      hasPermission(
+        'dashboards.permissions:read',
+        id ? `dashboards:uid:${id}` : undefined,
+      ) ||
+      hasPermission('dashboards.permissions:read'));
 
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [loading, setLoading] = useState(true);
@@ -91,10 +100,18 @@ export default function DashboardWorkspace() {
 
   const loadDashboard = useCallback(async () => {
     if (!id) return;
-    const res = await apiClient.getValidated<Dashboard>(`/dashboards/${id}`, DashboardSchema, 'Dashboard');
-    const errStatus = Number((res.error as Record<string, unknown> | undefined)?.status);
+    const res = await apiClient.getValidated<Dashboard>(
+      `/dashboards/${id}`,
+      DashboardSchema,
+      'Dashboard',
+    );
+    const errStatus = Number(
+      (res.error as Record<string, unknown> | undefined)?.status,
+    );
     const isTransient =
-      !!res.error && (res.error.code === 'RATE_LIMITED' || (!Number.isNaN(errStatus) && errStatus >= 500));
+      !!res.error &&
+      (res.error.code === 'RATE_LIMITED' ||
+        (!Number.isNaN(errStatus) && errStatus >= 500));
 
     if (isTransient) {
       if (dashboardLoadedRef.current) {
@@ -137,7 +154,7 @@ export default function DashboardWorkspace() {
   // Chat / SSE
   const {
     events,
-    isGenerating,
+    isGenerating: dashboardChatGenerating,
     sendMessage,
     stopGeneration,
     panels,
@@ -145,43 +162,39 @@ export default function DashboardWorkspace() {
     setPanels,
     setVariables,
     investigationReport,
-  } = useDashboardChat(id ?? '', dashboard?.panels ?? [], dashboard?.variables ?? [], timeRange, dashboard?.sessionId);
+  } = useDashboardChat(
+    id ?? '',
+    dashboard?.panels ?? [],
+    dashboard?.variables ?? [],
+    timeRange,
+  );
   const [showReport, setShowReport] = useState(false);
   const globalChat = useGlobalChat();
+  const isGenerating = dashboardChatGenerating || globalChat.isGenerating;
 
   // Tell the global chat which dashboard the user is viewing + current time range
   useEffect(() => {
     if (id) {
       globalChat.setPageContext({ kind: 'dashboard', id, timeRange });
     }
-    return () => { globalChat.setPageContext(null); };
+    return () => {
+      globalChat.setPageContext(null);
+    };
   }, [id, timeRange, globalChat]);
 
-  // Load the session that created this dashboard so the ChatPanel shows its
-  // full history (messages + agent step events). We always call loadSession
-  // on mount — not only when the session IDs differ — because after a page
-  // refresh localStorage still holds the matching sessionId while the
-  // in-memory events/messages arrays start empty, so a naive equality guard
-  // would leave the chat panel blank.
-  //
-  // Exception: when arriving from Home with an initialPrompt we're about to
-  // start a fresh live run in this same session — loadSession would race the
-  // first outgoing SSE events and wipe them, so skip it in that case.
-  const sessionLoadedRef = useRef<string | null>(null);
-  useEffect(() => {
-    const sid = dashboard?.sessionId;
-    if (!sid || initialPrompt) return;
-    if (sessionLoadedRef.current === sid) return;
-    sessionLoadedRef.current = sid;
-    void globalChat.loadSession(sid);
-  }, [dashboard?.sessionId, initialPrompt]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Chat history is bound by the URL (`?chat=...`) and loaded in Layout.
 
   // Investigation reports are now handled in the Investigations page.
   // No auto-show on dashboard — the chat will display a link instead.
 
   // Auto-send initial prompt from Home page via the global chat
   useEffect(() => {
-    if (initialPrompt && dashboard && !initialPromptSent.current && !globalChat.isGenerating) {
+    if (
+      initialPrompt &&
+      dashboard &&
+      !initialPromptSent.current &&
+      !globalChat.isGenerating
+    ) {
       initialPromptSent.current = true;
       if (location.state) {
         window.history.replaceState({}, '');
@@ -195,28 +208,37 @@ export default function DashboardWorkspace() {
   useEffect(() => {
     if (wasGeneratingRef.current && !isGenerating && id) {
       // Generation just finished — fetch final dashboard state once
-      void apiClient.getValidated<Dashboard>(`/dashboards/${id}`, DashboardSchema, 'Dashboard').then((res) => {
-        if (!res.error && res.data) {
-          setDashboard(res.data);
-          setPanels(res.data.panels ?? []);
-          setVariables(res.data.variables ?? []);
-        }
-      });
+      void apiClient
+        .getValidated<Dashboard>(
+          `/dashboards/${id}`,
+          DashboardSchema,
+          'Dashboard',
+        )
+        .then((res) => {
+          if (!res.error && res.data) {
+            setDashboard(res.data);
+            setPanels(res.data.panels ?? []);
+            setVariables(res.data.variables ?? []);
+          }
+        });
     }
     wasGeneratingRef.current = isGenerating;
   }, [isGenerating, id, setPanels, setVariables]);
 
   // Variable changes
-  const handleVariableChange = useCallback((name: string, value: string) => {
-    setVariables((prev) =>
-      prev.map((v) => (v.name === name ? { ...v, current: value } : v))
-    );
-    // Datasource swaps invalidate every panel's query cache key, so wipe the
-    // shared cache and broadcast a refresh — without this, panels keep
-    // showing data from the previous backend until their next interval tick.
-    queryScheduler.clearCache();
-    window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
-  }, [setVariables]);
+  const handleVariableChange = useCallback(
+    (name: string, value: string) => {
+      setVariables((prev) =>
+        prev.map((v) => (v.name === name ? { ...v, current: value } : v)),
+      );
+      // Datasource swaps invalidate every panel's query cache key, so wipe the
+      // shared cache and broadcast a refresh — without this, panels keep
+      // showing data from the previous backend until their next interval tick.
+      queryScheduler.clearCache();
+      window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
+    },
+    [setVariables],
+  );
 
   // Resolved variable values for `${name}` substitution in panel queries.
   // Today only `$datasource` flows through here, but the map shape lets us
@@ -238,9 +260,14 @@ export default function DashboardWorkspace() {
 
   const saveTitle = async () => {
     if (!id || !titleDraft.trim()) return;
-    const res = await apiClient.putValidated<Dashboard>(`/dashboards/${id}`, {
-      title: titleDraft.trim(),
-    }, DashboardSchema, 'Dashboard');
+    const res = await apiClient.putValidated<Dashboard>(
+      `/dashboards/${id}`,
+      {
+        title: titleDraft.trim(),
+      },
+      DashboardSchema,
+      'Dashboard',
+    );
     if (!res.error) setDashboard(res.data);
     setEditingTitle(false);
   };
@@ -255,7 +282,12 @@ export default function DashboardWorkspace() {
   const handleSavePanel = async (updated: PanelConfig) => {
     if (!id || !dashboard) return;
     const newPanels = panels.map((p) => (p.id === updated.id ? updated : p));
-    const res = await apiClient.putValidated<Dashboard>(`/dashboards/${id}/panels`, newPanels, DashboardSchema, 'Dashboard');
+    const res = await apiClient.putValidated<Dashboard>(
+      `/dashboards/${id}/panels`,
+      newPanels,
+      DashboardSchema,
+      'Dashboard',
+    );
     if (!res.error) {
       setDashboard(res.data);
       setPanels(res.data.panels);
@@ -281,7 +313,12 @@ export default function DashboardWorkspace() {
       visualization: 'time_series',
       refreshIntervalSec: 30,
     };
-    const res = await apiClient.postValidated<Dashboard>(`/dashboards/${id}/panels`, newPanel, DashboardSchema, 'Dashboard');
+    const res = await apiClient.postValidated<Dashboard>(
+      `/dashboards/${id}/panels`,
+      newPanel,
+      DashboardSchema,
+      'Dashboard',
+    );
     if (!res.error) {
       setDashboard(res.data);
       setPanels(res.data.panels);
@@ -295,7 +332,15 @@ export default function DashboardWorkspace() {
   const layoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleLayoutChange = useCallback(
-    (newLayout: Array<{ i: string; x: number; y: number; w: number; h: number }>) => {
+    (
+      newLayout: Array<{
+        i: string;
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+      }>,
+    ) => {
       if (!id || !panels) return;
       if (layoutTimerRef.current) clearTimeout(layoutTimerRef.current);
       layoutTimerRef.current = setTimeout(() => {
@@ -311,15 +356,22 @@ export default function DashboardWorkspace() {
           };
         });
 
-        void apiClient.putValidated<Dashboard>(`/dashboards/${id}/panels`, { panels: updatedPanels }, DashboardSchema, 'Dashboard').then((res) => {
-          if (!res.error) {
-            setDashboard(res.data);
-            setPanels(res.data.panels);
-          }
-        });
+        void apiClient
+          .putValidated<Dashboard>(
+            `/dashboards/${id}/panels`,
+            { panels: updatedPanels },
+            DashboardSchema,
+            'Dashboard',
+          )
+          .then((res) => {
+            if (!res.error) {
+              setDashboard(res.data);
+              setPanels(res.data.panels);
+            }
+          });
       }, 500);
     },
-    [id, panels, setPanels]
+    [id, panels, setPanels],
   );
 
   // Scroll to panel
@@ -340,7 +392,9 @@ export default function DashboardWorkspace() {
   if (loadError || !dashboard) {
     return (
       <div className="flex flex-col items-center justify-center h-full bg-surface-lowest text-center px-6">
-        <p className="text-error text-sm mb-4">{loadError ?? 'Dashboard not found.'}</p>
+        <p className="text-error text-sm mb-4">
+          {loadError ?? 'Dashboard not found.'}
+        </p>
         <button
           type="button"
           onClick={() => navigate(-1)}
@@ -359,7 +413,13 @@ export default function DashboardWorkspace() {
       <div className="shrink-0 flex items-center gap-3 px-6 py-2.5 bg-surface-lowest border-b border-outline-variant">
         <button
           type="button"
-          onClick={() => navigate(dashboard?.type === 'investigation' ? '/investigations' : '/dashboards')}
+          onClick={() =>
+            navigate(
+              dashboard?.type === 'investigation'
+                ? '/investigations'
+                : '/dashboards',
+            )
+          }
           className="p-1.5 rounded-lg hover:bg-surface-high text-on-surface-variant hover:text-on-surface transition-colors shrink-0"
           aria-label="Back to dashboards"
         >
@@ -377,16 +437,30 @@ export default function DashboardWorkspace() {
             <div className="flex items-center gap-2 min-w-0">
               <span className="inline-block w-2 h-2 rounded-full bg-primary animate-pulse shrink-0" />
               <span className="text-sm text-on-surface-variant truncate italic">
-                {dashboard.prompt?.length > 50 ? `${dashboard.prompt.slice(0, 50)}...` : dashboard.prompt}
+                {dashboard.prompt?.length > 50
+                  ? `${dashboard.prompt.slice(0, 50)}...`
+                  : dashboard.prompt}
               </span>
             </div>
           ) : showReport ? (
             <div className="flex items-center gap-2 min-w-0">
-              <svg className="w-4 h-4 text-primary shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197M4.7 10a5.3 5.3 0 1010.6 0 5.3 5.3 0 00-10.6 0z" />
+              <svg
+                className="w-4 h-4 text-primary shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21 21l-5.197-5.197M4.7 10a5.3 5.3 0 1010.6 0 5.3 5.3 0 00-10.6 0z"
+                />
               </svg>
               <span className="text-sm font-semibold text-on-surface truncate">
-                {dashboard.title.startsWith('Investigation') ? dashboard.title : 'Investigation'}
+                {dashboard.title.startsWith('Investigation')
+                  ? dashboard.title
+                  : 'Investigation'}
               </span>
             </div>
           ) : editingTitle ? (
@@ -417,11 +491,11 @@ export default function DashboardWorkspace() {
             </span>
           )}
 
-        {!showReport && !isGenerating && dashboard.folder && (
-          <span className="text-xs px-2 py-0.5 rounded bg-primary/10 text-primary border border-primary/20 shrink-0">
-            {dashboard.folder}
-          </span>
-        )}
+          {!showReport && !isGenerating && dashboard.folder && (
+            <span className="text-xs px-2 py-0.5 rounded bg-primary/10 text-primary border border-primary/20 shrink-0">
+              {dashboard.folder}
+            </span>
+          )}
         </div>
 
         {/* Center: time range + refresh */}
@@ -453,8 +527,18 @@ export default function DashboardWorkspace() {
                     : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-high'
                 }`}
               >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
                 </svg>
                 {editMode ? 'Editing' : 'Edit'}
               </button>
@@ -467,8 +551,18 @@ export default function DashboardWorkspace() {
                 onClick={() => void handleAddPanel()}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-colors"
               >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 4.5v15m7.5-7.5h-15"
+                  />
                 </svg>
                 Add Panel
               </button>
@@ -482,10 +576,24 @@ export default function DashboardWorkspace() {
                 type="button"
                 onClick={() => setShowFolderDialog(true)}
                 className="p-1.5 rounded-lg transition-colors hover:bg-surface-high text-on-surface-variant hover:text-on-surface"
-                title={dashboard.folder ? `Folder: ${dashboard.folder}` : 'Move to folder'}
+                title={
+                  dashboard.folder
+                    ? `Folder: ${dashboard.folder}`
+                    : 'Move to folder'
+                }
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+                  />
                 </svg>
               </button>
             )}
@@ -498,8 +606,18 @@ export default function DashboardWorkspace() {
                 title="Permissions"
               >
                 {/* Shield icon */}
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 2l8 3v6c0 5-3.5 9.5-8 11-4.5-1.5-8-6-8-11V5l8-3z" />
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 2l8 3v6c0 5-3.5 9.5-8 11-4.5-1.5-8-6-8-11V5l8-3z"
+                  />
                 </svg>
               </button>
             )}
@@ -511,8 +629,18 @@ export default function DashboardWorkspace() {
                 className="group relative p-2 rounded-lg text-on-surface-variant hover:text-error hover:bg-surface-high transition-colors shrink-0"
                 title="Delete"
               >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3M4 7h16" />
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3M4 7h16"
+                  />
                 </svg>
               </button>
             )}
@@ -547,15 +675,21 @@ export default function DashboardWorkspace() {
                 // truthiness of these callbacks (see DashboardPanelCard.tsx
                 // lines ~690 and ~715), so this removes them from the DOM
                 // entirely — not just hidden-until-hover — for Viewers.
-                onEditPanel={canEditDashboard
-                  ? (panelId) => {
-                      const p = panels.find((x) => x.id === panelId);
-                      if (p) setEditingPanel(p);
-                    }
-                  : undefined}
-                onDeletePanel={canEditDashboard
-                  ? (panelId) => { void handleDeletePanel(panelId); }
-                  : undefined}
+                onEditPanel={
+                  canEditDashboard
+                    ? (panelId) => {
+                        const p = panels.find((x) => x.id === panelId);
+                        if (p) setEditingPanel(p);
+                      }
+                    : undefined
+                }
+                onDeletePanel={
+                  canEditDashboard
+                    ? (panelId) => {
+                        void handleDeletePanel(panelId);
+                      }
+                    : undefined
+                }
                 onLayoutChange={handleLayoutChange}
                 onTimeRangeChange={setTimeRange}
               />
@@ -563,13 +697,16 @@ export default function DashboardWorkspace() {
           )}
 
           <div className="shrink-0 px-6 py-2 flex items-center gap-2">
-            <span className={`w-1.5 h-1.5 rounded-full ${isGenerating ? 'bg-primary animate-pulse' : 'bg-secondary'}`} />
+            <span
+              className={`w-1.5 h-1.5 rounded-full ${isGenerating ? 'bg-primary animate-pulse' : 'bg-secondary'}`}
+            />
             <span className="text-xs text-on-surface-variant">
-              {isGenerating ? 'Generating...' : `${panels.length} panel${panels.length !== 1 ? 's' : ''} ready`}
+              {isGenerating
+                ? 'Generating...'
+                : `${panels.length} panel${panels.length !== 1 ? 's' : ''} ready`}
             </span>
           </div>
         </div>
-
       </div>
 
       {editingPanel && (
@@ -588,7 +725,9 @@ export default function DashboardWorkspace() {
           currentFolder={dashboard?.folder}
           open={showFolderDialog}
           onClose={() => setShowFolderDialog(false)}
-          onSaved={(folder) => setDashboard((prev) => (prev ? { ...prev, folder } : prev))}
+          onSaved={(folder) =>
+            setDashboard((prev) => (prev ? { ...prev, folder } : prev))
+          }
         />
       )}
 
@@ -608,7 +747,12 @@ export default function DashboardWorkspace() {
         onConfirm={async () => {
           if (id) {
             const res = await apiClient.delete(`/dashboards/${id}`);
-            if (!res.error) navigate(dashboard?.type === 'investigation' ? '/investigations' : '/dashboards');
+            if (!res.error)
+              navigate(
+                dashboard?.type === 'investigation'
+                  ? '/investigations'
+                  : '/dashboards',
+              );
           }
           setShowDeleteConfirm(false);
         }}

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { apiClient } from '../api/client.js';
 import { fadeIn } from '../animations.js';
@@ -8,7 +8,11 @@ import { relativeTime } from '../utils/time.js';
 import { useGlobalChat } from '../contexts/ChatContext.js';
 import { groupEvents } from '../components/chat/event-processing.js';
 import type { Block } from '../components/chat/event-processing.js';
-import { UserMessage, AssistantMessage, ErrorMessage } from '../components/chat/MessageComponents.js';
+import {
+  UserMessage,
+  AssistantMessage,
+  ErrorMessage,
+} from '../components/chat/MessageComponents.js';
 import AgentActivityBlock from '../components/chat/AgentActivityBlock.js';
 import { OpenObsLogo } from '../components/OpenObsLogo.js';
 
@@ -25,8 +29,9 @@ interface Dashboard {
 
 interface ChatSession {
   id: string;
-  title: string;
+  title?: string | null;
   createdAt: string;
+  updatedAt?: string;
 }
 
 // Quick action cards
@@ -35,8 +40,18 @@ const QUICK_ACTIONS = [
   {
     category: 'Investigate',
     icon: (
-      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+      <svg
+        className="w-4 h-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M13 10V3L4 14h7v7l9-11h-7z"
+        />
       </svg>
     ),
     colorClass: 'text-on-surface',
@@ -46,8 +61,18 @@ const QUICK_ACTIONS = [
   {
     category: 'Build',
     icon: (
-      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 3v18h18M7 16l4-4 4 4 4-4" />
+      <svg
+        className="w-4 h-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 3v18h18M7 16l4-4 4 4 4-4"
+        />
       </svg>
     ),
     colorClass: 'text-secondary',
@@ -57,8 +82,18 @@ const QUICK_ACTIONS = [
   {
     category: 'Alert',
     icon: (
-      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      <svg
+        className="w-4 h-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+        />
       </svg>
     ),
     colorClass: 'text-error',
@@ -71,8 +106,16 @@ const QUICK_ACTIONS = [
 
 export default function Home() {
   const navigate = useNavigate();
+  const location = useLocation();
   const globalChat = useGlobalChat();
-  const { events, isGenerating, sendMessage, stopGeneration } = globalChat;
+  const {
+    events,
+    isGenerating,
+    sendMessage,
+    stopGeneration,
+    currentSessionId,
+    loadSession,
+  } = globalChat;
 
   const [input, setInput] = useState('');
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
@@ -85,18 +128,27 @@ export default function Home() {
   const blocks = useMemo(() => groupEvents(events), [events]);
   const lastAgentBlockId = useMemo(() => {
     for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      if (blocks[i]!.type === 'agent') return (blocks[i] as Extract<Block, { type: 'agent' }>).id;
+      if (blocks[i]!.type === 'agent')
+        return (blocks[i] as Extract<Block, { type: 'agent' }>).id;
     }
     return null;
   }, [blocks]);
 
-  // Home = new conversation entry point. Start a fresh session on mount
-  // so user always gets a clean slate when clicking "Home".
-  // Past conversations are accessible via the "Recent Conversations" section below.
+  const chatIdFromUrl = useMemo(
+    () => new URLSearchParams(location.search).get('chat'),
+    [location.search],
+  );
+
+  // Home is the new conversation entry point unless the URL explicitly names
+  // a durable personal chat to reopen.
   useEffect(() => {
-    globalChat.startNewSession();
+    if (chatIdFromUrl) {
+      void loadSession(chatIdFromUrl);
+    } else {
+      globalChat.startNewSession();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [chatIdFromUrl]);
 
   const handleDeleteDashboard = useCallback(async (id: string) => {
     const res = await apiClient.delete(`/dashboards/${id}`);
@@ -107,16 +159,40 @@ export default function Home() {
 
   useEffect(() => {
     void apiClient.get<Dashboard[]>(`/dashboards?limit=6`).then((res) => {
-      if (!res.error && Array.isArray(res.data)) setDashboards(res.data.slice(0, 6));
+      if (!res.error && Array.isArray(res.data))
+        setDashboards(res.data.slice(0, 6));
     });
+  }, []);
+
+  const refreshSessions = useCallback(() => {
+    void apiClient
+      .get<{ sessions: ChatSession[] }>('/chat/sessions?limit=10')
+      .then((res) => {
+        if (!res.error && res.data?.sessions) setSessions(res.data.sessions);
+      });
   }, []);
 
   useEffect(() => {
-    void apiClient.get<{ sessions: ChatSession[] }>('/chat/sessions?limit=10').then((res) => {
-      if (!res.error && res.data?.sessions) setSessions(res.data.sessions);
-    });
-  }, []);
+    refreshSessions();
+  }, [refreshSessions]);
 
+  useEffect(() => {
+    if (!currentSessionId || currentSessionId === chatIdFromUrl) return;
+    const params = new URLSearchParams(location.search);
+    params.set('chat', currentSessionId);
+    navigate(
+      { pathname: '/', search: `?${params.toString()}` },
+      { replace: true },
+    );
+  }, [chatIdFromUrl, currentSessionId, location.search, navigate]);
+
+  const wasGeneratingRef = useRef(false);
+  useEffect(() => {
+    if (wasGeneratingRef.current && !isGenerating) {
+      refreshSessions();
+    }
+    wasGeneratingRef.current = isGenerating;
+  }, [isGenerating, refreshSessions]);
 
   // Auto-scroll on new events
   useEffect(() => {
@@ -140,6 +216,17 @@ export default function Home() {
   const handleQuickAction = (actionPrompt: string) => {
     void sendMessage(actionPrompt);
   };
+
+  const handleOpenSession = useCallback(
+    (sessionId: string) => {
+      void loadSession(sessionId);
+      navigate({
+        pathname: '/',
+        search: `?chat=${encodeURIComponent(sessionId)}`,
+      });
+    },
+    [loadSession, navigate],
+  );
 
   // Reusable input component (used in both modes)
   const inputArea = (
@@ -167,7 +254,11 @@ export default function Home() {
             className="absolute right-14 bottom-3 w-8 h-8 bg-surface-highest hover:bg-error/15 text-on-surface-variant hover:text-error flex items-center justify-center transition-colors rounded-full"
             title="Stop"
           >
-            <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+            <svg
+              className="w-3.5 h-3.5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
               <rect x="5" y="5" width="10" height="10" rx="1" />
             </svg>
           </button>
@@ -180,7 +271,12 @@ export default function Home() {
           title="Send"
         >
           <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H3a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 011.414-1.414l4 4z" clipRule="evenodd" transform="rotate(-90 10 10)" />
+            <path
+              fillRule="evenodd"
+              d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H3a1 1 0 110-2h9.586l-3.293-3.293a1 1 0 011.414-1.414l4 4z"
+              clipRule="evenodd"
+              transform="rotate(-90 10 10)"
+            />
           </svg>
         </button>
       </div>
@@ -209,7 +305,8 @@ export default function Home() {
                 How can OpenObs help?
               </h1>
               <p className="text-on-surface-variant text-sm md:text-base max-w-xl mx-auto leading-relaxed">
-                Ask it to build, explain, investigate, or prepare an approved fix.
+                Ask it to build, explain, investigate, or prepare an approved
+                fix.
               </p>
             </motion.div>
 
@@ -245,15 +342,80 @@ export default function Home() {
                 </button>
               ))}
             </motion.div>
-          </div>
 
+            {sessions.length > 0 && (
+              <motion.section
+                className="mt-10"
+                variants={fadeIn}
+                initial="hidden"
+                animate="visible"
+                transition={{ delay: 0.25 }}
+                aria-label="My conversations"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+                    My conversations
+                  </h2>
+                  {currentSessionId && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        globalChat.startNewSession();
+                        navigate('/', { replace: true });
+                      }}
+                      className="text-xs text-primary hover:text-primary-container transition-colors"
+                    >
+                      New chat
+                    </button>
+                  )}
+                </div>
+                <div className="grid gap-2">
+                  {sessions.map((session) => (
+                    <button
+                      key={session.id}
+                      type="button"
+                      onClick={() => handleOpenSession(session.id)}
+                      className={`flex min-w-0 items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                        session.id === currentSessionId
+                          ? 'border-primary/50 bg-primary/5'
+                          : 'border-outline-variant bg-surface-container/60 hover:border-outline hover:bg-surface-container'
+                      }`}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm text-on-surface">
+                          {session.title?.trim() || 'Untitled conversation'}
+                        </span>
+                        <span className="block text-xs text-on-surface-variant">
+                          {relativeTime(session.updatedAt ?? session.createdAt)}
+                        </span>
+                      </span>
+                      <svg
+                        className="h-4 w-4 shrink-0 text-on-surface-variant"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </button>
+                  ))}
+                </div>
+              </motion.section>
+            )}
+          </div>
         </div>
 
         <ConfirmDialog
           open={deletingDashId !== null}
           title="Delete dashboard?"
           message="This dashboard and all its panels will be permanently deleted."
-          onConfirm={() => { if (deletingDashId) void handleDeleteDashboard(deletingDashId); setDeletingDashId(null); }}
+          onConfirm={() => {
+            if (deletingDashId) void handleDeleteDashboard(deletingDashId);
+            setDeletingDashId(null);
+          }}
           onCancel={() => setDeletingDashId(null)}
         />
       </div>
@@ -272,13 +434,25 @@ export default function Home() {
             if (block.type === 'message') {
               const evt = block.event;
               if (evt.kind === 'error') {
-                return <ErrorMessage key={evt.id} content={evt.content ?? 'An error occurred'} />;
+                return (
+                  <ErrorMessage
+                    key={evt.id}
+                    content={evt.content ?? 'An error occurred'}
+                  />
+                );
               }
               if (evt.message?.role === 'user') {
-                return <UserMessage key={evt.id} content={evt.message.content} />;
+                return (
+                  <UserMessage key={evt.id} content={evt.message.content} />
+                );
               }
               if (evt.message?.role === 'assistant') {
-                return <AssistantMessage key={evt.id} content={evt.message.content} />;
+                return (
+                  <AssistantMessage
+                    key={evt.id}
+                    content={evt.message.content}
+                  />
+                );
               }
               return null;
             }

--- a/packages/web/src/pages/InvestigationDetail.tsx
+++ b/packages/web/src/pages/InvestigationDetail.tsx
@@ -5,7 +5,10 @@ import InvestigationReportView from '../components/InvestigationReportView.js';
 import type { ConclusionData } from '../components/ConclusionPanel.js';
 import ChatPanel from '../components/ChatPanel.js';
 import type { ChatEvent } from '../hooks/useDashboardChat.js';
-import type { InvestigationReport as IReport, InvestigationReportSection } from '../hooks/useDashboardChat.js';
+import type {
+  InvestigationReport as IReport,
+  InvestigationReportSection,
+} from '../hooks/useDashboardChat.js';
 import type { Evidence } from '@agentic-obs/common';
 import type { InvestigationStatus } from '../api/types.js';
 import { relativeTime } from '../utils/time.js';
@@ -59,11 +62,16 @@ function statusDescription(status: string): string {
 }
 
 let eventCounter = 0;
-function makeEventId() { return `inv_evt_${++eventCounter}`; }
+function makeEventId() {
+  return `inv_evt_${++eventCounter}`;
+}
 
 // Convert investigation state changes into ChatEvents for the ChatPanel
 
-function buildChatEvents(investigation: FullInvestigation, conclusion: ConclusionData | null): ChatEvent[] {
+function buildChatEvents(
+  investigation: FullInvestigation,
+  conclusion: ConclusionData | null,
+): ChatEvent[] {
   const events: ChatEvent[] = [];
 
   // Initial user message — the investigation question
@@ -129,7 +137,11 @@ function buildChatEvents(investigation: FullInvestigation, conclusion: Conclusio
   }
 
   // Analysis / status update
-  if (investigation.status === 'explaining' || investigation.status === 'acting' || investigation.status === 'verifying') {
+  if (
+    investigation.status === 'explaining' ||
+    investigation.status === 'acting' ||
+    investigation.status === 'verifying'
+  ) {
     events.push({
       id: makeEventId(),
       kind: 'thinking',
@@ -144,7 +156,11 @@ function buildChatEvents(investigation: FullInvestigation, conclusion: Conclusio
       msg += `\n\n**Root Cause:** ${conclusion.rootCause}`;
     }
     if (conclusion.recommendedActions?.length) {
-      msg += '\n\n**Recommended Actions:**\n' + conclusion.recommendedActions.map((a) => `- ${typeof a === 'string' ? a : a.label}`).join('\n');
+      msg +=
+        '\n\n**Recommended Actions:**\n' +
+        conclusion.recommendedActions
+          .map((a) => `- ${typeof a === 'string' ? a : a.label}`)
+          .join('\n');
     }
     events.push({
       id: makeEventId(),
@@ -172,10 +188,13 @@ function buildChatEvents(investigation: FullInvestigation, conclusion: Conclusio
   return events;
 }
 
-
 // Live progress view while investigation is running
 
-function LiveProgressView({ investigation }: { investigation: FullInvestigation }) {
+function LiveProgressView({
+  investigation,
+}: {
+  investigation: FullInvestigation;
+}) {
   return (
     <div className="px-12 py-10 max-w-4xl mx-auto space-y-8">
       <header className="space-y-4">
@@ -186,7 +205,6 @@ function LiveProgressView({ investigation }: { investigation: FullInvestigation 
           {investigation.intent}
         </h1>
       </header>
-
 
       {/* Plan objective */}
       {investigation.plan?.objective && (
@@ -213,16 +231,44 @@ function LiveProgressView({ investigation }: { investigation: FullInvestigation 
               <div key={step.id || i} className="flex items-start gap-3 py-1">
                 <span className="mt-1 shrink-0">
                   {step.status === 'completed' ? (
-                    <svg className="w-4 h-4 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
+                    <svg
+                      className="w-4 h-4 text-emerald-400"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
                   ) : step.status === 'running' ? (
-                    <span className="w-4 h-4 flex items-center justify-center"><span className="w-2.5 h-2.5 rounded-full bg-amber-400 animate-pulse" /></span>
+                    <span className="w-4 h-4 flex items-center justify-center">
+                      <span className="w-2.5 h-2.5 rounded-full bg-amber-400 animate-pulse" />
+                    </span>
                   ) : step.status === 'failed' ? (
-                    <svg className="w-4 h-4 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                    <svg
+                      className="w-4 h-4 text-red-400"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
                   ) : (
                     <span className="w-4 h-4 rounded-full border-2 border-outline-variant block" />
                   )}
                 </span>
-                <p className={`text-[15px] leading-relaxed ${step.status === 'skipped' ? 'text-outline line-through' : 'text-on-surface-variant'}`}>
+                <p
+                  className={`text-[15px] leading-relaxed ${step.status === 'skipped' ? 'text-outline line-through' : 'text-on-surface-variant'}`}
+                >
                   {step.description}
                 </p>
               </div>
@@ -239,7 +285,8 @@ function LiveProgressView({ investigation }: { investigation: FullInvestigation 
             Evidence Collected
           </h3>
           <p className="text-[15px] text-on-surface-variant pl-4 border-l-2 border-primary/40">
-            {investigation.evidence.length} data point{investigation.evidence.length > 1 ? 's' : ''} collected so far...
+            {investigation.evidence.length} data point
+            {investigation.evidence.length > 1 ? 's' : ''} collected so far...
           </p>
         </section>
       )}
@@ -248,7 +295,9 @@ function LiveProgressView({ investigation }: { investigation: FullInvestigation 
       {!investigation.plan?.steps?.length && (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <span className="inline-block w-8 h-8 border-2 border-outline-variant border-t-primary rounded-full animate-spin mb-4" />
-          <p className="text-sm text-on-surface-variant">{statusDescription(investigation.status)}</p>
+          <p className="text-sm text-on-surface-variant">
+            {statusDescription(investigation.status)}
+          </p>
         </div>
       )}
     </div>
@@ -261,7 +310,9 @@ export default function InvestigationDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const globalChat = useGlobalChat();
-  const [investigation, setInvestigation] = useState<FullInvestigation | null>(null);
+  const [investigation, setInvestigation] = useState<FullInvestigation | null>(
+    null,
+  );
   const [conclusion, setConclusion] = useState<ConclusionData | null>(null);
   const [report, setReport] = useState<IReport | null>(null);
   const [loading, setLoading] = useState(true);
@@ -269,12 +320,7 @@ export default function InvestigationDetail() {
   const [agentEvents, setAgentEvents] = useState<ChatEvent[]>([]);
   const [agentGenerating, setAgentGenerating] = useState(false);
 
-  // Load the session that created this investigation so the ChatPanel shows its history
-  useEffect(() => {
-    if (investigation?.sessionId && investigation.sessionId !== globalChat.currentSessionId) {
-      void globalChat.loadSession(investigation.sessionId);
-    }
-  }, [investigation?.sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Chat history is bound by the URL (`?chat=...`) and loaded in Layout.
 
   const fetchInvestigation = useCallback(async () => {
     if (!id) return;
@@ -289,26 +335,35 @@ export default function InvestigationDetail() {
 
     if (res.data.status === 'completed' || res.data.status === 'failed') {
       // Fetch the LLM-generated report
-      const rRes = await apiClient.get<{ summary: string; sections: InvestigationReportSection[] }>(`/investigations/${id}/report`);
+      const rRes = await apiClient.get<{
+        summary: string;
+        sections: InvestigationReportSection[];
+      }>(`/investigations/${id}/report`);
       if (!rRes.error && rRes.data?.summary) {
         setReport({ summary: rRes.data.summary, sections: rRes.data.sections });
       }
       // Fetch conclusion for chat panel
-      const cRes = await apiClient.get<{ conclusion: ConclusionData }>(`/investigations/${id}/conclusion`);
+      const cRes = await apiClient.get<{ conclusion: ConclusionData }>(
+        `/investigations/${id}/conclusion`,
+      );
       if (!cRes.error && cRes.data?.conclusion) {
         setConclusion(cRes.data.conclusion);
       }
     }
   }, [id]);
 
-  useEffect(() => { void fetchInvestigation(); }, [fetchInvestigation]);
+  useEffect(() => {
+    void fetchInvestigation();
+  }, [fetchInvestigation]);
 
   // Tell the global chat which investigation the user is viewing
   useEffect(() => {
     if (id) {
       globalChat.setPageContext({ kind: 'investigation', id });
     }
-    return () => { globalChat.setPageContext(null); };
+    return () => {
+      globalChat.setPageContext(null);
+    };
   }, [id, globalChat]);
 
   // Poll while investigation is active
@@ -325,120 +380,146 @@ export default function InvestigationDetail() {
     return buildChatEvents(investigation, conclusion);
   }, [investigation, conclusion]);
 
-  const chatEvents = useMemo(() => [...baseChatEvents, ...agentEvents], [baseChatEvents, agentEvents]);
+  const chatEvents = useMemo(
+    () => [...baseChatEvents, ...agentEvents],
+    [baseChatEvents, agentEvents],
+  );
 
-  const isGenerating = (investigation ? !isTerminal(investigation.status) : false) || agentGenerating;
+  const isGenerating =
+    (investigation ? !isTerminal(investigation.status) : false) ||
+    agentGenerating;
 
   // Handle follow-up messages from ChatPanel
-  const handleSendMessage = useCallback(async (content: string) => {
-    if (!id) return;
-    const userEventId = crypto.randomUUID();
-    setAgentEvents((prev) => [
-      ...prev,
-      {
-        id: userEventId,
-        kind: 'message',
-        message: {
-          id: userEventId,
-          role: 'user',
-          content,
-          timestamp: new Date().toISOString(),
-        },
-      },
-    ]);
-    setAgentGenerating(true);
-
-    // Investigation follow-ups go through the canonical chat-service endpoint
-    // with `pageContext.kind = 'investigation'` so the orchestrator knows
-    // which investigation to scope tools against. The investigation's own
-    // sessionId is reused so subsequent turns share history.
-    await apiClient.postStream(
-      `/chat`,
-      {
-        message: content,
-        ...(investigation?.sessionId ? { sessionId: investigation.sessionId } : {}),
-        pageContext: { kind: 'investigation', id },
-      },
-      (eventType: string, rawData: string) => {
-        let parsed: Record<string, unknown> = {};
-        try {
-          parsed = JSON.parse(rawData) as Record<string, unknown>;
-        } catch {
-          parsed = { content: rawData };
-        }
-
-        const eventId = crypto.randomUUID();
-
-        if (eventType === 'thinking') {
-          setAgentEvents((prev) => [
-            ...prev,
-            {
-              id: eventId,
-              kind: 'thinking',
-              content: (parsed.content as string) ?? 'Thinking...',
-            },
-          ]);
-          return;
-        }
-
-        if (eventType === 'reply') {
-          setAgentEvents((prev) => [
-            ...prev,
-            {
-              id: eventId,
-              kind: 'message',
-              message: {
-                id: eventId,
-                role: 'assistant',
-                content: (parsed.content as string) ?? '',
-                timestamp: new Date().toISOString(),
-              },
-            },
-          ]);
-          return;
-        }
-
-        if (eventType === 'error') {
-          setAgentEvents((prev) => [
-            ...prev,
-            {
-              id: eventId,
-              kind: 'error',
-              content: (parsed.message as string) ?? 'Something went wrong',
-            },
-          ]);
-          setAgentGenerating(false);
-          return;
-        }
-
-        if (eventType === 'done') {
-          if (typeof parsed.navigate === 'string' && parsed.navigate !== `/investigations/${id}`) {
-            if (parsed.intent === 'dashboard') {
-              navigate(parsed.navigate, { state: { initialPrompt: content } });
-            } else {
-              navigate(parsed.navigate);
-            }
-            return;
-          }
-          setAgentEvents((prev) => [...prev, { id: eventId, kind: 'done' }]);
-          setAgentGenerating(false);
-        }
-      },
-    ).catch((err) => {
-      const message = err instanceof Error ? err.message : 'Network error';
+  const handleSendMessage = useCallback(
+    async (content: string) => {
+      if (!id) return;
+      const userEventId = crypto.randomUUID();
       setAgentEvents((prev) => [
         ...prev,
         {
-          id: crypto.randomUUID(),
-          kind: 'error',
-          content: message,
+          id: userEventId,
+          kind: 'message',
+          message: {
+            id: userEventId,
+            role: 'user',
+            content,
+            timestamp: new Date().toISOString(),
+          },
         },
       ]);
-      setAgentGenerating(false);
-    }).finally(() => {
-      setAgentGenerating(false);
-    });
-  }, [id, investigation?.sessionId, navigate]);
+      setAgentGenerating(true);
+
+      // Investigation follow-ups go through the canonical chat-service endpoint
+      // with `pageContext.kind = 'investigation'` so the orchestrator knows
+      // which investigation to scope tools against. Continue the active
+      // personal chat from the URL/global context when one exists.
+      await apiClient
+        .postStream(
+          `/chat`,
+          {
+            message: content,
+            ...(globalChat.currentSessionId
+              ? { sessionId: globalChat.currentSessionId }
+              : {}),
+            pageContext: { kind: 'investigation', id },
+          },
+          (eventType: string, rawData: string) => {
+            let parsed: Record<string, unknown> = {};
+            try {
+              parsed = JSON.parse(rawData) as Record<string, unknown>;
+            } catch {
+              parsed = { content: rawData };
+            }
+
+            const eventId = crypto.randomUUID();
+
+            if (eventType === 'thinking') {
+              setAgentEvents((prev) => [
+                ...prev,
+                {
+                  id: eventId,
+                  kind: 'thinking',
+                  content: (parsed.content as string) ?? 'Thinking...',
+                },
+              ]);
+              return;
+            }
+
+            if (eventType === 'reply') {
+              setAgentEvents((prev) => [
+                ...prev,
+                {
+                  id: eventId,
+                  kind: 'message',
+                  message: {
+                    id: eventId,
+                    role: 'assistant',
+                    content: (parsed.content as string) ?? '',
+                    timestamp: new Date().toISOString(),
+                  },
+                },
+              ]);
+              return;
+            }
+
+            if (eventType === 'error') {
+              setAgentEvents((prev) => [
+                ...prev,
+                {
+                  id: eventId,
+                  kind: 'error',
+                  content: (parsed.message as string) ?? 'Something went wrong',
+                },
+              ]);
+              setAgentGenerating(false);
+              return;
+            }
+
+            if (eventType === 'done') {
+              if (
+                typeof parsed.navigate === 'string' &&
+                parsed.navigate !== `/investigations/${id}`
+              ) {
+                const target = new URL(parsed.navigate, window.location.origin);
+                const sessionId =
+                  typeof parsed.sessionId === 'string'
+                    ? parsed.sessionId
+                    : globalChat.currentSessionId;
+                if (sessionId) target.searchParams.set('chat', sessionId);
+                const path = `${target.pathname}${target.search}${target.hash}`;
+                if (parsed.intent === 'dashboard') {
+                  navigate(path, { state: { initialPrompt: content } });
+                } else {
+                  navigate(path);
+                }
+                return;
+              }
+              setAgentEvents((prev) => [
+                ...prev,
+                { id: eventId, kind: 'done' },
+              ]);
+              setAgentGenerating(false);
+            }
+          },
+        )
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : 'Network error';
+          setAgentEvents((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              kind: 'error',
+              content: message,
+            },
+          ]);
+          setAgentGenerating(false);
+        })
+        .finally(() => {
+          setAgentGenerating(false);
+        });
+    },
+    [id, globalChat.currentSessionId, navigate],
+  );
 
   if (loading) {
     return (
@@ -451,8 +532,14 @@ export default function InvestigationDetail() {
   if (error || !investigation) {
     return (
       <div className="h-full flex flex-col items-center justify-center gap-3">
-        <p className="text-sm text-red-400">{error ?? 'Investigation not found'}</p>
-        <button type="button" onClick={() => navigate('/investigations')} className="text-sm text-primary hover:underline">
+        <p className="text-sm text-red-400">
+          {error ?? 'Investigation not found'}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/investigations')}
+          className="text-sm text-primary hover:underline"
+        >
           Back to Investigations
         </button>
       </div>
@@ -469,15 +556,29 @@ export default function InvestigationDetail() {
           className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-colors"
           title="Back to investigations"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
         </button>
 
         <div className="flex-1 min-w-0">
-          <h1 className="text-sm font-semibold text-on-surface truncate">{investigation.intent}</h1>
+          <h1 className="text-sm font-semibold text-on-surface truncate">
+            {investigation.intent}
+          </h1>
           <div className="flex items-center gap-2">
-            <span className="text-[11px] text-on-surface-variant">{relativeTime(investigation.createdAt)}</span>
+            <span className="text-[11px] text-on-surface-variant">
+              {relativeTime(investigation.createdAt)}
+            </span>
             {investigation.plan?.entity && (
               <span className="px-1.5 py-0.5 rounded bg-surface-high text-on-surface-variant text-[10px] font-mono">
                 {investigation.plan.entity}
@@ -487,14 +588,18 @@ export default function InvestigationDetail() {
         </div>
 
         {/* Status badge */}
-        <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
-          isGenerating
-            ? 'bg-primary/10 text-primary'
-            : investigation.status === 'completed'
-            ? 'bg-secondary/15 text-secondary'
-            : 'bg-error/15 text-error'
-        }`}>
-          {isGenerating && <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />}
+        <div
+          className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
+            isGenerating
+              ? 'bg-primary/10 text-primary'
+              : investigation.status === 'completed'
+                ? 'bg-secondary/15 text-secondary'
+                : 'bg-error/15 text-error'
+          }`}
+        >
+          {isGenerating && (
+            <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+          )}
           {getInvestigationStatusStyle(investigation.status).label}
         </div>
       </div>
@@ -508,7 +613,10 @@ export default function InvestigationDetail() {
         {/* Left: Report (complete) or live progress (running) */}
         <div className="flex-1 flex flex-col min-w-0">
           {report ? (
-            <InvestigationReportView report={report} title={investigation.intent} />
+            <InvestigationReportView
+              report={report}
+              title={investigation.intent}
+            />
           ) : (
             <div className="flex-1 overflow-y-auto overscroll-contain bg-surface-lowest">
               <LiveProgressView investigation={investigation} />
@@ -516,14 +624,15 @@ export default function InvestigationDetail() {
           )}
 
           <div className="shrink-0 px-6 py-2 flex items-center gap-2">
-            <span className={`w-1.5 h-1.5 rounded-full ${isGenerating ? 'bg-primary animate-pulse' : investigation.status === 'completed' ? 'bg-secondary' : 'bg-red-400'}`} />
+            <span
+              className={`w-1.5 h-1.5 rounded-full ${isGenerating ? 'bg-primary animate-pulse' : investigation.status === 'completed' ? 'bg-secondary' : 'bg-red-400'}`}
+            />
             <span className="text-xs text-on-surface-variant">
               {isGenerating
                 ? statusDescription(investigation.status)
                 : investigation.status === 'completed'
-                ? `${investigation.evidence?.length ?? 0} evidence · ${investigation.hypotheses?.length ?? 0} hypotheses`
-                : 'Failed'
-              }
+                  ? `${investigation.evidence?.length ?? 0} evidence · ${investigation.hypotheses?.length ?? 0} hypotheses`
+                  : 'Failed'}
             </span>
           </div>
         </div>

--- a/packages/web/src/pages/Investigations.tsx
+++ b/packages/web/src/pages/Investigations.tsx
@@ -12,7 +12,6 @@ interface InvestigationSummary {
   id: string;
   status: string;
   intent: string;
-  sessionId: string;
   userId: string;
   createdAt: string;
   updatedAt: string;
@@ -94,7 +93,6 @@ export default function Investigations() {
     return sorted.filter((inv) =>
       inv.intent.toLowerCase().includes(q)
       || inv.status.toLowerCase().includes(q)
-      || inv.sessionId.toLowerCase().includes(q)
       || inv.userId.toLowerCase().includes(q)
     );
   }, [search, sorted]);


### PR DESCRIPTION
## Summary
- make chat sessions personal to the authenticated user and scope session reads/writes by org + owner
- persist resource context links separately from dashboards/investigations/alerts
- restore Home/resource chat via durable ?chat= session URLs and remove dashboard-owned chat state
- clean legacy dashboard sessionId plumbing and stop accepting investigation sessionId as a chat binding

## Verification
- npm run typecheck
- npm --workspace @agentic-obs/web run typecheck
- npx vitest run packages/api-gateway/src/services/chat-service.test.ts packages/api-gateway/src/services/investigation-workspace-service.test.ts packages/data-layer/src/repository/sqlite/chat-session.test.ts packages/data-layer/src/repository/sqlite/dashboard.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat sessions now track and display associated resources (dashboards, investigations, alerts)
  * Enhanced session management with improved persistence and URL-based session navigation
  * Better multi-user session ownership and access control

* **Bug Fixes**
  * Improved chat session scoping for workspace and organizational boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->