### PR TITLE
Filter service accounts out of setup hasAdmin / seed checks

### DIFF
--- a/packages/api-gateway/src/auth/seed-admin.ts
+++ b/packages/api-gateway/src/auth/seed-admin.ts
@@ -42,7 +42,12 @@ export async function seedAdminIfNeeded(
   opts: SeedAdminOptions = {},
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
-  const list = await deps.users.list({ limit: 1 });
+  // Exclude service accounts. Without this filter, seed-auto-
+  // investigation-sa (which runs at every boot) creates the openobs SA
+  // first, this check sees total > 0 and bails — meaning a fresh
+  // install with SEED_ADMIN_EMAIL/PASSWORD set would never seed the
+  // human admin. Boot order is: migrations → seed-admin → seed SA.
+  const list = await deps.users.list({ limit: 1, isServiceAccount: false });
   if (list.total > 0) {
     return null;
   }

--- a/packages/api-gateway/src/migrations/auth-to-db.ts
+++ b/packages/api-gateway/src/migrations/auth-to-db.ts
@@ -99,7 +99,9 @@ export async function migrateAuthToDbIfNeeded(
     };
   }
 
-  const existing = await deps.users.list({ limit: 1 });
+  // Exclude service accounts so the auto-investigation SA (seeded at
+  // every boot) never makes a fresh install look "already migrated".
+  const existing = await deps.users.list({ limit: 1, isServiceAccount: false });
   if (existing.total > 0) {
     log.info({ userCount: existing.total }, 'users already present; marking migration done');
     if (!dryRun) await writeMarker(deps.db);

--- a/packages/api-gateway/src/routes/setup.ts
+++ b/packages/api-gateway/src/routes/setup.ts
@@ -181,7 +181,10 @@ export function createSetupRouter(deps: SetupRouterDeps): Router {
   router.get('/status', async (_req: Request, res: Response) => {
     let hasAdmin = false;
     try {
-      const { total } = await deps.users.list({ limit: 1 });
+      // Exclude service accounts: seed-auto-investigation-sa inserts a
+      // user row on every boot, so an unfiltered count makes a fresh DB
+      // look bootstrapped and skips the wizard's admin step.
+      const { total } = await deps.users.list({ limit: 1, isServiceAccount: false });
       hasAdmin = total > 0;
     } catch (err) {
       log.warn({ err }, 'hasAdmin probe failed');

--- a/tests/e2e/scenarios/alerts/rule-edit-via-put.test.ts
+++ b/tests/e2e/scenarios/alerts/rule-edit-via-put.test.ts
@@ -32,10 +32,9 @@ describe('alerts/rule-edit-via-put', () => {
     try { await scaleDeployment(NS, DEPLOY, 3); } catch { /* noop */ }
   }, 180_000);
 
-  // Marked `it.fails` until evaluator hot-reload is wired through —
-  // ALERT_EVALUATOR_REFRESH_MS is pinned high in the test harness, so
-  // edits won't be visible without a process restart.
-  it.fails('PUT threshold is honored within one evaluator cycle (hot-reload todo)', async () => {
+  // PR #128 wired evaluator hot-reload through EventEmittingAlertRuleRepository,
+  // so PUT changes are visible without a process restart.
+  it('PUT threshold is honored within one evaluator cycle', async () => {
     // Create a rule with a threshold that will NOT trigger at full traffic.
     const created = await apiPost<AlertRule>('/api/alert-rules', {
       name: 'web-api-edit',

--- a/tests/e2e/scenarios/helpers/scale.ts
+++ b/tests/e2e/scenarios/helpers/scale.ts
@@ -58,7 +58,7 @@ export async function scaleDeployment(
     // count directly until every replica is gone.
     await pollUntil(
       async () => ((await podCount(namespace, name)) === 0 ? true : null),
-      { timeoutMs: 90_000, intervalMs: 2000, label: `pods of ${name} -> 0` },
+      { timeoutMs: 180_000, intervalMs: 2000, label: `pods of ${name} -> 0` },
     );
   } else {
     await run('kubectl', [

--- a/tests/e2e/scenarios/helpers/users.ts
+++ b/tests/e2e/scenarios/helpers/users.ts
@@ -179,13 +179,25 @@ function mergeCookies(existing: string, addition: string[]): string {
  * /api/user) so subsequent state-changing requests can echo it.
  */
 export async function loginAs(user: TestUser): Promise<string> {
-  const res = await fetch(`${BASE_URL}/api/login`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ user: user.login, password: user.password }),
-  });
-  if (!res.ok) {
-    throw new Error(`login as ${user.login} -> ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  // /api/login has a per-IP rate limiter. Spinning up many test users
+  // in sequence trips it; retry 429 with exponential backoff.
+  let res: Response | null = null;
+  let attempt = 0;
+  while (attempt < 6) {
+    res = await fetch(`${BASE_URL}/api/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ user: user.login, password: user.password }),
+    });
+    if (res.status !== 429) break;
+    attempt += 1;
+    const backoff = Math.min(1000 * 2 ** attempt, 16_000);
+    await new Promise((r) => setTimeout(r, backoff));
+  }
+  if (!res || !res.ok) {
+    const status = res?.status ?? '<no response>';
+    const body = res ? (await res.text()).slice(0, 200) : '';
+    throw new Error(`login as ${user.login} -> ${status}: ${body}`);
   }
   const setCookie = res.headers.get('set-cookie') ?? '';
   let cookie = parseSetCookie(setCookie).join('; ');


### PR DESCRIPTION
Fresh install boots → migrations → seed-admin → seed-auto-investigation-sa creates the openobs SA. Three checks then incorrectly see a 'user' and short-circuit: setup status hasAdmin=true (wizard skips Admin step), seed-admin bails when SEED_ADMIN_EMAIL is set, auth-to-db migration marks itself done. Fix: pass isServiceAccount=false to all three users.list() calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin bootstrap and user detection to exclude system service accounts.
  * Corrected API readiness status for fresh installations.
  * Enhanced login retry mechanism for rate-limited requests.

* **Tests**
  * Fixed alert threshold update test following evaluator hot-reload implementation.
  * Increased timeout for deployment scaling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->