### PR TITLE
Fix Corporate Gateway / Bedrock setup + Anthropic wire whitelist

### DIFF
--- a/packages/api-gateway/src/routes/datasources.ts
+++ b/packages/api-gateway/src/routes/datasources.ts
@@ -7,7 +7,7 @@
  */
 
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import type {
@@ -121,7 +121,7 @@ export function createDatasourcesRouter(deps: DatasourcesRouterDeps): Router {
   router.post(
     '/',
     requirePermission(() => ac.eval(ACTIONS.DatasourcesCreate)),
-    async (req: Request, res: Response) => {
+    async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body as DatasourceBody;
     if (!body?.type || !body.url || !body.name) {
       res.status(400).json({
@@ -131,29 +131,47 @@ export function createDatasourcesRouter(deps: DatasourcesRouterDeps): Router {
     }
     const actor = actorFromReq(req);
     const orgId = resolveOrgId(req, body);
-    // If caller supplies an id that already exists, surface 409.
-    if (body.id && (await setupConfig.getDatasource(body.id, { orgId }))) {
-      res.status(409).json({
-        error: { code: 'CONFLICT', message: `Datasource "${body.id}" already exists` },
-      });
-      return;
+    try {
+      // If caller supplies an id that already exists, surface 409.
+      if (body.id && (await setupConfig.getDatasource(body.id, { orgId }))) {
+        res.status(409).json({
+          error: { code: 'CONFLICT', message: `Datasource "${body.id}" already exists` },
+        });
+        return;
+      }
+      const input: NewInstanceDatasource = {
+        id: body.id,
+        type: body.type,
+        name: body.name,
+        url: body.url,
+        environment: body.environment ?? null,
+        cluster: body.cluster ?? null,
+        label: body.label ?? null,
+        apiKey: body.apiKey ?? null,
+        username: body.username ?? null,
+        password: body.password ?? null,
+        isDefault: body.isDefault ?? false,
+        orgId,
+      };
+      const created = await setupConfig.createDatasource(input, actor);
+      res.status(201).json({ datasource: maskForWire(created) });
+    } catch (err) {
+      // SQLite unique-constraint races (e.g. two concurrent POSTs with the
+      // same name/id) reach here after the pre-check above. Map them to a
+      // proper 409 instead of letting the request hang on an unhandled
+      // promise rejection — Express 4 doesn't auto-forward async throws.
+      const code = (err as { code?: string } | null)?.code;
+      if (code === 'SQLITE_CONSTRAINT_UNIQUE' || code === 'SQLITE_CONSTRAINT') {
+        res.status(409).json({
+          error: {
+            code: 'CONFLICT',
+            message: `Datasource conflicts with an existing entry${body.id ? ` ("${body.id}")` : ''}`,
+          },
+        });
+        return;
+      }
+      next(err);
     }
-    const input: NewInstanceDatasource = {
-      id: body.id,
-      type: body.type,
-      name: body.name,
-      url: body.url,
-      environment: body.environment ?? null,
-      cluster: body.cluster ?? null,
-      label: body.label ?? null,
-      apiKey: body.apiKey ?? null,
-      username: body.username ?? null,
-      password: body.password ?? null,
-      isDefault: body.isDefault ?? false,
-      orgId,
-    };
-    const created = await setupConfig.createDatasource(input, actor);
-    res.status(201).json({ datasource: maskForWire(created) });
   },
   );
 

--- a/packages/api-gateway/src/routes/system.ts
+++ b/packages/api-gateway/src/routes/system.ts
@@ -73,9 +73,18 @@ export function createSystemRouter(deps: SystemRouterDeps): Router {
       });
       return;
     }
-    if (!cfg.apiKey && cfg.provider !== 'ollama' && cfg.provider !== 'aws-bedrock') {
+    // Providers that authenticate without a static `apiKey`:
+    //  - ollama / aws-bedrock: no key concept (Bedrock uses SigV4)
+    //  - corporate-gateway: typically authed at the network edge
+    //    (mTLS / sidecar) or via a rotating helper command
+    // For everyone else, accept either a static key OR an apiKeyHelper.
+    const keylessProviders = new Set(['ollama', 'aws-bedrock', 'corporate-gateway']);
+    if (!cfg.apiKey && !cfg.apiKeyHelper && !keylessProviders.has(cfg.provider)) {
       res.status(400).json({
-        error: { code: 'VALIDATION', message: 'apiKey is required for this provider' },
+        error: {
+          code: 'VALIDATION',
+          message: 'apiKey or apiKeyHelper is required for this provider',
+        },
       });
       return;
     }
@@ -86,6 +95,8 @@ export function createSystemRouter(deps: SystemRouterDeps): Router {
       baseUrl: cfg.baseUrl ?? null,
       authType: cfg.authType ?? null,
       region: cfg.region ?? null,
+      apiKeyHelper: cfg.apiKeyHelper ?? null,
+      apiFormat: cfg.apiFormat ?? null,
     };
     const saved = await setupConfig.setLlm(input, actorFromReq(req));
     res.json({ ok: true, llm: { ...saved, apiKey: saved.apiKey ? '••••••' + (saved.apiKey.slice(-4)) : null } });

--- a/packages/api-gateway/src/services/setup-llm-service.ts
+++ b/packages/api-gateway/src/services/setup-llm-service.ts
@@ -7,6 +7,7 @@ import {
   GeminiProvider,
   OllamaProvider,
   ProviderError,
+  buildApiKeyResolver,
   type ModelInfo,
 } from '@agentic-obs/llm-gateway';
 import { ensureSafeUrl } from '../utils/url-validator.js';
@@ -40,8 +41,16 @@ export class SetupLlmServiceError extends Error {
   }
 }
 
-function resolveToken(cfg: LlmConfigWire): string | null {
-  return cfg.apiKey ?? null;
+async function resolveToken(cfg: LlmConfigWire): Promise<string | null> {
+  // Honour `apiKeyHelper` here too — otherwise the Test Connection probe
+  // sends no auth header even though the saved config will, and the user
+  // sees a confusing 401 against a config that actually works.
+  const resolver = buildApiKeyResolver({
+    staticKey: cfg.apiKey ?? null,
+    helperCommand: cfg.apiKeyHelper ?? null,
+  });
+  const value = (await resolver()).trim();
+  return value.length > 0 ? value : null;
 }
 
 function describeFetchError(err: unknown): string {
@@ -89,7 +98,7 @@ export class SetupLlmService {
         const baseUrl = cfg.baseUrl;
         if (!baseUrl) return { ok: false, message: 'Gateway base URL is required' };
         const apiFormat = cfg.apiFormat ?? 'anthropic';
-        const token = resolveToken(cfg);
+        const token = await resolveToken(cfg);
         // Token is OPTIONAL for corp gateways — some authenticate via the
         // network boundary (mTLS / IP allowlist / sidecar proxy). When set
         // we forward it; when empty we skip the auth header entirely.
@@ -131,9 +140,16 @@ export class SetupLlmService {
           headers['anthropic-version'] = '2023-06-01';
         }
         if (token && apiFormat !== 'gemini') {
-          if (cfg.authType === 'bearer' || apiFormat === 'openai') {
+          // Bedrock-style upstreams (and any explicit `bearer` authType)
+          // expect `Authorization: Bearer …`. Anthropic native gateways use
+          // `x-api-key`. Anything else falls back to `api-key`.
+          if (
+            cfg.authType === 'bearer' ||
+            apiFormat === 'openai' ||
+            apiFormat === 'anthropic-bedrock'
+          ) {
             headers['Authorization'] = `Bearer ${token}`;
-          } else if (apiFormat === 'anthropic' || apiFormat === 'anthropic-bedrock') {
+          } else if (apiFormat === 'anthropic') {
             headers['x-api-key'] = token;
           } else {
             headers['api-key'] = token;

--- a/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
@@ -180,6 +180,160 @@ describe('AnthropicProvider — request body', () => {
     expect(body.system).toBe('You are helpful.\nBe brief.');
     expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
   });
+
+  // ── Wire-translation regression tests ──────────────────────────────
+  // Bedrock validates request bodies strictly; any internal-only field
+  // that leaks into the wire body becomes a 400. These tests pin the
+  // chokepoint so future internal additions don't silently re-leak.
+
+  it('strips tool_name from tool_result blocks (internal-only field)', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-sonnet-4-5',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete(
+      [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'tu_1', name: 'metrics.query', input: { q: 'up' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            // tool_name is required by openobs's internal ContentBlock (used
+            // by OpenAI/Gemini providers) but MUST NOT appear on the wire.
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_1',
+              tool_name: 'metrics.query',
+              content: '{"value": 1}',
+            },
+          ],
+        },
+      ],
+      { model: 'claude-sonnet-4-5' },
+    );
+
+    const body = getRequestBody(spy);
+    const messages = body.messages as Array<{ role: string; content: unknown }>;
+    const userBlocks = messages[1]?.content as Array<Record<string, unknown>>;
+    expect(userBlocks[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: '{"value": 1}',
+    });
+    expect(userBlocks[0]).not.toHaveProperty('tool_name');
+  });
+
+  it('preserves is_error on tool_result when set', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-sonnet-4-5',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete(
+      [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_1',
+              tool_name: 'metrics.query',
+              content: 'boom',
+              is_error: true,
+            },
+          ],
+        },
+      ],
+      { model: 'claude-sonnet-4-5' },
+    );
+
+    const body = getRequestBody(spy);
+    const userBlocks = (body.messages as Array<{ content: unknown }>)[0]
+      ?.content as Array<Record<string, unknown>>;
+    expect(userBlocks[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: 'boom',
+      is_error: true,
+    });
+  });
+
+  it('omits temperature for Opus 4.7 (deprecated sampling)', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-opus-4-7',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'claude-opus-4-7',
+      temperature: 0.2,
+    });
+
+    const body = getRequestBody(spy);
+    expect(body).not.toHaveProperty('temperature');
+  });
+
+  it('passes temperature through for older models that still accept it', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-3-5-sonnet-latest',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'claude-3-5-sonnet-latest',
+      temperature: 0.2,
+    });
+
+    const body = getRequestBody(spy);
+    expect(body.temperature).toBe(0.2);
+  });
+
+  it('omits temperature when thinking is enabled on a sampling-deprecated model', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-opus-4-7',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'claude-opus-4-7',
+      temperature: 0.2,
+      thinking: { effort: 'low' },
+    });
+
+    const body = getRequestBody(spy);
+    expect(body).not.toHaveProperty('temperature');
+    expect(body.thinking).toMatchObject({ type: 'enabled' });
+  });
 });
 
 describe('AnthropicProvider — response parsing', () => {

--- a/packages/llm-gateway/src/providers/anthropic.ts
+++ b/packages/llm-gateway/src/providers/anthropic.ts
@@ -4,11 +4,12 @@ import type {
   LLMOptions,
   LLMResponse,
   CompletionMessage,
+  ContentBlock,
   ModelInfo,
   ToolCall,
 } from '../types.js';
 import { ProviderError, classifyProviderHttpError } from '../types.js';
-import { effortToBudgetTokens, getCapabilities } from './capabilities.js';
+import { effortToBudgetTokens, getCapabilities, type SamplingParam } from './capabilities.js';
 import { buildApiKeyResolver } from '../api-key-helper.js';
 
 const log = createLogger('anthropic-provider');
@@ -108,6 +109,84 @@ function isThinkingBlock(block: AnthropicContentBlock): block is AnthropicThinki
   return block.type === 'thinking' && typeof (block as AnthropicThinkingBlock).thinking === 'string';
 }
 
+// ── Wire translation ──────────────────────────────────────────────────────
+//
+// The gateway's internal `ContentBlock` is a superset designed to round-trip
+// across all providers (it carries fields like `tool_name` that OpenAI /
+// Gemini's wire shapes need on tool_result). The Anthropic wire is stricter —
+// Bedrock in particular rejects unknown fields with
+// `ValidationException: Extra inputs are not permitted`. Every block that
+// leaves this provider goes through these explicit rebuilds, so adding a new
+// internal field never silently leaks onto the Anthropic wire.
+
+interface AnthropicToolResultWireBlock {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+type AnthropicWireBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | AnthropicToolResultWireBlock
+  | { type: 'thinking'; thinking: string; signature?: string };
+
+interface AnthropicWireMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicWireBlock[];
+}
+
+function toAnthropicWireBlock(b: ContentBlock): AnthropicWireBlock {
+  switch (b.type) {
+    case 'text':
+      return { type: 'text', text: b.text };
+    case 'tool_use':
+      return { type: 'tool_use', id: b.id, name: b.name, input: b.input };
+    case 'tool_result': {
+      // Deliberately drop `tool_name` — the Anthropic wire has no such field.
+      // tool_result is correlated to its tool_use purely via `tool_use_id`.
+      const out: AnthropicToolResultWireBlock = {
+        type: 'tool_result',
+        tool_use_id: b.tool_use_id,
+        content: b.content,
+      };
+      if (b.is_error !== undefined) out.is_error = b.is_error;
+      return out;
+    }
+  }
+}
+
+function toAnthropicWireMessage(m: CompletionMessage): AnthropicWireMessage {
+  // Anthropic only accepts user/assistant in the messages array; system is
+  // hoisted out by the caller. Anything else here is a programmer error.
+  if (m.role !== 'user' && m.role !== 'assistant') {
+    throw new Error(`toAnthropicWireMessage: unexpected role "${m.role}"`);
+  }
+  if (typeof m.content === 'string') {
+    return { role: m.role, content: m.content };
+  }
+  return { role: m.role, content: m.content.map(toAnthropicWireBlock) };
+}
+
+/**
+ * Pick the sampling knobs the model accepts. Returns an object spread-ready
+ * for the request body — keys absent from the result must NOT appear on the
+ * wire (some upstreams treat presence-with-undefined as a validation error).
+ */
+function pickSamplingParams(
+  options: LLMOptions,
+  allowed: ReadonlySet<SamplingParam>,
+): { temperature?: number; top_p?: number; top_k?: number } {
+  const out: { temperature?: number; top_p?: number; top_k?: number } = {};
+  if (allowed.has('temperature') && options.temperature !== undefined) {
+    out.temperature = options.temperature;
+  }
+  // top_p / top_k aren't on LLMOptions today; reserved for future without
+  // having to re-touch this site.
+  return out;
+}
+
 export class AnthropicProvider implements LLMProvider {
   readonly name = 'anthropic';
   private readonly resolveKey: () => Promise<string>;
@@ -143,15 +222,20 @@ export class AnthropicProvider implements LLMProvider {
       if (typeof c === 'string') return c;
       return c.filter((b) => b.type === 'text').map((b) => (b as { type: 'text'; text: string }).text).join('\n');
     };
+
+    const capabilities = getCapabilities('anthropic', options.model ?? '');
+    const sampling = pickSamplingParams(options, capabilities.samplingParams);
+
     const requestBody: Record<string, unknown> = {
       model: options.model,
       system: systemParts.length > 0 ? systemParts.map((m) => flattenContent(m.content)).join('\n') : undefined,
-      // Conversation messages pass through as-is. Anthropic's API natively
-      // accepts content as either a string or an array of {type:'text'|'tool_use'|'tool_result'}
-      // blocks, which exactly matches our ContentBlock shape — no translation needed.
-      messages: conversationParts,
-      temperature: options.temperature,
+      // Translate to Anthropic wire shape. Internal ContentBlock carries
+      // fields (e.g. tool_result.tool_name) that other providers need but
+      // Anthropic/Bedrock reject as "Extra inputs". Whitelisting here is the
+      // single chokepoint that keeps internal shape from leaking out.
+      messages: conversationParts.map(toAnthropicWireMessage),
       max_tokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+      ...sampling,
     };
     if (tools) {
       requestBody.tools = tools;
@@ -161,11 +245,17 @@ export class AnthropicProvider implements LLMProvider {
     }
 
     // Extended thinking — only attach when the model supports it. Anthropic
-    // requires temperature=1 when thinking is enabled, so we override here.
-    if (options.thinking && getCapabilities('anthropic', options.model ?? '').supportsThinking) {
+    // requires temperature=1 when thinking is enabled, so we override here
+    // (only when the model actually accepts a temperature knob; otherwise
+    // the API uses its own implicit value).
+    if (options.thinking && capabilities.supportsThinking) {
       const budget = effortToBudgetTokens(options.thinking.effort);
       requestBody.thinking = { type: 'enabled', budget_tokens: budget };
-      requestBody.temperature = 1;
+      if (capabilities.samplingParams.has('temperature')) {
+        requestBody.temperature = 1;
+      } else {
+        delete requestBody.temperature;
+      }
       // budget_tokens must be < max_tokens; bump max_tokens if needed
       const currentMax = (requestBody.max_tokens as number) ?? DEFAULT_MAX_TOKENS;
       if (currentMax <= budget) {

--- a/packages/llm-gateway/src/providers/capabilities.ts
+++ b/packages/llm-gateway/src/providers/capabilities.ts
@@ -1,3 +1,5 @@
+export type SamplingParam = 'temperature' | 'top_p' | 'top_k';
+
 export interface ProviderCapabilities {
   /** Does the provider support native tool_use API? Required to use ANY tools. */
   supportsNativeTools: boolean;
@@ -9,7 +11,18 @@ export interface ProviderCapabilities {
   supportsThinking: boolean;
   /** Can the model emit multiple tool_use blocks in a single turn? */
   supportsParallelTools: boolean;
+  /**
+   * Sampling knobs the model accepts on the wire. Models outside this set
+   * MUST be filtered out before sending — newer Anthropic models (Opus 4.7+)
+   * deprecated `temperature`/`top_p`/`top_k` and Bedrock returns 400
+   * `ValidationException: temperature is deprecated for this model` when an
+   * older default leaks through. Empty set = no sampling knobs supported.
+   */
+  samplingParams: ReadonlySet<SamplingParam>;
 }
+
+const ALL_SAMPLING: ReadonlySet<SamplingParam> = new Set(['temperature', 'top_p', 'top_k']);
+const NO_SAMPLING: ReadonlySet<SamplingParam> = new Set();
 
 // Per-provider model-name predicates for thinking support. Kept narrow on
 // purpose — when a new model family lands, add the regex here rather than
@@ -20,6 +33,20 @@ function anthropicSupportsThinking(model: string): boolean {
   if (/^claude-3-7-/.test(model)) return true;
   if (/^claude-(opus|sonnet|haiku)-([4-9]|\d{2,})/.test(model)) return true;
   return false;
+}
+
+/**
+ * Anthropic deprecated sampling knobs (temperature/top_p/top_k) starting with
+ * the Opus 4.7 line. Older models (3.x, 4.x through 4.6) still accept them.
+ * Bedrock enforces this strictly; api.anthropic.com is currently lenient but
+ * will follow.
+ */
+function anthropicSamplingParams(model: string): ReadonlySet<SamplingParam> {
+  // 4.7+ deprecated all sampling controls. Match `claude-(opus|sonnet|haiku)-4-7`
+  // and any future minor (4-8, 4-9, 4-10…) plus the entire 5.x+ line.
+  if (/^claude-(opus|sonnet|haiku)-4-([7-9]|\d{2,})/.test(model)) return NO_SAMPLING;
+  if (/^claude-(opus|sonnet|haiku)-([5-9]|\d{2,})/.test(model)) return NO_SAMPLING;
+  return ALL_SAMPLING;
 }
 
 function openaiSupportsReasoning(model: string): boolean {
@@ -52,26 +79,40 @@ export function getCapabilities(
         supportsNativeTools: true,
         supportsThinking: anthropicSupportsThinking(model),
         supportsParallelTools: true,
+        samplingParams: anthropicSamplingParams(model),
       };
     case 'openai':
       return {
         supportsNativeTools: true,
         supportsThinking: openaiSupportsReasoning(model),
         supportsParallelTools: true,
+        // OpenAI reasoning models (o-series, gpt-5) reject temperature/top_p.
+        samplingParams: openaiSupportsReasoning(model) ? NO_SAMPLING : ALL_SAMPLING,
       };
     case 'gemini':
       return {
         supportsNativeTools: true,
         supportsThinking: geminiSupportsThinking(model),
         supportsParallelTools: false,
+        samplingParams: ALL_SAMPLING,
       };
     case 'ollama':
       // Per-model — runtime probe handles tool capability. Thinking is model
       // dependent (Qwen3-Thinking, QwQ have it) and we can't tell without a
       // probe; keep false so we don't send an unsupported flag.
-      return { supportsNativeTools: true, supportsThinking: false, supportsParallelTools: false };
+      return {
+        supportsNativeTools: true,
+        supportsThinking: false,
+        supportsParallelTools: false,
+        samplingParams: ALL_SAMPLING,
+      };
     case 'mock':
-      return { supportsNativeTools: true, supportsThinking: false, supportsParallelTools: true };
+      return {
+        supportsNativeTools: true,
+        supportsThinking: false,
+        supportsParallelTools: true,
+        samplingParams: ALL_SAMPLING,
+      };
   }
 }
 

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -1114,11 +1114,16 @@ function LlmTab({ canWrite }: { canWrite: boolean }) {
   }, []);
 
   const provider = LLM_PROVIDERS.find((p) => p.value === config.provider) ?? LLM_PROVIDERS[0]!;
-  // Only fetched models are selectable — no manual entry, no fallback list.
-  const availableModels = remoteModels.map((m) => ({
-    id: m.id,
-    label: m.description ? `${m.name} (${m.description})` : m.name,
-  }));
+  // Prefer fetched models, but fall back to the provider's known list so
+  // providers without a /models endpoint (e.g. corporate-gateway) still
+  // surface options. The Default Model field is also free-text via
+  // <datalist> so users can type any model the upstream supports.
+  const availableModels = (remoteModels.length > 0
+    ? remoteModels.map((m) => ({
+        id: m.id,
+        label: m.description ? `${m.name} (${m.description})` : m.name,
+      }))
+    : provider.fallbackModels.map((id) => ({ id, label: id })));
 
   const handleFetchModels = async () => {
     setFetchingModels(true); setRemoteModels([]); setModelsFetched(false); setModelsWarning(null);
@@ -1260,9 +1265,16 @@ function LlmTab({ canWrite }: { canWrite: boolean }) {
       <div>
         <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Default Model</label>
         <div className="flex gap-2">
-          <select value={config.model} onChange={(e) => setConfig((prev) => ({ ...prev, model: e.target.value }))} className={selectCls + ' flex-1'}>
+          <input
+            list="llm-model-options"
+            value={config.model}
+            onChange={(e) => setConfig((prev) => ({ ...prev, model: e.target.value }))}
+            placeholder="model id"
+            className={inputCls + ' flex-1'}
+          />
+          <datalist id="llm-model-options">
             {availableModels.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
-          </select>
+          </datalist>
           {provider.supportsModelFetch && (
             <button type="button" onClick={() => void handleFetchModels()} disabled={fetchingModels || (provider.needsKey && !config.apiKey)} className={btnSecondary + ' whitespace-nowrap'}>
               {fetchingModels ? 'Loading...' : 'Fetch Models'}

--- a/packages/web/src/pages/setup/StepLlm.tsx
+++ b/packages/web/src/pages/setup/StepLlm.tsx
@@ -25,12 +25,16 @@ export function StepLlm({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const provider = LLM_PROVIDERS.find((p) => p.value === config.provider) ?? LLM_PROVIDERS[0]!;
 
-  // Only fetched models are selectable — no manual entry, no fallback list.
-  // The user must click Fetch Models successfully before they can pick one.
-  const availableModels: Array<{ id: string; label: string }> = remoteModels.map((m) => ({
-    id: m.id,
-    label: m.description ? `${m.name} (${m.description})` : m.name,
-  }));
+  // Prefer fetched models; fall back to the provider's known list so
+  // providers without a /models endpoint (e.g. corporate-gateway) still
+  // surface options. The Default Model field is also free-text via
+  // <datalist> so users can type any model the upstream supports.
+  const availableModels: Array<{ id: string; label: string }> = remoteModels.length > 0
+    ? remoteModels.map((m) => ({
+        id: m.id,
+        label: m.description ? `${m.name} (${m.description})` : m.name,
+      }))
+    : provider.fallbackModels.map((id) => ({ id, label: id }));
 
   const handleFetchModels = async () => {
     setFetchingModels(true);
@@ -122,7 +126,7 @@ export function StepLlm({
     config.apiKey.length > 0 ||
     config.apiKeyHelper.length > 0 ||
     config.provider === 'corporate-gateway';
-  const canProceed = Boolean(config.model) && remoteModels.length > 0 && hasCredential;
+  const canProceed = Boolean(config.model) && hasCredential;
 
   return (
     <div>
@@ -262,21 +266,20 @@ export function StepLlm({
         <div>
           <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Default Model</label>
           <div className="flex gap-2 items-stretch min-w-0">
-            <select
+            <input
+              list="step-llm-model-options"
               value={config.model}
               onChange={(e) => onChange({ model: e.target.value })}
-              disabled={availableModels.length === 0}
-              className="flex-1 min-w-0 w-full px-3 py-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 focus:border-[var(--color-primary)] truncate disabled:opacity-60"
-            >
-              {availableModels.length === 0 && (
-                <option value="">— Click "Fetch Models" to load —</option>
-              )}
+              placeholder="model id"
+              className="flex-1 min-w-0 w-full px-3 py-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 focus:border-[var(--color-primary)] truncate"
+            />
+            <datalist id="step-llm-model-options">
               {availableModels.map((m) => (
                 <option key={m.id} value={m.id}>
                   {m.label}
                 </option>
               ))}
-            </select>
+            </datalist>
             {provider.supportsModelFetch && (
               <button
                 type="button"


### PR DESCRIPTION
## Summary

Two related sets of fixes surfaced while wiring Corporate Gateway + Bedrock as LLM providers.

**Setup-flow bugs (commit 331dd32)** — the wizard / Settings page couldn't actually save or use a Corporate Gateway / Bedrock config:
- `setup-llm-service.resolveToken` ignored `apiKeyHelper`, so Test Connection sent no auth header even when the saved config would have. Now goes through `buildApiKeyResolver`, same path as live requests.
- Anthropic-on-Bedrock was sent `x-api-key` (Bedrock 401s); now goes through `Authorization: Bearer`.
- `PUT /api/system/llm` rejected helper-only configs as VALIDATION 400 (apiKey required) and dropped `apiKeyHelper` + `apiFormat` on save, so even successful saves didn't round-trip. Added `corporate-gateway` to the keyless whitelist; helper now substitutes for key.
- Default Model `<select>` only accepted fetched models — Corporate Gateway has no `/models` endpoint, so the dropdown was empty and Continue stayed grey forever. Swapped for `<input list>` + `<datalist>` with `provider.fallbackModels`; dropped the `remoteModels.length > 0` gate from `canProceed`.
- `POST /api/datasources` had no try/catch on `createDatasource`, so SQLITE_CONSTRAINT_UNIQUE became an unhandled async rejection and the request hung. Express 4 doesn't auto-forward async throws — wrapped with try/catch returning 409 on conflict, `next(err)` otherwise.

**Anthropic wire-shape whitelist (commit 23c6f1d)** — Bedrock validates request bodies strictly and exposed two latent bugs that api.anthropic.com had been lenient about:
- `tool_result.tool_name: Extra inputs are not permitted` — internal `ContentBlock` is a superset (carries `tool_name` for the OpenAI/Gemini providers' wire shapes), but the Anthropic provider was passing it straight through. Mirrors how OpenAI/Gemini already rebuild their own wire shapes — Anthropic was the only passthrough offender. Added explicit `toAnthropicWireBlock()` chokepoint so future internal fields can't silently leak.
- `temperature is deprecated for this model` — Opus 4.7+ removed sampling knobs, but agent layer hardcodes `temperature: 0.2` and the provider was unconditionally spreading it. Capabilities now declare per-(provider, model) which sampling knobs are accepted; Anthropic 4.7+ and OpenAI reasoning models get an empty set, so sampling fields don't appear on the wire at all (not `temperature: undefined` — some validators are presence-sensitive).

Five regression tests pin both behaviours.

## Test plan
- [x] `vitest run packages/llm-gateway` — 76/76 pass (including 5 new Anthropic regression tests)
- [x] `vitest run packages/api-gateway/src/routes/datasources.test.ts` — 2/2 pass
- [x] `tsc -p packages/llm-gateway` clean
- [ ] Manual: configure a Corporate Gateway (anthropic-bedrock format) in Settings, save, run a chat — should not see 400 `tool_name` or `temperature` validation errors
- [ ] Manual: configure Corporate Gateway with apiKeyHelper only (no static key) — save should succeed; Continue button should not be permanently disabled
- [ ] Manual: POST a duplicate datasource — should return 409 quickly, not hang the UI on "Adding..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for keyless LLM providers (Ollama, AWS Bedrock, Corporate Gateway) without requiring API keys
  * Model selection changed to free-text input with suggestions for improved flexibility and manual entry
  * Added API key helper command support for credential management

* **Bug Fixes**
  * Improved error handling for duplicate datasource creation with proper HTTP 409 Conflict response

* **Tests**
  * Enhanced test coverage for Anthropic API request formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->