### PR TITLE
Steer agent away from Grafana label_values() in metrics_query

### DIFF
--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -104,7 +104,8 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: {
       name: 'metrics_query',
       description:
-        'Run an instant PromQL/MetricsQL query against a metrics datasource. Returns up to 20 series at a specific timestamp (defaults to now). When analyzing what a panel currently shows, pass `time` set to the panel time-window end so the instant value matches the panel rather than "now". Validate complex queries with metrics_validate first when adding panels.',
+        'Run an instant PromQL/MetricsQL query against a metrics datasource. Returns up to 20 series at a specific timestamp (defaults to now). When analyzing what a panel currently shows, pass `time` set to the panel time-window end so the instant value matches the panel rather than "now". Validate complex queries with metrics_validate first when adding panels.\n\n' +
+        'IMPORTANT: this is *Prometheus* PromQL, not Grafana template-variable syntax. Functions like `label_values(metric, label)` and `query_result(...)` are Grafana-only and will return HTTP 400. To enumerate label values, call `metrics_discover` with `kind="values"` and `label="<name>"` instead — that hits the dedicated Prometheus label-values endpoint.',
       input_schema: {
         type: 'object',
         properties: {

--- a/tests/e2e/fixtures/workloads/kube-state-metrics.yaml
+++ b/tests/e2e/fixtures/workloads/kube-state-metrics.yaml
@@ -1,0 +1,125 @@
+# kube-state-metrics: cluster-state metrics surfaced from the
+# Kubernetes API. Provides:
+#   - gauges: kube_pod_status_phase, kube_deployment_status_replicas,
+#             kube_node_status_condition, kube_pod_container_resource_requests
+#   - counters: kube_pod_container_status_restarts_total,
+#               kube_deployment_spec_replicas (sort of — it's a gauge over time
+#               but increments are still meaningful)
+#
+# Cluster-scoped read access is required (deployments, pods, nodes,
+# etc.) — see the ClusterRole below. Scoped to read-only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: openobs-e2e
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openobs-e2e-kube-state-metrics
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - configmaps
+      - secrets
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumes
+    verbs: [list, watch]
+  - apiGroups: [apps]
+    resources: [deployments, statefulsets, daemonsets, replicasets]
+    verbs: [list, watch]
+  - apiGroups: [batch]
+    resources: [cronjobs, jobs]
+    verbs: [list, watch]
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [list, watch]
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses, networkpolicies]
+    verbs: [list, watch]
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses, volumeattachments]
+    verbs: [list, watch]
+  - apiGroups: [certificates.k8s.io]
+    resources: [certificatesigningrequests]
+    verbs: [list, watch]
+  - apiGroups: [policy]
+    resources: [poddisruptionbudgets]
+    verbs: [list, watch]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openobs-e2e-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openobs-e2e-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: openobs-e2e
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: openobs-e2e
+  labels:
+    app: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: telemetry
+              containerPort: 8081
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: openobs-e2e
+  labels:
+    app: kube-state-metrics
+spec:
+  selector:
+    app: kube-state-metrics
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: metrics

--- a/tests/e2e/fixtures/workloads/node-exporter.yaml
+++ b/tests/e2e/fixtures/workloads/node-exporter.yaml
@@ -1,0 +1,75 @@
+# node-exporter: classic node-level metrics. Provides comprehensive
+# coverage of:
+#   - gauges: node_memory_MemAvailable_bytes, node_load1, node_filesystem_avail_bytes
+#   - counters: node_cpu_seconds_total, node_network_receive_bytes_total, node_disk_io_time_seconds_total
+#   - histograms: node_scrape_collector_duration_seconds_bucket
+#
+# Single deployment (not DaemonSet) to keep the kind cluster light;
+# we only need representative metrics, not per-node coverage. The
+# container reads /proc/1 by default, which on kind reflects the node
+# control-plane container (sufficient for testing dashboards).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-exporter
+  namespace: openobs-e2e
+  labels:
+    app: node-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+    spec:
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.8.2
+          args:
+            - --path.rootfs=/host
+            - --collector.disable-defaults
+            - --collector.cpu
+            - --collector.loadavg
+            - --collector.meminfo
+            - --collector.filesystem
+            - --collector.netdev
+            - --collector.diskstats
+          ports:
+            - name: metrics
+              containerPort: 9100
+          volumeMounts:
+            - name: host
+              mountPath: /host
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: openobs-e2e
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    app: node-exporter
+  ports:
+    - port: 9100
+      targetPort: 9100
+      name: metrics

--- a/tests/e2e/fixtures/workloads/prometheus.yaml
+++ b/tests/e2e/fixtures/workloads/prometheus.yaml
@@ -88,6 +88,12 @@ spec:
     metadata:
       labels:
         app: prometheus
+      annotations:
+        # Self-scrape: prometheus's own /metrics exposes counters,
+        # gauges, AND summaries (e.g. prometheus_target_interval_length_seconds),
+        # giving the e2e cluster coverage of all Prometheus metric types.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
       serviceAccountName: prometheus
       containers:


### PR DESCRIPTION
Free-tier models emit label_values(metric, label) (Grafana template-var function) when asked to enumerate label values — Prometheus 400s and agent gives up. Add a one-line callout in metrics_query's description: use metrics_discover(kind=values) instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `metrics_query` tool documentation to clarify incompatibility with certain Grafana template functions and recommend using `metrics_discover` as an alternative for label-value enumeration.

* **Tests**
  * Enhanced e2e test infrastructure with Kubernetes fixtures for monitoring agents and improved Prometheus self-monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->