### PR TITLE
Fix resolver test arity (follow-up to #150)

### DIFF
--- a/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
+++ b/packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts
@@ -272,7 +272,7 @@ describe('buildSaIdentityResolverFromRepos', () => {
         member: { role: 'Editor' },
       }),
     );
-    const id = await resolver(basePayload());
+    const id = await resolver();
     expect(id).toEqual({
       userId: 'u_sa',
       orgId: 'org_main',
@@ -287,7 +287,7 @@ describe('buildSaIdentityResolverFromRepos', () => {
     const resolver = buildSaIdentityResolverFromRepos(
       makeRepos({ sa: null, member: null }),
     );
-    expect(await resolver(basePayload())).toBeNull();
+    expect(await resolver()).toBeNull();
   });
 
   it('returns null when the SA user is disabled', async () => {
@@ -297,7 +297,7 @@ describe('buildSaIdentityResolverFromRepos', () => {
         member: { role: 'Editor' },
       }),
     );
-    expect(await resolver(basePayload())).toBeNull();
+    expect(await resolver()).toBeNull();
   });
 
   it('returns null when the SA has no membership in the target org', async () => {
@@ -307,6 +307,6 @@ describe('buildSaIdentityResolverFromRepos', () => {
         member: null,
       }),
     );
-    expect(await resolver(basePayload())).toBeNull();
+    expect(await resolver()).toBeNull();
   });
 });


### PR DESCRIPTION
The four new resolver tests added in #150 call `resolver(basePayload())`, but the resolver returned by `buildSaIdentityResolverFromRepos` accepts no parameters. The fix commit (`b828104` on the original branch) didn't make the squash-merge.

Production typecheck on `main` currently fails:

\`\`\`
auto-investigation-dispatcher.test.ts(275,31): error TS2554: Expected 0 arguments, but got 1.
auto-investigation-dispatcher.test.ts(290,27): error TS2554: Expected 0 arguments, but got 1.
auto-investigation-dispatcher.test.ts(300,27): error TS2554: Expected 0 arguments, but got 1.
auto-investigation-dispatcher.test.ts(310,27): error TS2554: Expected 0 arguments, but got 1.
\`\`\`

This PR removes the spurious arguments. Pure test cleanup; no behaviour change.

## Test plan
- [x] `tsc -p packages/api-gateway` clean (filtering pre-existing chat-service / github-change errors)
- [x] `vitest run packages/api-gateway/src/services/auto-investigation-dispatcher.test.ts` — 20/20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This update contains internal testing improvements with no user-facing changes. Test infrastructure was updated to refine resolver function validation scenarios, ensuring robust behavior for identity resolution across various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->