### PR TITLE
Canonicalize Bedrock/Vertex/ARN model ids before capability lookup

### DIFF
--- a/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
@@ -313,6 +313,29 @@ describe('AnthropicProvider — request body', () => {
     expect(body.temperature).toBe(0.2);
   });
 
+  it('omits temperature for Bedrock cross-region Opus 4.7 inference profile id', async () => {
+    // The user's actual Bedrock id; previous regex (`^claude-…`) failed to
+    // match this and silently let temperature through, re-triggering the
+    // 400 these capabilities exist to prevent.
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'us.anthropic.claude-opus-4-7-20250101-v1:0',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'us.anthropic.claude-opus-4-7-20250101-v1:0',
+      temperature: 0.2,
+    });
+
+    const body = getRequestBody(spy);
+    expect(body).not.toHaveProperty('temperature');
+  });
+
   it('omits temperature when thinking is enabled on a sampling-deprecated model', async () => {
     const spy = mockFetch(async () =>
       makeJsonResponse({

--- a/packages/llm-gateway/src/providers/__tests__/capabilities.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/capabilities.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Capability detection — focuses on the model-id normalization that lets
+ * Bedrock / Vertex / ARN-wrapped ids collapse to the same answer as the bare
+ * first-party id. The previous regex-only implementation only matched
+ * `^claude-…` and silently fell back to "old model behavior" for every
+ * Bedrock cross-region inference profile, re-introducing the
+ * `temperature is deprecated` 400 these capabilities exist to prevent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getCapabilities } from '../capabilities.js';
+
+describe('getCapabilities — Anthropic sampling gating', () => {
+  it.each([
+    // First-party
+    'claude-opus-4-7',
+    'claude-opus-4-7-20250101',
+    // Vertex AI version syntax
+    'claude-opus-4-7@20250101',
+    // Bedrock foundation model
+    'anthropic.claude-opus-4-7-v1:0',
+    // Bedrock cross-region inference profiles
+    'us.anthropic.claude-opus-4-7-20250101-v1:0',
+    'eu.anthropic.claude-opus-4-7-v1:0',
+    'apac.anthropic.claude-opus-4-7-v1:0',
+    'global.anthropic.claude-opus-4-7-v1:0',
+    // Bedrock ARN
+    'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-opus-4-7-v1:0',
+    // Casing should not matter
+    'US.Anthropic.Claude-Opus-4-7-v1:0',
+  ])('drops sampling for Opus 4.7 across id form: %s', (model) => {
+    const caps = getCapabilities('anthropic', model);
+    expect(caps.samplingParams.size).toBe(0);
+  });
+
+  it.each([
+    'claude-sonnet-4-5',
+    'claude-3-5-sonnet-latest',
+    'claude-3-5-haiku-20241022',
+    'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+  ])('keeps sampling for older models: %s', (model) => {
+    const caps = getCapabilities('anthropic', model);
+    expect(caps.samplingParams.has('temperature')).toBe(true);
+  });
+
+  it.each([
+    'claude-sonnet-4-7',
+    'claude-haiku-4-8',
+    'claude-opus-5-0',
+    'us.anthropic.claude-sonnet-5-1-v1:0',
+  ])('drops sampling for future 4.7+/5.x ids: %s', (model) => {
+    const caps = getCapabilities('anthropic', model);
+    expect(caps.samplingParams.size).toBe(0);
+  });
+});
+
+describe('getCapabilities — Anthropic thinking gating', () => {
+  it.each([
+    'claude-opus-4-7',
+    'us.anthropic.claude-opus-4-7-v1:0',
+    'arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-opus-4-7-v1:0',
+    'claude-3-7-sonnet-20250219',
+    'anthropic.claude-3-7-sonnet-20250219-v1:0',
+  ])('reports thinking support across id forms: %s', (model) => {
+    expect(getCapabilities('anthropic', model).supportsThinking).toBe(true);
+  });
+
+  it.each([
+    'claude-3-5-sonnet-latest',
+    'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  ])('reports no thinking for pre-3.7 models: %s', (model) => {
+    expect(getCapabilities('anthropic', model).supportsThinking).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/providers/capabilities.ts
+++ b/packages/llm-gateway/src/providers/capabilities.ts
@@ -28,10 +28,37 @@ const NO_SAMPLING: ReadonlySet<SamplingParam> = new Set();
 // purpose — when a new model family lands, add the regex here rather than
 // guessing from prefix patterns elsewhere in the code.
 
+/**
+ * Strip Bedrock / Vertex / ARN wrappers off an Anthropic model id and return
+ * a lowercased canonical short name suitable for substring matching.
+ *
+ * Inputs we have to handle in the wild:
+ *   - first-party:        `claude-opus-4-7`, `claude-opus-4-7-20250101`
+ *   - Vertex AI:          `claude-opus-4-7@20250101`
+ *   - Bedrock foundation: `anthropic.claude-opus-4-7-v1:0`
+ *   - Bedrock cross-region: `us.anthropic.claude-opus-4-7-20250101-v1:0`
+ *                           (also `eu.`, `apac.`, `global.` prefixes)
+ *   - Bedrock ARN:        `arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-opus-4-7-v1:0`
+ *
+ * We don't try to extract the exact short name — we just normalize to a form
+ * where `name.includes('claude-opus-4-7')` is a reliable test. Mirrors
+ * `firstPartyNameToCanonical()` in claude-code (utils/model/model.ts).
+ */
+export function canonicalizeAnthropicModel(model: string): string {
+  let name = model.toLowerCase();
+  // Strip ARN wrapper: `arn:…/<profile-id>` → `<profile-id>`
+  if (name.startsWith('arn:')) {
+    const slash = name.lastIndexOf('/');
+    if (slash >= 0) name = name.slice(slash + 1);
+  }
+  return name;
+}
+
 function anthropicSupportsThinking(model: string): boolean {
+  const name = canonicalizeAnthropicModel(model);
   // Claude 3.7 Sonnet and the entire 4.x line (opus/sonnet/haiku 4, 4.5, 4.6, 4.7…)
-  if (/^claude-3-7-/.test(model)) return true;
-  if (/^claude-(opus|sonnet|haiku)-([4-9]|\d{2,})/.test(model)) return true;
+  if (name.includes('claude-3-7-')) return true;
+  if (/claude-(opus|sonnet|haiku)-([4-9]|\d{2,})/.test(name)) return true;
   return false;
 }
 
@@ -40,12 +67,18 @@ function anthropicSupportsThinking(model: string): boolean {
  * the Opus 4.7 line. Older models (3.x, 4.x through 4.6) still accept them.
  * Bedrock enforces this strictly; api.anthropic.com is currently lenient but
  * will follow.
+ *
+ * Substring-matched on the canonicalized id so Bedrock cross-region inference
+ * profiles (`us.anthropic.claude-opus-4-7-v1:0`), Vertex versions
+ * (`claude-opus-4-7@20250101`), and ARNs all collapse to the same answer as
+ * the bare first-party id.
  */
 function anthropicSamplingParams(model: string): ReadonlySet<SamplingParam> {
+  const name = canonicalizeAnthropicModel(model);
   // 4.7+ deprecated all sampling controls. Match `claude-(opus|sonnet|haiku)-4-7`
   // and any future minor (4-8, 4-9, 4-10…) plus the entire 5.x+ line.
-  if (/^claude-(opus|sonnet|haiku)-4-([7-9]|\d{2,})/.test(model)) return NO_SAMPLING;
-  if (/^claude-(opus|sonnet|haiku)-([5-9]|\d{2,})/.test(model)) return NO_SAMPLING;
+  if (/claude-(opus|sonnet|haiku)-4-([7-9]|\d{2,})/.test(name)) return NO_SAMPLING;
+  if (/claude-(opus|sonnet|haiku)-([5-9]|\d{2,})/.test(name)) return NO_SAMPLING;
   return ALL_SAMPLING;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #143. The Anthropic capability gating I added in that PR used `^claude-…`-anchored regexes, which silently fall through to "old model" defaults for every non-bare-first-party id Bedrock and Vertex actually emit:

| Form | Example | Previous match |
|---|---|---|
| First-party (bare) | `claude-opus-4-7` | ✅ |
| First-party (dated) | `claude-opus-4-7-20250101` | ✅ |
| Vertex AI version | `claude-opus-4-7@20250101` | ✅ |
| Bedrock foundation | `anthropic.claude-opus-4-7-v1:0` | ❌ |
| Bedrock cross-region | `us.anthropic.claude-opus-4-7-20250101-v1:0` | ❌ |
| Bedrock ARN | `arn:aws:bedrock:us-east-1:…/us.anthropic.claude-opus-4-7-v1:0` | ❌ |

Result: Opus 4.7 on Bedrock kept getting `temperature: 0.2` re-attached, re-triggering the `ValidationException: temperature is deprecated for this model` 400 the gating exists to prevent.

## Fix

Mirrors [`firstPartyNameToCanonical()`](https://github.com/anthropics/claude-code/blob/main/src/utils/model/model.ts) in claude-code:
1. Lowercase
2. If ARN, strip everything up to the last `/`
3. Substring-match (`name.includes('claude-opus-4-7')`) instead of `^`-anchored

The substring approach handles all current and likely-future id wrappers without needing to enumerate them. Same canonicalizer is used by both `anthropicSupportsThinking` and `anthropicSamplingParams`.

## Test plan
- [x] 26 new parameterized tests in `capabilities.test.ts` cover all seven id forms (sampling gating + thinking gating, positive + negative cases)
- [x] One end-to-end test in `anthropic.test.ts` exercises a real Bedrock cross-region id through `provider.complete()` and asserts `temperature` is absent from the wire body
- [x] `vitest run packages/llm-gateway` — 103/103 pass
- [x] `tsc -p packages/llm-gateway` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Anthropic model capabilities and parameter handling across multiple deployment formats (Bedrock, Vertex, and direct).

* **Bug Fixes**
  * Improved consistency in model parameter handling and capability detection for Anthropic models across different identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->