### PR TITLE
Drop api_key requirement for auto-investigation SA identity

### DIFF
--- a/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
+++ b/packages/api-gateway/src/auth/seed-auto-investigation-sa.ts
@@ -1,24 +1,25 @@
 /**
  * Seed the `openobs` auto-investigation service account on first boot.
  *
- * Phase 8 / O1 of the auto-remediation design. The dispatcher
- * (#108 / alerts-boot.ts) needs an SA token to spawn background
- * investigations; this seed makes sure the SA user exists, ready for
- * an admin to mint a key for it via the existing service-account UI.
+ * Phase 8 / O1 of the auto-remediation design. The dispatcher uses this
+ * SA's identity in-process to run agent tools with the right permissions
+ * — it does NOT need an api_key row or plaintext token. Auto-investigation
+ * is a system feature like the alert evaluator itself: no operator setup
+ * required.
  *
  * Idempotent: if a user with login `openobs` and `is_service_account=1`
- * already exists, no-op. Org membership is also idempotent.
+ * already exists, no-op. Org membership and the
+ * `fixed:ops.commands:runner` role assignment are also idempotent.
  *
- * Why we don't auto-mint the API key here: API keys are minted through
- * `ApiKeyService` which performs an audit + binds the key to the
- * caller's identity. Auto-minting at boot bypasses that and produces
- * unattributed audit rows. The setup story is:
- *   1. This seed creates the SA user.
- *   2. An admin opens the service-accounts page, picks `openobs`, and
- *      generates a token via the existing UI. The audit row attributes
- *      the key to that admin.
- *   3. Operator copies the raw `openobs_sa_...` token into the
- *      `AUTO_INVESTIGATION_SA_TOKEN` env var and restarts the gateway.
+ * To disable auto-investigation at runtime, set
+ * `AUTO_INVESTIGATION_ENABLED=false` (handled at the alerts-boot level)
+ * or set `is_disabled=1` on the SA user row.
+ *
+ * Cross-process callers that authenticate AS the SA (e.g. an external
+ * script) still need a real api_key — mint one through the
+ * service-accounts UI as before. The legacy
+ * `AUTO_INVESTIGATION_SA_TOKEN` env var also still works as an explicit
+ * override for that path.
  */
 
 import type {

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import {
   AutoInvestigationDispatcher,
   buildAlertQuestion,
+  buildSaIdentityResolverFromRepos,
 } from './auto-investigation-dispatcher.js';
 import type { AlertFiredPayload } from './alert-evaluator-service.js';
 
@@ -245,5 +246,67 @@ describe('AutoInvestigationDispatcher', () => {
       expect(repos.updateStatus).toHaveBeenCalledWith('inv-NEW', 'completed');
       expect(repos.ruleUpdate).toHaveBeenCalledWith('rule-A', { investigationId: 'inv-NEW' });
     });
+  });
+});
+
+describe('buildSaIdentityResolverFromRepos', () => {
+  // The earlier resolver gated on a live api_key row; users had to mint a
+  // token via the UI before any auto-investigation could run, with no error
+  // surfacing the requirement. The resolver now runs on the SA user row
+  // alone — no token needed. These tests pin that contract.
+
+  function makeRepos(opts: {
+    sa: { id: string; isServiceAccount: boolean; isDisabled?: boolean } | null;
+    member: { role: 'Editor' | 'Viewer' | 'Admin' } | null;
+  }) {
+    return {
+      users: { findByLogin: vi.fn(async () => opts.sa) },
+      orgUsers: { findMembership: vi.fn(async () => opts.member) },
+    } as unknown as Parameters<typeof buildSaIdentityResolverFromRepos>[0];
+  }
+
+  it('returns identity for an enabled SA without any api_key row', async () => {
+    const resolver = buildSaIdentityResolverFromRepos(
+      makeRepos({
+        sa: { id: 'u_sa', isServiceAccount: true },
+        member: { role: 'Editor' },
+      }),
+    );
+    const id = await resolver(basePayload());
+    expect(id).toEqual({
+      userId: 'u_sa',
+      orgId: 'org_main',
+      orgRole: 'Editor',
+      isServerAdmin: false,
+      authenticatedBy: 'api_key',
+      serviceAccountId: 'u_sa',
+    });
+  });
+
+  it('returns null when the SA user does not exist (seed has not run)', async () => {
+    const resolver = buildSaIdentityResolverFromRepos(
+      makeRepos({ sa: null, member: null }),
+    );
+    expect(await resolver(basePayload())).toBeNull();
+  });
+
+  it('returns null when the SA user is disabled', async () => {
+    const resolver = buildSaIdentityResolverFromRepos(
+      makeRepos({
+        sa: { id: 'u_sa', isServiceAccount: true, isDisabled: true },
+        member: { role: 'Editor' },
+      }),
+    );
+    expect(await resolver(basePayload())).toBeNull();
+  });
+
+  it('returns null when the SA has no membership in the target org', async () => {
+    const resolver = buildSaIdentityResolverFromRepos(
+      makeRepos({
+        sa: { id: 'u_sa', isServiceAccount: true },
+        member: null,
+      }),
+    );
+    expect(await resolver(basePayload())).toBeNull();
   });
 });

--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.ts
@@ -114,46 +114,38 @@ export interface AutoInvestigationDispatcherOptions {
 }
 
 /**
- * Build a {@link SaIdentityResolver} backed by the SA user row + the live
- * api_key table. Returns `null` when:
+ * Build a {@link SaIdentityResolver} backed by the SA user row alone.
+ * Returns `null` only when:
  *   - the SA user doesn't exist (seeding hasn't run)
  *   - the SA has no membership in the target org
- *   - no non-revoked, non-expired api_key row exists for the SA
  *
- * The identity is constructed directly — we never look up plaintext
- * tokens (the column stores SHA-256 only). The presence of a live key
- * row is the operator-consent gate; any caller spawning agent runs with
- * this identity is auditable as the SA.
+ * Auto-investigation is a system feature — same mental model as the alert
+ * evaluator itself, which doesn't need an operator-minted token to run.
+ * Earlier versions of this resolver gated on the existence of a live
+ * `api_key` row for the SA, on the theory that minting a key was the
+ * operator's "consent" signal. In practice it just made auto-investigation
+ * silently no-op until someone discovered they had to click through the
+ * service-accounts UI to mint a token — bad UX with no real security gain
+ * (the dispatcher is in-process; no token validation actually happens).
+ *
+ * To disable auto-investigation, set `AUTO_INVESTIGATION_ENABLED=false`
+ * (handled at the alerts-boot level), or disable the SA user.
  */
 export function buildSaIdentityResolverFromRepos(deps: {
   users: import('@agentic-obs/common').IUserRepository;
   orgUsers: import('@agentic-obs/common').IOrgUserRepository;
-  apiKeys: import('@agentic-obs/common').IApiKeyRepository;
   /** SA login name; defaults to 'openobs' (the seeded auto-investigation SA). */
   saLogin?: string;
   /** Org id to bind the identity to; defaults to 'org_main'. */
   orgId?: string;
-  clock?: () => Date;
 }): SaIdentityResolver {
   const saLogin = deps.saLogin ?? 'openobs';
   const orgId = deps.orgId ?? 'org_main';
-  const clock = deps.clock ?? (() => new Date());
   return async () => {
     const sa = await deps.users.findByLogin(saLogin);
-    if (!sa || !sa.isServiceAccount) return null;
+    if (!sa || !sa.isServiceAccount || sa.isDisabled) return null;
     const member = await deps.orgUsers.findMembership(orgId, sa.id);
     if (!member) return null;
-    const keys = await deps.apiKeys.list({
-      orgId,
-      serviceAccountId: sa.id,
-      includeRevoked: false,
-      includeExpired: false,
-    });
-    const nowIso = clock().toISOString();
-    const live = keys.items.find(
-      (k) => !k.isRevoked && (k.expires === null || k.expires > nowIso),
-    );
-    if (!live) return null;
     return {
       userId: sa.id,
       orgId,


### PR DESCRIPTION
## Summary

Auto-investigation is a system feature — same mental model as the alert evaluator itself, which doesn't need an operator-minted token to run. The dispatcher's SA-identity resolver previously gated on the existence of a live `api_key` row; without one the resolver returned `null` and the dispatcher silently skipped every `alert.fired` event. **No error surfaced — alerts just stopped triggering investigations and there was no UI hint that anything was wrong.**

The previous design rationale was "minting a token is the operator's consent signal." In practice that signal was buried in the service-accounts UI with no link from anywhere alert-related, so users hit:

- Alert fires → dispatcher gets event ✅
- Resolver looks for live api_key → none → returns null
- Dispatcher silently skips
- User: "why isn't auto-investigation working?"

The api_key was never doing meaningful work either: this is an in-process resolver, no token is ever validated against a hash. The row was a pseudo-consent gate that hurt UX with no real security gain.

## Change

`buildSaIdentityResolverFromRepos` now only requires:
- SA user exists and is enabled (`isDisabled === false`)
- SA has org membership

`apiKeys` is dropped from the function signature.

## Disable mechanisms

Both already exist:
- `AUTO_INVESTIGATION_ENABLED=false` — env flag handled at the alerts-boot level
- `is_disabled=1` on the SA user row — disables the identity directly

## Cross-process callers

Unchanged: external scripts authenticating AS the SA still need a real `api_key`. The legacy `AUTO_INVESTIGATION_SA_TOKEN` env override path also still works.

## Test plan
- [x] Four new tests in `auto-investigation-dispatcher.test.ts` pin the new resolver contract: enabled SA → returns identity; missing / disabled SA / no membership → null
- [x] `vitest run` on dispatcher + alerts-boot + seed-sa → 31/31 pass
- [ ] Manual: fresh dev install, fire an alert, verify auto-investigation runs without any operator setup beyond the existing wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal service account behavior and configuration override options.

* **Tests**
  * Added test coverage for service account identity resolution logic.

* **Refactor**
  * Simplified internal service account validation by streamlining identity resolution checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->