### PR TITLE
Login 429 backoff + scale timeout + drop it.fails

### DIFF
--- a/tests/e2e/scenarios/alerts/rule-edit-via-put.test.ts
+++ b/tests/e2e/scenarios/alerts/rule-edit-via-put.test.ts
@@ -32,10 +32,9 @@ describe('alerts/rule-edit-via-put', () => {
     try { await scaleDeployment(NS, DEPLOY, 3); } catch { /* noop */ }
   }, 180_000);
 
-  // Marked `it.fails` until evaluator hot-reload is wired through —
-  // ALERT_EVALUATOR_REFRESH_MS is pinned high in the test harness, so
-  // edits won't be visible without a process restart.
-  it.fails('PUT threshold is honored within one evaluator cycle (hot-reload todo)', async () => {
+  // PR #128 wired evaluator hot-reload through EventEmittingAlertRuleRepository,
+  // so PUT changes are visible without a process restart.
+  it('PUT threshold is honored within one evaluator cycle', async () => {
     // Create a rule with a threshold that will NOT trigger at full traffic.
     const created = await apiPost<AlertRule>('/api/alert-rules', {
       name: 'web-api-edit',

--- a/tests/e2e/scenarios/helpers/scale.ts
+++ b/tests/e2e/scenarios/helpers/scale.ts
@@ -58,7 +58,7 @@ export async function scaleDeployment(
     // count directly until every replica is gone.
     await pollUntil(
       async () => ((await podCount(namespace, name)) === 0 ? true : null),
-      { timeoutMs: 90_000, intervalMs: 2000, label: `pods of ${name} -> 0` },
+      { timeoutMs: 180_000, intervalMs: 2000, label: `pods of ${name} -> 0` },
     );
   } else {
     await run('kubectl', [

--- a/tests/e2e/scenarios/helpers/users.ts
+++ b/tests/e2e/scenarios/helpers/users.ts
@@ -179,13 +179,25 @@ function mergeCookies(existing: string, addition: string[]): string {
  * /api/user) so subsequent state-changing requests can echo it.
  */
 export async function loginAs(user: TestUser): Promise<string> {
-  const res = await fetch(`${BASE_URL}/api/login`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ user: user.login, password: user.password }),
-  });
-  if (!res.ok) {
-    throw new Error(`login as ${user.login} -> ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  // /api/login has a per-IP rate limiter. Spinning up many test users
+  // in sequence trips it; retry 429 with exponential backoff.
+  let res: Response | null = null;
+  let attempt = 0;
+  while (attempt < 6) {
+    res = await fetch(`${BASE_URL}/api/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ user: user.login, password: user.password }),
+    });
+    if (res.status !== 429) break;
+    attempt += 1;
+    const backoff = Math.min(1000 * 2 ** attempt, 16_000);
+    await new Promise((r) => setTimeout(r, backoff));
+  }
+  if (!res || !res.ok) {
+    const status = res?.status ?? '<no response>';
+    const body = res ? (await res.text()).slice(0, 200) : '';
+    throw new Error(`login as ${user.login} -> ${status}: ${body}`);
   }
   const setCookie = res.headers.get('set-cookie') ?? '';
   let cookie = parseSetCookie(setCookie).join('; ');


### PR DESCRIPTION
loginAs retries 429 with backoff, scale.ts 90s→180s, rule-edit-via-put drops it.fails (PR #128 wired hot-reload).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Rule threshold edits via PUT now take immediate effect within one evaluator cycle, eliminating the need for process restarts.
  * Login process now automatically retries when rate-limited (HTTP 429), using exponential backoff to improve reliability during high-demand periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->