### PR TITLE
Use admin session cookie for /api/admin/* in e2e helpers

### DIFF
--- a/tests/e2e/scenarios/helpers/users.ts
+++ b/tests/e2e/scenarios/helpers/users.ts
@@ -21,7 +21,9 @@
  * loginAs does the login + a primer GET, and apiAs auto-attaches the
  * CSRF header on non-safe methods.
  */
-import { apiPost, apiDelete, BASE_URL, getSaToken } from './api-client.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { BASE_URL, getSaToken } from './api-client.js';
 
 export type Role = 'Viewer' | 'Editor' | 'Admin';
 
@@ -40,6 +42,51 @@ interface CreateUserResp {
 
 let counter = 0;
 
+/**
+ * /api/admin/* requires server-admin. The seeded SA in seed.sh is only
+ * Editor — not server-admin. Use the seeded admin user's session cookie
+ * instead (the bootstrap admin IS server-admin) and prime the CSRF
+ * cookie via a safe-method probe so mutations clear the CSRF middleware.
+ */
+async function adminCookieHeader(): Promise<string> {
+  const jarPath = join(process.cwd(), 'tests/e2e/.state/admin-cookie');
+  const jar = readFileSync(jarPath, 'utf8');
+  const sessionLine = jar
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l && l.includes('openobs_session') && !/^#\s/.test(l));
+  if (!sessionLine) {
+    throw new Error('tests/e2e/.state/admin-cookie missing openobs_session — did seed.sh run?');
+  }
+  const sessionVal = sessionLine.split(/\t+/)[6] ?? '';
+  const probe = await fetch(`${BASE_URL}/api/whoami`, {
+    headers: { cookie: `openobs_session=${sessionVal}` },
+  });
+  const setCookie = probe.headers.get('set-cookie') ?? '';
+  const csrfMatch = setCookie.match(/openobs_csrf=([^;,\s]+)/);
+  const csrf = csrfMatch?.[1] ?? '';
+  return `openobs_session=${sessionVal}${csrf ? `; openobs_csrf=${csrf}` : ''}`;
+}
+
+async function adminFetch<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const cookie = await adminCookieHeader();
+  const csrf = (cookie.match(/openobs_csrf=([^;]+)/) || [])[1] ?? '';
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      cookie,
+      ...(csrf ? { 'x-csrf-token': csrf } : {}),
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`admin ${method} ${path} -> ${res.status}: ${text.slice(0, 300)}`);
+  }
+  return text.length > 0 ? (JSON.parse(text) as T) : (undefined as T);
+}
+
 /** Create a local user with a generated email/password. */
 export async function createUser(role: Role): Promise<TestUser> {
   counter += 1;
@@ -47,7 +94,7 @@ export async function createUser(role: Role): Promise<TestUser> {
   const email = `e2e-${role.toLowerCase()}-${stamp}@example.com`;
   const login = `e2e-${role.toLowerCase()}-${stamp}`;
   const password = `e2e-pw-${stamp}-strongenough`;
-  const user = await apiPost<CreateUserResp>('/api/admin/users', {
+  const user = await adminFetch<CreateUserResp>('POST', '/api/admin/users', {
     email,
     login,
     name: login,
@@ -68,7 +115,7 @@ export async function createServerAdmin(): Promise<TestUser> {
   const email = `e2e-srvadmin-${stamp}@example.com`;
   const login = `e2e-srvadmin-${stamp}`;
   const password = `e2e-pw-${stamp}-strongenough`;
-  const user = await apiPost<CreateUserResp>('/api/admin/users', {
+  const user = await adminFetch<CreateUserResp>('POST', '/api/admin/users', {
     email,
     login,
     name: login,
@@ -81,7 +128,7 @@ export async function createServerAdmin(): Promise<TestUser> {
 
 export async function deleteUser(id: string): Promise<void> {
   try {
-    await apiDelete(`/api/admin/users/${id}`);
+    await adminFetch<unknown>('DELETE', `/api/admin/users/${id}`);
   } catch {
     /* best effort */
   }


### PR DESCRIPTION
PR #134 routed createUser/deleteUser through the cached SA Bearer token, but seed.sh's SA is Editor (org-role=Editor + fixed:ops.commands:runner), not server admin. /api/admin/* requires server admin, so every RBAC scenario failed at setup with 403.

Switches back to the seeded admin user's session cookie + CSRF (the bootstrap admin IS server-admin), the pattern PR #133 had before #134 reverted it.

Effect: full e2e run goes from 16 pass / 45 fail to 25 pass / 36 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test infrastructure for user and token management with an improved authentication flow for admin operations.
  * Enhanced test helper utilities with refined access control patterns for test user lifecycle management (creation and deletion).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->