### PR TITLE
Fix personal chat audit findings

### DIFF
--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -558,7 +558,7 @@ export class ChatService {
       {
         sessionId: resolvedSessionId,
         dashboardId,
-        message: message.slice(0, 80),
+        messageLength: message.length,
       },
       'starting session orchestrator',
     );

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -621,6 +621,7 @@ CREATE TABLE IF NOT EXISTS chat_session_contexts (
 
 CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_session ON chat_session_contexts(session_id);
 CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_owner_resource ON chat_session_contexts(org_id, owner_user_id, resource_type, resource_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_chat_session_contexts_unique ON chat_session_contexts(session_id, resource_type, resource_id, relation);
 
 CREATE TABLE IF NOT EXISTS chat_messages (
   id         TEXT PRIMARY KEY,

--- a/packages/data-layer/src/repository/postgres/chat-session-context.ts
+++ b/packages/data-layer/src/repository/postgres/chat-session-context.ts
@@ -44,26 +44,57 @@ function resourceWhere(scope: ChatSessionContextResourceScope) {
   );
 }
 
+function contextUniqueWhere(context: Parameters<IChatSessionContextRepository['create']>[0]) {
+  return and(
+    eq(chatSessionContexts.sessionId, context.sessionId),
+    eq(chatSessionContexts.orgId, context.orgId),
+    eq(chatSessionContexts.ownerUserId, context.ownerUserId),
+    eq(chatSessionContexts.resourceType, context.resourceType),
+    eq(chatSessionContexts.resourceId, context.resourceId),
+    eq(chatSessionContexts.relation, context.relation),
+  );
+}
+
+function isDuplicateKeyError(err: unknown): boolean {
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+  const cause = err && typeof err === 'object' && 'cause' in err ? (err as { cause?: unknown }).cause : undefined;
+  const message = `${String(err)} ${String(cause)}`.toLowerCase();
+  return code === '23505' || message.includes('duplicate key value violates unique constraint');
+}
+
 export class PostgresChatSessionContextRepository implements IChatSessionContextRepository {
   constructor(private readonly db: any) {}
 
   async create(
     context: Parameters<IChatSessionContextRepository['create']>[0],
   ): Promise<ChatSessionContext> {
-    const [row] = await this.db
-      .insert(chatSessionContexts)
-      .values({
-        id: context.id ?? `chatctx_${randomUUID()}`,
-        sessionId: context.sessionId,
-        orgId: context.orgId,
-        ownerUserId: context.ownerUserId,
-        resourceType: context.resourceType,
-        resourceId: context.resourceId,
-        relation: context.relation,
-        createdAt: context.createdAt ?? new Date().toISOString(),
-      })
-      .returning();
-    return rowToContext(row!);
+    try {
+      const [row] = await this.db
+        .insert(chatSessionContexts)
+        .values({
+          id: context.id ?? `chatctx_${randomUUID()}`,
+          sessionId: context.sessionId,
+          orgId: context.orgId,
+          ownerUserId: context.ownerUserId,
+          resourceType: context.resourceType,
+          resourceId: context.resourceId,
+          relation: context.relation,
+          createdAt: context.createdAt ?? new Date().toISOString(),
+        })
+        .returning();
+      return rowToContext(row!);
+    } catch (err) {
+      if (!isDuplicateKeyError(err)) throw err;
+      const [existing] = await this.db
+        .select()
+        .from(chatSessionContexts)
+        .where(contextUniqueWhere(context));
+      if (existing) return rowToContext(existing);
+      throw err;
+    }
   }
 
   async listBySession(

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -614,6 +614,7 @@ CREATE TABLE IF NOT EXISTS chat_session_contexts (
 
 CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_session ON chat_session_contexts(session_id);
 CREATE INDEX IF NOT EXISTS ix_chat_session_contexts_owner_resource ON chat_session_contexts(org_id, owner_user_id, resource_type, resource_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_chat_session_contexts_unique ON chat_session_contexts(session_id, resource_type, resource_id, relation);
 
 CREATE TABLE IF NOT EXISTS chat_messages (
   id         TEXT PRIMARY KEY,

--- a/packages/data-layer/src/repository/sqlite/chat-session-context.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session-context.ts
@@ -45,26 +45,53 @@ function resourceWhere(scope: ChatSessionContextResourceScope) {
   );
 }
 
+function contextUniqueWhere(context: Parameters<IChatSessionContextRepository['create']>[0]) {
+  return and(
+    eq(chatSessionContexts.sessionId, context.sessionId),
+    eq(chatSessionContexts.orgId, context.orgId),
+    eq(chatSessionContexts.ownerUserId, context.ownerUserId),
+    eq(chatSessionContexts.resourceType, context.resourceType),
+    eq(chatSessionContexts.resourceId, context.resourceId),
+    eq(chatSessionContexts.relation, context.relation),
+  );
+}
+
+function isDuplicateKeyError(err: unknown): boolean {
+  const cause = err && typeof err === 'object' && 'cause' in err ? (err as { cause?: unknown }).cause : undefined;
+  const message = `${String(err)} ${String(cause)}`.toLowerCase();
+  return message.includes('unique constraint failed') || message.includes('constraint_unique');
+}
+
 export class SqliteChatSessionContextRepository implements IChatSessionContextRepository {
   constructor(private readonly db: SqliteClient) {}
 
   async create(
     context: Parameters<IChatSessionContextRepository['create']>[0],
   ): Promise<ChatSessionContext> {
-    const [row] = await this.db
-      .insert(chatSessionContexts)
-      .values({
-        id: context.id ?? `chatctx_${randomUUID()}`,
-        sessionId: context.sessionId,
-        orgId: context.orgId,
-        ownerUserId: context.ownerUserId,
-        resourceType: context.resourceType,
-        resourceId: context.resourceId,
-        relation: context.relation,
-        createdAt: context.createdAt ?? new Date().toISOString(),
-      })
-      .returning();
-    return rowToContext(row!);
+    try {
+      const [row] = await this.db
+        .insert(chatSessionContexts)
+        .values({
+          id: context.id ?? `chatctx_${randomUUID()}`,
+          sessionId: context.sessionId,
+          orgId: context.orgId,
+          ownerUserId: context.ownerUserId,
+          resourceType: context.resourceType,
+          resourceId: context.resourceId,
+          relation: context.relation,
+          createdAt: context.createdAt ?? new Date().toISOString(),
+        })
+        .returning();
+      return rowToContext(row!);
+    } catch (err) {
+      if (!isDuplicateKeyError(err)) throw err;
+      const [existing] = await this.db
+        .select()
+        .from(chatSessionContexts)
+        .where(contextUniqueWhere(context));
+      if (existing) return rowToContext(existing);
+      throw err;
+    }
   }
 
   async listBySession(

--- a/packages/data-layer/src/repository/sqlite/chat-session.test.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session.test.ts
@@ -107,4 +107,31 @@ describe('SqliteChatSessionRepository', () => {
       ).map((c) => c.id),
     ).toEqual(['ctx-b']);
   });
+
+  it('treats duplicate resource context writes as idempotent', async () => {
+    await sessions.create({ id: 's-a', orgId: 'org-1', ownerUserId: 'user-a' });
+    const first = await contexts.create({
+      id: 'ctx-a',
+      sessionId: 's-a',
+      orgId: 'org-1',
+      ownerUserId: 'user-a',
+      resourceType: 'dashboard',
+      resourceId: 'dash-1',
+      relation: 'viewed_with_chat',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    const second = await contexts.create({
+      id: 'ctx-duplicate',
+      sessionId: 's-a',
+      orgId: 'org-1',
+      ownerUserId: 'user-a',
+      resourceType: 'dashboard',
+      resourceId: 'dash-1',
+      relation: 'viewed_with_chat',
+      createdAt: '2026-05-01T00:01:00.000Z',
+    });
+
+    expect(second).toEqual(first);
+    expect(await contexts.listBySession('s-a')).toHaveLength(1);
+  });
 });

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -516,6 +516,11 @@ export function useChat(): UseChatResult {
           sessionId,
           error: res.error,
         });
+        if (is404) {
+          sessionIdRef.current = '';
+          setCurrentSessionId('');
+          lastLoadSessionIdRef.current = null;
+        }
         setLoadError(is404 ? 'not-found' : 'network');
         return;
       }

--- a/packages/web/src/pages/InvestigationDetail.tsx
+++ b/packages/web/src/pages/InvestigationDetail.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { apiClient } from '../api/client.js';
 import InvestigationReportView from '../components/InvestigationReportView.js';
-import type { ConclusionData } from '../components/ConclusionPanel.js';
-import ChatPanel from '../components/ChatPanel.js';
-import type { ChatEvent } from '../hooks/useDashboardChat.js';
 import type {
   InvestigationReport as IReport,
   InvestigationReportSection,
@@ -40,7 +37,6 @@ interface Hypothesis {
 interface FullInvestigation {
   id: string;
   intent: string;
-  sessionId: string;
   status: InvestigationStatus;
   plan: InvestigationPlan;
   hypotheses: Hypothesis[];
@@ -59,133 +55,6 @@ import { getInvestigationStatusStyle } from '../constants/status-styles.js';
 
 function statusDescription(status: string): string {
   return getInvestigationStatusStyle(status).description;
-}
-
-let eventCounter = 0;
-function makeEventId() {
-  return `inv_evt_${++eventCounter}`;
-}
-
-// Convert investigation state changes into ChatEvents for the ChatPanel
-
-function buildChatEvents(
-  investigation: FullInvestigation,
-  conclusion: ConclusionData | null,
-): ChatEvent[] {
-  const events: ChatEvent[] = [];
-
-  // Initial user message — the investigation question
-  events.push({
-    id: makeEventId(),
-    kind: 'message',
-    message: {
-      id: 'user_0',
-      role: 'user',
-      content: investigation.intent,
-      timestamp: investigation.createdAt,
-    },
-  });
-
-  // Planning phase
-  if (investigation.plan?.objective) {
-    events.push({
-      id: makeEventId(),
-      kind: 'thinking',
-      content: `Planning: ${investigation.plan.objective}`,
-    });
-  }
-
-  // Plan steps as tool calls
-  if (investigation.plan?.steps?.length) {
-    for (const step of investigation.plan.steps) {
-      if (step.status === 'pending') continue;
-
-      events.push({
-        id: makeEventId(),
-        kind: 'tool_call',
-        tool: step.type || 'query',
-        content: step.description,
-      });
-
-      if (step.status === 'completed') {
-        events.push({
-          id: makeEventId(),
-          kind: 'tool_result',
-          tool: step.type || 'query',
-          content: `Step completed: ${step.description}`,
-          success: true,
-        });
-      } else if (step.status === 'failed') {
-        events.push({
-          id: makeEventId(),
-          kind: 'tool_result',
-          tool: step.type || 'query',
-          content: `Step failed: ${step.description}`,
-          success: false,
-        });
-      }
-    }
-  }
-
-  // Evidence collected
-  if (investigation.evidence?.length > 0) {
-    events.push({
-      id: makeEventId(),
-      kind: 'thinking',
-      content: `Collected ${investigation.evidence.length} piece${investigation.evidence.length > 1 ? 's' : ''} of evidence`,
-    });
-  }
-
-  // Analysis / status update
-  if (
-    investigation.status === 'explaining' ||
-    investigation.status === 'acting' ||
-    investigation.status === 'verifying'
-  ) {
-    events.push({
-      id: makeEventId(),
-      kind: 'thinking',
-      content: statusDescription(investigation.status),
-    });
-  }
-
-  // Conclusion as assistant message
-  if (conclusion) {
-    let msg = conclusion.summary;
-    if (conclusion.rootCause) {
-      msg += `\n\n**Root Cause:** ${conclusion.rootCause}`;
-    }
-    if (conclusion.recommendedActions?.length) {
-      msg +=
-        '\n\n**Recommended Actions:**\n' +
-        conclusion.recommendedActions
-          .map((a) => `- ${typeof a === 'string' ? a : a.label}`)
-          .join('\n');
-    }
-    events.push({
-      id: makeEventId(),
-      kind: 'message',
-      message: {
-        id: 'conclusion',
-        role: 'assistant',
-        content: msg,
-        timestamp: investigation.updatedAt,
-      },
-    });
-  } else if (investigation.status === 'failed') {
-    events.push({
-      id: makeEventId(),
-      kind: 'error',
-      content: 'Investigation failed. The AI could not complete the analysis.',
-    });
-  }
-
-  // Done event if terminal
-  if (isTerminal(investigation.status)) {
-    events.push({ id: makeEventId(), kind: 'done' });
-  }
-
-  return events;
 }
 
 // Live progress view while investigation is running
@@ -313,12 +182,9 @@ export default function InvestigationDetail() {
   const [investigation, setInvestigation] = useState<FullInvestigation | null>(
     null,
   );
-  const [conclusion, setConclusion] = useState<ConclusionData | null>(null);
   const [report, setReport] = useState<IReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [agentEvents, setAgentEvents] = useState<ChatEvent[]>([]);
-  const [agentGenerating, setAgentGenerating] = useState(false);
 
   // Chat history is bound by the URL (`?chat=...`) and loaded in Layout.
 
@@ -341,13 +207,6 @@ export default function InvestigationDetail() {
       }>(`/investigations/${id}/report`);
       if (!rRes.error && rRes.data?.summary) {
         setReport({ summary: rRes.data.summary, sections: rRes.data.sections });
-      }
-      // Fetch conclusion for chat panel
-      const cRes = await apiClient.get<{ conclusion: ConclusionData }>(
-        `/investigations/${id}/conclusion`,
-      );
-      if (!cRes.error && cRes.data?.conclusion) {
-        setConclusion(cRes.data.conclusion);
       }
     }
   }, [id]);
@@ -373,153 +232,7 @@ export default function InvestigationDetail() {
     return () => clearInterval(timer);
   }, [investigation, fetchInvestigation]);
 
-  // Build chat events from investigation state
-  const baseChatEvents = useMemo(() => {
-    if (!investigation) return [];
-    eventCounter = 0;
-    return buildChatEvents(investigation, conclusion);
-  }, [investigation, conclusion]);
-
-  const chatEvents = useMemo(
-    () => [...baseChatEvents, ...agentEvents],
-    [baseChatEvents, agentEvents],
-  );
-
-  const isGenerating =
-    (investigation ? !isTerminal(investigation.status) : false) ||
-    agentGenerating;
-
-  // Handle follow-up messages from ChatPanel
-  const handleSendMessage = useCallback(
-    async (content: string) => {
-      if (!id) return;
-      const userEventId = crypto.randomUUID();
-      setAgentEvents((prev) => [
-        ...prev,
-        {
-          id: userEventId,
-          kind: 'message',
-          message: {
-            id: userEventId,
-            role: 'user',
-            content,
-            timestamp: new Date().toISOString(),
-          },
-        },
-      ]);
-      setAgentGenerating(true);
-
-      // Investigation follow-ups go through the canonical chat-service endpoint
-      // with `pageContext.kind = 'investigation'` so the orchestrator knows
-      // which investigation to scope tools against. Continue the active
-      // personal chat from the URL/global context when one exists.
-      await apiClient
-        .postStream(
-          `/chat`,
-          {
-            message: content,
-            ...(globalChat.currentSessionId
-              ? { sessionId: globalChat.currentSessionId }
-              : {}),
-            pageContext: { kind: 'investigation', id },
-          },
-          (eventType: string, rawData: string) => {
-            let parsed: Record<string, unknown> = {};
-            try {
-              parsed = JSON.parse(rawData) as Record<string, unknown>;
-            } catch {
-              parsed = { content: rawData };
-            }
-
-            const eventId = crypto.randomUUID();
-
-            if (eventType === 'thinking') {
-              setAgentEvents((prev) => [
-                ...prev,
-                {
-                  id: eventId,
-                  kind: 'thinking',
-                  content: (parsed.content as string) ?? 'Thinking...',
-                },
-              ]);
-              return;
-            }
-
-            if (eventType === 'reply') {
-              setAgentEvents((prev) => [
-                ...prev,
-                {
-                  id: eventId,
-                  kind: 'message',
-                  message: {
-                    id: eventId,
-                    role: 'assistant',
-                    content: (parsed.content as string) ?? '',
-                    timestamp: new Date().toISOString(),
-                  },
-                },
-              ]);
-              return;
-            }
-
-            if (eventType === 'error') {
-              setAgentEvents((prev) => [
-                ...prev,
-                {
-                  id: eventId,
-                  kind: 'error',
-                  content: (parsed.message as string) ?? 'Something went wrong',
-                },
-              ]);
-              setAgentGenerating(false);
-              return;
-            }
-
-            if (eventType === 'done') {
-              if (
-                typeof parsed.navigate === 'string' &&
-                parsed.navigate !== `/investigations/${id}`
-              ) {
-                const target = new URL(parsed.navigate, window.location.origin);
-                const sessionId =
-                  typeof parsed.sessionId === 'string'
-                    ? parsed.sessionId
-                    : globalChat.currentSessionId;
-                if (sessionId) target.searchParams.set('chat', sessionId);
-                const path = `${target.pathname}${target.search}${target.hash}`;
-                if (parsed.intent === 'dashboard') {
-                  navigate(path, { state: { initialPrompt: content } });
-                } else {
-                  navigate(path);
-                }
-                return;
-              }
-              setAgentEvents((prev) => [
-                ...prev,
-                { id: eventId, kind: 'done' },
-              ]);
-              setAgentGenerating(false);
-            }
-          },
-        )
-        .catch((err) => {
-          const message = err instanceof Error ? err.message : 'Network error';
-          setAgentEvents((prev) => [
-            ...prev,
-            {
-              id: crypto.randomUUID(),
-              kind: 'error',
-              content: message,
-            },
-          ]);
-          setAgentGenerating(false);
-        })
-        .finally(() => {
-          setAgentGenerating(false);
-        });
-    },
-    [id, globalChat.currentSessionId, navigate],
-  );
+  const isGenerating = investigation ? !isTerminal(investigation.status) : false;
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- recover from stale or unauthorized ?chat= URLs by clearing the active session on 404
- make chat session context writes idempotent and add the missing SQL unique index
- stop logging prompt snippets in chat startup logs
- remove dead embedded investigation chat/follow-up logic now that Layout owns personal chat

## Verification
- npm run typecheck
- npm --workspace @agentic-obs/web run typecheck
- npx vitest run packages/api-gateway/src/services/chat-service.test.ts packages/api-gateway/src/services/investigation-workspace-service.test.ts packages/data-layer/src/repository/sqlite/chat-session.test.ts packages/data-layer/src/repository/sqlite/dashboard.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate resource context creation is now handled gracefully, returning existing data instead of failing
  * Improved error recovery when sessions are not found, clearing local state appropriately

* **UI Changes**
  * Refactored Investigation Detail page layout to integrate chat interface with global navigation instead of embedding it locally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->