### PR TITLE
Use adaptive thinking wire shape for Opus 4.6+ / Sonnet 4.6+

### DIFF
--- a/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
@@ -336,6 +336,78 @@ describe('AnthropicProvider — request body', () => {
     expect(body).not.toHaveProperty('temperature');
   });
 
+  it('uses adaptive thinking wire shape for Opus 4.7 (no budget_tokens; effort moves to output_config)', async () => {
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-opus-4-7',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'claude-opus-4-7',
+      thinking: { effort: 'high' },
+    });
+
+    const body = getRequestBody(spy);
+    expect(body.thinking).toEqual({ type: 'adaptive' });
+    expect(body.thinking).not.toHaveProperty('budget_tokens');
+    expect(body.output_config).toEqual({ effort: 'high' });
+  });
+
+  it('uses adaptive shape for Bedrock cross-region Opus 4.7 inference profile', async () => {
+    // Same wire shape regardless of how the model id is wrapped — capability
+    // gating goes through the canonicalizer.
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'us.anthropic.claude-opus-4-7-v1:0',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'us.anthropic.claude-opus-4-7-20250101-v1:0',
+      thinking: { effort: 'medium' },
+    });
+
+    const body = getRequestBody(spy);
+    expect(body.thinking).toEqual({ type: 'adaptive' });
+    expect(body.output_config).toEqual({ effort: 'medium' });
+    expect(body).not.toHaveProperty('temperature');
+  });
+
+  it('keeps the budget_tokens thinking shape for Claude 3.7 Sonnet', async () => {
+    // 3.7 / 4.0–4.5 stay on the original wire — switching them to adaptive
+    // would 400 with the same "Extra inputs" error in reverse.
+    const spy = mockFetch(async () =>
+      makeJsonResponse({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'claude-3-7-sonnet-20250219',
+        stop_reason: 'end_turn',
+      }),
+    );
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], {
+      model: 'claude-3-7-sonnet-20250219',
+      thinking: { effort: 'low' },
+    });
+
+    const body = getRequestBody(spy);
+    expect(body.thinking).toMatchObject({ type: 'enabled' });
+    expect(body.thinking).toHaveProperty('budget_tokens');
+    expect(body).not.toHaveProperty('output_config');
+    // Older thinking-capable models still want temperature: 1
+    expect(body.temperature).toBe(1);
+  });
+
   it('omits temperature when thinking is enabled on a sampling-deprecated model', async () => {
     const spy = mockFetch(async () =>
       makeJsonResponse({
@@ -355,7 +427,8 @@ describe('AnthropicProvider — request body', () => {
 
     const body = getRequestBody(spy);
     expect(body).not.toHaveProperty('temperature');
-    expect(body.thinking).toMatchObject({ type: 'enabled' });
+    // Opus 4.7 uses adaptive thinking — no `enabled`, no budget_tokens.
+    expect(body.thinking).toEqual({ type: 'adaptive' });
   });
 });
 

--- a/packages/llm-gateway/src/providers/__tests__/capabilities.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/capabilities.test.ts
@@ -73,3 +73,38 @@ describe('getCapabilities — Anthropic thinking gating', () => {
     expect(getCapabilities('anthropic', model).supportsThinking).toBe(false);
   });
 });
+
+describe('getCapabilities — Anthropic adaptive thinking gating', () => {
+  it.each([
+    // Adaptive: Opus 4.6+, Sonnet 4.6+
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'us.anthropic.claude-opus-4-7-20250101-v1:0',
+    'anthropic.claude-opus-4-6-v1:0',
+    'arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-sonnet-4-6-v1:0',
+    // Future minors / 5.x
+    'claude-opus-5-0',
+    'claude-haiku-4-8',
+  ])('uses adaptive thinking shape: %s', (model) => {
+    expect(getCapabilities('anthropic', model).supportsAdaptiveThinking).toBe(true);
+  });
+
+  it.each([
+    // Older thinking-capable models still on the budget shape
+    'claude-3-7-sonnet-20250219',
+    'claude-opus-4',
+    'claude-opus-4-1',
+    'claude-sonnet-4-5',
+    'claude-haiku-4-5',
+    'anthropic.claude-3-7-sonnet-20250219-v1:0',
+  ])('keeps the budget thinking shape: %s', (model) => {
+    expect(getCapabilities('anthropic', model).supportsAdaptiveThinking).toBe(false);
+  });
+
+  it('non-Anthropic providers always report false', () => {
+    expect(getCapabilities('openai', 'gpt-5').supportsAdaptiveThinking).toBe(false);
+    expect(getCapabilities('gemini', 'gemini-2.5-pro').supportsAdaptiveThinking).toBe(false);
+    expect(getCapabilities('ollama', 'llama3.2').supportsAdaptiveThinking).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/providers/anthropic.ts
+++ b/packages/llm-gateway/src/providers/anthropic.ts
@@ -244,22 +244,43 @@ export class AnthropicProvider implements LLMProvider {
       }
     }
 
-    // Extended thinking — only attach when the model supports it. Anthropic
-    // requires temperature=1 when thinking is enabled, so we override here
-    // (only when the model actually accepts a temperature knob; otherwise
-    // the API uses its own implicit value).
+    // Extended thinking — only attach when the model supports it. Two wire
+    // shapes exist:
+    //
+    //   • Adaptive (Opus 4.6+, Sonnet 4.6+): `thinking: { type: 'adaptive' }`
+    //     and the effort hint moves to `output_config.effort`. No
+    //     budget_tokens — the model decides. Bedrock REJECTS budget_tokens
+    //     for these models with `Extra inputs are not permitted`.
+    //
+    //   • Budget (3.7, 4.0–4.5): `thinking: { type: 'enabled', budget_tokens }`
+    //     — the original shape. `temperature` must be 1 if temperature is
+    //     supported at all (which on these older models, it is).
+    //
+    // The single chokepoint here keeps callers (agent layer) provider/model
+    // agnostic: they pass `thinking: { effort: 'low'|'medium'|'high' }` and
+    // the right wire shape lands at the right model.
     if (options.thinking && capabilities.supportsThinking) {
-      const budget = effortToBudgetTokens(options.thinking.effort);
-      requestBody.thinking = { type: 'enabled', budget_tokens: budget };
-      if (capabilities.samplingParams.has('temperature')) {
-        requestBody.temperature = 1;
+      if (capabilities.supportsAdaptiveThinking) {
+        requestBody.thinking = { type: 'adaptive' };
+        const existingOutputConfig =
+          (requestBody.output_config as Record<string, unknown> | undefined) ?? {};
+        requestBody.output_config = {
+          ...existingOutputConfig,
+          effort: options.thinking.effort,
+        };
       } else {
-        delete requestBody.temperature;
-      }
-      // budget_tokens must be < max_tokens; bump max_tokens if needed
-      const currentMax = (requestBody.max_tokens as number) ?? DEFAULT_MAX_TOKENS;
-      if (currentMax <= budget) {
-        requestBody.max_tokens = budget + DEFAULT_MAX_TOKENS;
+        const budget = effortToBudgetTokens(options.thinking.effort);
+        requestBody.thinking = { type: 'enabled', budget_tokens: budget };
+        if (capabilities.samplingParams.has('temperature')) {
+          requestBody.temperature = 1;
+        } else {
+          delete requestBody.temperature;
+        }
+        // budget_tokens must be < max_tokens; bump max_tokens if needed
+        const currentMax = (requestBody.max_tokens as number) ?? DEFAULT_MAX_TOKENS;
+        if (currentMax <= budget) {
+          requestBody.max_tokens = budget + DEFAULT_MAX_TOKENS;
+        }
       }
     }
 

--- a/packages/llm-gateway/src/providers/capabilities.ts
+++ b/packages/llm-gateway/src/providers/capabilities.ts
@@ -9,6 +9,14 @@ export interface ProviderCapabilities {
    * sending an unsupported parameter.
    */
   supportsThinking: boolean;
+  /**
+   * Does this model use Anthropic's *adaptive* thinking wire format?
+   * Opus 4.6+, Sonnet 4.6+ rejected `thinking: { type: 'enabled', budget_tokens }`
+   * — they expect `thinking: { type: 'adaptive' }` plus the effort hint moved
+   * to `output_config.effort`. Older thinking-capable models (3.7, 4.0–4.5)
+   * still want the budget form. Anthropic-only flag; ignored elsewhere.
+   */
+  supportsAdaptiveThinking: boolean;
   /** Can the model emit multiple tool_use blocks in a single turn? */
   supportsParallelTools: boolean;
   /**
@@ -63,6 +71,30 @@ function anthropicSupportsThinking(model: string): boolean {
 }
 
 /**
+ * Allowlist of models that use the *adaptive* thinking wire format. Mirrors
+ * `modelSupportsAdaptiveThinking()` in claude-code (utils/thinking.ts). The
+ * default for unknown thinking-capable models is **false** — the budget form
+ * was the original API and remains the safer wire shape until we positively
+ * know a new model is on adaptive. Bedrock will reject a budget-form request
+ * sent to an adaptive-only model with `Extra inputs are not permitted`, and
+ * vice-versa, so this gate has to be exact.
+ */
+function anthropicSupportsAdaptiveThinking(model: string): boolean {
+  const name = canonicalizeAnthropicModel(model);
+  // Known adaptive models. Add a new minor here when the model team confirms.
+  if (name.includes('claude-opus-4-7')) return true;
+  if (name.includes('claude-opus-4-6')) return true;
+  if (name.includes('claude-sonnet-4-6')) return true;
+  // Any 4.7+ minor / 5.x+ family on opus|sonnet|haiku — these are trained
+  // adaptive-only by default. Conservative because the model launch DRI in
+  // claude-code's thinking.ts notes "DO NOT default to false… we may silently
+  // degrade model quality."
+  if (/claude-(opus|sonnet|haiku)-4-([7-9]|\d{2,})/.test(name)) return true;
+  if (/claude-(opus|sonnet|haiku)-([5-9]|\d{2,})/.test(name)) return true;
+  return false;
+}
+
+/**
  * Anthropic deprecated sampling knobs (temperature/top_p/top_k) starting with
  * the Opus 4.7 line. Older models (3.x, 4.x through 4.6) still accept them.
  * Bedrock enforces this strictly; api.anthropic.com is currently lenient but
@@ -111,6 +143,7 @@ export function getCapabilities(
       return {
         supportsNativeTools: true,
         supportsThinking: anthropicSupportsThinking(model),
+        supportsAdaptiveThinking: anthropicSupportsAdaptiveThinking(model),
         supportsParallelTools: true,
         samplingParams: anthropicSamplingParams(model),
       };
@@ -118,6 +151,7 @@ export function getCapabilities(
       return {
         supportsNativeTools: true,
         supportsThinking: openaiSupportsReasoning(model),
+        supportsAdaptiveThinking: false,
         supportsParallelTools: true,
         // OpenAI reasoning models (o-series, gpt-5) reject temperature/top_p.
         samplingParams: openaiSupportsReasoning(model) ? NO_SAMPLING : ALL_SAMPLING,
@@ -126,6 +160,7 @@ export function getCapabilities(
       return {
         supportsNativeTools: true,
         supportsThinking: geminiSupportsThinking(model),
+        supportsAdaptiveThinking: false,
         supportsParallelTools: false,
         samplingParams: ALL_SAMPLING,
       };
@@ -136,6 +171,7 @@ export function getCapabilities(
       return {
         supportsNativeTools: true,
         supportsThinking: false,
+        supportsAdaptiveThinking: false,
         supportsParallelTools: false,
         samplingParams: ALL_SAMPLING,
       };
@@ -143,6 +179,7 @@ export function getCapabilities(
       return {
         supportsNativeTools: true,
         supportsThinking: false,
+        supportsAdaptiveThinking: false,
         supportsParallelTools: true,
         samplingParams: ALL_SAMPLING,
       };


### PR DESCRIPTION
## Summary

Re-targeted version of #146. The original PR was created with `--base claude/canonicalize-bedrock-model-ids` (a stacked-on-#144 setup) and ended up merged into that intermediate branch instead of `main`, so `main` never received the change. #144 has since merged cleanly to main, so this branch is now a clean single-commit delta on top of main.

---

Issue 12 from the audit. Anthropic switched extended thinking to a new wire shape on the 4.6 model line:

| Models | Wire shape |
|---|---|
| 3.7, 4.0–4.5 | `thinking: { type: 'enabled', budget_tokens: N }` |
| **4.6, 4.7, 5.x+** | `thinking: { type: 'adaptive' }` + `output_config: { effort: 'low' \| 'medium' \| 'high' }` |

The model now decides budget internally for adaptive — `budget_tokens` MUST NOT appear. Bedrock returns 400 `ValidationException: thinking.budget_tokens: Extra inputs are not permitted` when the old shape leaks through. Anthropic native is currently lenient but will follow (same trajectory as `tool_name` and `temperature` deprecation).

## Fix

Adds `supportsAdaptiveThinking: boolean` to `ProviderCapabilities` with an explicit allowlist (Opus 4.6, Opus 4.7, Sonnet 4.6 + future 4.7+ / 5.x families). Mirrors `modelSupportsAdaptiveThinking()` in claude-code's `utils/thinking.ts`.

The Anthropic provider branches on the flag and emits the right wire shape:

```ts
if (capabilities.supportsAdaptiveThinking) {
  requestBody.thinking = { type: 'adaptive' };
  requestBody.output_config = { ...existing, effort: options.thinking.effort };
} else {
  // existing { type: 'enabled', budget_tokens } path
}
```

Agent layer keeps passing `thinking: { effort }` — provider/model agnostic.

### Why allowlist instead of "always adaptive on 4.6+"

Sending `adaptive` to a model that only knows `enabled` returns the same 400 in reverse. The exact gate has to come from the model team's confirmation. claude-code's `thinking.ts` warns explicitly: *"Do not change adaptive thinking support without notifying the model launch DRI"* — so the allowlist + a regex for unmistakably-future minors (4.7+, 5.x+) is the safer default.

## Test plan
- [x] 16 new tests across two files:
  - 3 in `anthropic.test.ts` — wire body shape for Opus 4.7 (adaptive), Bedrock cross-region Opus 4.7 (adaptive via canonicalizer), Claude 3.7 Sonnet (still budget)
  - 13 in `capabilities.test.ts` — adaptive flag across id wrappers (positive + negative + non-Anthropic providers)
- [x] `vitest run packages/llm-gateway` — 121/121 pass
- [x] `tsc -p packages/llm-gateway` clean
- [ ] Manual: Opus 4.7 on Bedrock with thinking enabled — should not see `Extra inputs are not permitted` for `budget_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adaptive thinking in newer Anthropic Claude models (Opus 4.7).
  * Improved capability detection to identify which Claude models support adaptive thinking versus earlier configurations.

* **Tests**
  * Added comprehensive test coverage for Claude thinking configurations across different model versions and deployment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->