### PR TITLE
T2.1+T2.2: enrich approval write path + per-row read scope

### DIFF
--- a/packages/agent-core/src/agent/handlers/remediation-plan.ts
+++ b/packages/agent-core/src/agent/handlers/remediation-plan.ts
@@ -19,7 +19,7 @@
  * surfaces it for approval.
  */
 
-import { checkKubectl } from '@agentic-obs/adapters';
+import { checkKubectl, parseKubectlArgv } from '@agentic-obs/adapters';
 import type {
   NewRemediationPlanStep,
   RemediationPlanStepKind,
@@ -176,6 +176,29 @@ async function createPlanCommon(
       // up in /api/approvals + the ActionCenter UI immediately. Rescue
       // plans do NOT — they're invoked on demand by an operator.
       if (rescueForPlanId === null && ctx.approvalRequests) {
+        // Multi-team scope tags (docs/design/approvals-multi-team-scope.md
+        // §3.6). The plan-level approval is what lands in /api/approvals,
+        // so it's the row that needs scope-narrowing for visibility. We
+        // pull connector + namespace from the first ops step; team is
+        // resolved upstream and (for now) not threaded through ctx — left
+        // null with a TODO. Without these tags multi-team customers see
+        // every cluster's plan-level approvals; this is the fix.
+        const firstOpsStep = parsed.find(
+          (s) => typeof (s.paramsJson as Record<string, unknown>)?.['argv'] !== 'undefined'
+            && typeof s.connectorId === 'string'
+            && s.connectorId.length > 0,
+        );
+        const opsConnectorId = firstOpsStep?.connectorId ?? null;
+        const targetNamespace = firstOpsStep
+          ? (parseKubectlArgv((firstOpsStep.paramsJson as { argv: string[] }).argv).namespace ?? null)
+          : null;
+        // TODO(approvals-multi-team): resolve requesterTeamId via ctx.
+        // Needs alertRule.investigation_id → folder → team chain wired
+        // through ctx (not currently exposed in agent-core). Tracked
+        // separately; null is the safe default — wildcard `approvals:*`
+        // grants still match.
+        const requesterTeamId: string | null = null;
+
         const submitted = await ctx.approvalRequests.submit({
           action: {
             type: 'plan',
@@ -190,6 +213,9 @@ async function createPlanCommon(
             // find the plan without re-parsing action.params.
             ...{ planId: plan.id } as Record<string, unknown>,
           },
+          opsConnectorId,
+          targetNamespace,
+          requesterTeamId,
         });
         await ctx.remediationPlans!.updatePlan(ctx.identity.orgId, plan.id, {
           approvalRequestId: submitted.id,

--- a/packages/agent-core/src/agent/types.ts
+++ b/packages/agent-core/src/agent/types.ts
@@ -181,5 +181,18 @@ export interface ApprovalRequest {
 }
 
 export interface ApprovalRequestStore {
-  submit(params: { action: ApprovalAction; context: ApprovalContext; ttlMs?: number }): ApprovalRequest | Promise<ApprovalRequest>
+  submit(params: {
+    action: ApprovalAction;
+    context: ApprovalContext;
+    ttlMs?: number;
+    /**
+     * Optional scope tags so multi-team RBAC can narrow visibility per
+     * connector / namespace / team. NULL when the plan has no ops step
+     * (cluster-wide write) or no team-owning alert rule. See
+     * docs/design/approvals-multi-team-scope.md §3.6.
+     */
+    opsConnectorId?: string | null;
+    targetNamespace?: string | null;
+    requesterTeamId?: string | null;
+  }): ApprovalRequest | Promise<ApprovalRequest>
 }

--- a/packages/api-gateway/src/routes/approval.test.ts
+++ b/packages/api-gateway/src/routes/approval.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Per-row scope tests for the approval router.
+ *
+ * Pins approvals-multi-team-scope §3.3 / §3.4 acceptance:
+ *   - List narrows by user's grants.
+ *   - Detail/action routes deny → 404 (not 403) when no scope matches.
+ *   - **Fail-closed invariant (R1)**: a connector-scoped grant for `dev-eks`
+ *     does NOT broaden to `approvals:*` and so MUST NOT see `prod-eks` rows.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Evaluator, Identity, ResolvedPermission } from '@agentic-obs/common';
+import { ACTIONS, FIXED_ROLE_DEFINITIONS, findFixedRole, scopeCovers } from '@agentic-obs/common';
+import type { ApprovalScopeFilter, IApprovalRequestRepository, IGatewayApprovalStore } from '@agentic-obs/data-layer';
+import type { ApprovalRequest, ApprovalStatus } from '@agentic-obs/data-layer';
+import { createApprovalRouter } from './approval.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { setAuthMiddleware } from '../middleware/auth.js';
+
+function row(
+  id: string,
+  patch: Partial<ApprovalRequest> = {},
+): ApprovalRequest {
+  return {
+    id,
+    action: { type: 't', targetService: 's', params: {} },
+    context: { requestedBy: 'u', reason: 'r' },
+    status: 'pending' as ApprovalStatus,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2026-01-02T00:00:00.000Z',
+    opsConnectorId: null,
+    targetNamespace: null,
+    requesterTeamId: null,
+    ...patch,
+  };
+}
+
+function buildHarness(rows: ApprovalRequest[], permissions: ResolvedPermission[]) {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const requests: IApprovalRequestRepository = {
+    findById: async (id) => byId.get(id),
+    submit: async () => { throw new Error('not used'); },
+    listPending: async () => [...rows],
+    list: async (_orgId, opts) => {
+      const filter: ApprovalScopeFilter = opts?.scopeFilter ?? { kind: 'wildcard' };
+      if (filter.kind === 'wildcard') return [...rows];
+      return rows.filter((r) => {
+        if (filter.uids?.has(r.id)) return true;
+        if (r.opsConnectorId && filter.connectors?.has(r.opsConnectorId)) return true;
+        if (
+          r.opsConnectorId &&
+          r.targetNamespace &&
+          filter.nsPairs?.some((p) => p.connectorId === r.opsConnectorId && p.ns === r.targetNamespace)
+        ) {
+          return true;
+        }
+        if (r.requesterTeamId && filter.teams?.has(r.requesterTeamId)) return true;
+        return false;
+      });
+    },
+    approve: async (id) => byId.get(id),
+    reject: async (id) => byId.get(id),
+    override: async (id) => byId.get(id),
+  };
+  const approvals: IGatewayApprovalStore = {
+    findById: requests.findById,
+    listPending: requests.listPending,
+    approve: requests.approve,
+    reject: requests.reject,
+    override: requests.override,
+  };
+
+  const accessControl: AccessControlSurface = {
+    getUserPermissions: async () => permissions,
+    ensurePermissions: async () => permissions,
+    filterByPermission: async (_id, items) => [...items],
+    evaluate: async (_identity: Identity, evaluator: Evaluator) =>
+      evaluator.evaluate(permissions),
+  };
+
+  setAuthMiddleware((req, _res, next) => { next(); return undefined as unknown as void; });
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as AuthenticatedRequest).auth = {
+      userId: 'u1',
+      orgId: 'org_a',
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  });
+  app.use('/api/approvals', createApprovalRouter({
+    approvals,
+    approvalRequests: requests,
+    ac: accessControl,
+  }));
+  return { app };
+}
+
+const PROD_ROW = row('appr-prod', { opsConnectorId: 'prod-eks', targetNamespace: 'platform', requesterTeamId: 'platform' });
+const DEV_ROW = row('appr-dev', { opsConnectorId: 'dev-eks', targetNamespace: 'apps', requesterTeamId: 'apps-team' });
+const PROD_KSYS_ROW = row('appr-prod-ks', { opsConnectorId: 'prod-eks', targetNamespace: 'kube-system', requesterTeamId: 'platform' });
+const NULL_ROW = row('appr-null'); // back-compat row, all NULL.
+
+describe('/api/approvals — per-row scope', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('R1 fail-closed: connector:dev-eks user gets 404 on prod row (does not broaden to *)', async () => {
+    const { app } = buildHarness([PROD_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:connector:dev-eks' },
+    ]);
+    const res = await request(app).get(`/api/approvals/${PROD_ROW.id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('approvals:* holder sees every row in list and detail', async () => {
+    const all = [PROD_ROW, DEV_ROW, PROD_KSYS_ROW, NULL_ROW];
+    const { app } = buildHarness(all, [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:*' },
+    ]);
+    const list = await request(app).get('/api/approvals');
+    expect(list.status).toBe(200);
+    expect(list.body.map((r: ApprovalRequest) => r.id).sort()).toEqual(all.map((r) => r.id).sort());
+
+    for (const r of all) {
+      const detail = await request(app).get(`/api/approvals/${r.id}`);
+      expect(detail.status).toBe(200);
+      expect(detail.body.id).toBe(r.id);
+    }
+  });
+
+  it('connector:prod-eks: list returns only prod rows; dev row → 404 on detail', async () => {
+    const { app } = buildHarness([PROD_ROW, DEV_ROW, PROD_KSYS_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:connector:prod-eks' },
+    ]);
+    const list = await request(app).get('/api/approvals');
+    expect(list.status).toBe(200);
+    expect(list.body.map((r: ApprovalRequest) => r.id).sort()).toEqual([PROD_KSYS_ROW.id, PROD_ROW.id].sort());
+
+    expect((await request(app).get(`/api/approvals/${PROD_ROW.id}`)).status).toBe(200);
+    expect((await request(app).get(`/api/approvals/${DEV_ROW.id}`)).status).toBe(404);
+  });
+
+  it('namespace:prod-eks:platform: matches platform ns only', async () => {
+    const { app } = buildHarness([PROD_ROW, PROD_KSYS_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:namespace:prod-eks:platform' },
+    ]);
+    const list = await request(app).get('/api/approvals');
+    expect(list.status).toBe(200);
+    expect(list.body.map((r: ApprovalRequest) => r.id)).toEqual([PROD_ROW.id]);
+    expect((await request(app).get(`/api/approvals/${PROD_KSYS_ROW.id}`)).status).toBe(404);
+  });
+
+  it('team:platform: matches platform-team rows only', async () => {
+    const { app } = buildHarness([PROD_ROW, DEV_ROW, PROD_KSYS_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:team:platform' },
+    ]);
+    const list = await request(app).get('/api/approvals');
+    expect(list.status).toBe(200);
+    expect(list.body.map((r: ApprovalRequest) => r.id).sort()).toEqual([PROD_KSYS_ROW.id, PROD_ROW.id].sort());
+    expect((await request(app).get(`/api/approvals/${DEV_ROW.id}`)).status).toBe(404);
+  });
+
+  it('NULL row visibility: visible to *, hidden from connector-scoped grant', async () => {
+    const wild = buildHarness([NULL_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:*' },
+    ]);
+    expect((await request(wild.app).get(`/api/approvals/${NULL_ROW.id}`)).status).toBe(200);
+
+    const narrow = buildHarness([NULL_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:connector:prod-eks' },
+    ]);
+    expect((await request(narrow.app).get(`/api/approvals/${NULL_ROW.id}`)).status).toBe(404);
+    const list = await request(narrow.app).get('/api/approvals');
+    expect(list.body).toEqual([]);
+  });
+
+  it('approve: connector:prod-eks can approve prod, gets 404 on dev', async () => {
+    const { app } = buildHarness([PROD_ROW, DEV_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:connector:prod-eks' },
+      { action: ACTIONS.ApprovalsApprove, scope: 'approvals:connector:prod-eks' },
+    ]);
+    expect((await request(app).post(`/api/approvals/${PROD_ROW.id}/approve`)).status).toBe(200);
+    expect((await request(app).post(`/api/approvals/${DEV_ROW.id}/approve`)).status).toBe(404);
+  });
+
+  it('override: holder of approvals:override on approvals:* can override any row', async () => {
+    const { app } = buildHarness([PROD_ROW, DEV_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:*' },
+      { action: ACTIONS.ApprovalsOverride, scope: 'approvals:*' },
+    ]);
+    expect((await request(app).post(`/api/approvals/${PROD_ROW.id}/override`)).status).toBe(200);
+    expect((await request(app).post(`/api/approvals/${DEV_ROW.id}/override`)).status).toBe(200);
+  });
+
+  it('override: read-only user cannot override (404)', async () => {
+    const { app } = buildHarness([PROD_ROW], [
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:*' },
+    ]);
+    expect((await request(app).post(`/api/approvals/${PROD_ROW.id}/override`)).status).toBe(404);
+  });
+});
+
+describe('FIXED_ROLE_DEFINITIONS — multi-team approval roles', () => {
+  it('cluster_approver is registered with read+approve on approvals:connector:*', () => {
+    const r = findFixedRole('fixed:approvals:cluster_approver');
+    expect(r).toBeDefined();
+    const perms = r!.permissions.map((p) => `${p.action} ${p.scope}`);
+    expect(perms).toContain(`${ACTIONS.ApprovalsRead} approvals:connector:*`);
+    expect(perms).toContain(`${ACTIONS.ApprovalsApprove} approvals:connector:*`);
+    // And it covers a concrete connector after admin binding.
+    expect(scopeCovers('approvals:connector:*', 'approvals:connector:prod-eks')).toBe(true);
+  });
+
+  it('namespace_approver is registered with read+approve on approvals:namespace:*:*', () => {
+    const r = findFixedRole('fixed:approvals:namespace_approver');
+    expect(r).toBeDefined();
+    const perms = r!.permissions.map((p) => `${p.action} ${p.scope}`);
+    expect(perms).toContain(`${ACTIONS.ApprovalsRead} approvals:namespace:*:*`);
+    expect(perms).toContain(`${ACTIONS.ApprovalsApprove} approvals:namespace:*:*`);
+  });
+
+  it('team_viewer is registered with read on approvals:team:*', () => {
+    const r = findFixedRole('fixed:approvals:team_viewer');
+    expect(r).toBeDefined();
+    expect(r!.permissions).toEqual([
+      { action: ACTIONS.ApprovalsRead, scope: 'approvals:team:*' },
+    ]);
+  });
+
+  it('all three roles appear in the catalog', () => {
+    const names = FIXED_ROLE_DEFINITIONS.map((r) => r.name);
+    expect(names).toContain('fixed:approvals:cluster_approver');
+    expect(names).toContain('fixed:approvals:namespace_approver');
+    expect(names).toContain('fixed:approvals:team_viewer');
+  });
+});

--- a/packages/api-gateway/src/routes/approval.ts
+++ b/packages/api-gateway/src/routes/approval.ts
@@ -1,11 +1,10 @@
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import type { ApiError } from '@agentic-obs/common';
-import { ac, ACTIONS } from '@agentic-obs/common';
-import type { IApprovalRequestRepository, IGatewayApprovalStore, IOpsConnectorRepository } from '@agentic-obs/data-layer';
+import type { ApiError, ResolvedPermission } from '@agentic-obs/common';
+import { ac, ACTIONS, approvalRowScopes, parseApprovalScope } from '@agentic-obs/common';
+import type { IApprovalRequestRepository, IGatewayApprovalStore, IOpsConnectorRepository, ApprovalScopeFilter } from '@agentic-obs/data-layer';
 import { authMiddleware } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
-import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import { OpsCommandRunnerService } from '../services/ops-command-runner-service.js';
 
@@ -22,8 +21,15 @@ function legacyOrgRole(role: string | undefined): string {
 }
 
 export interface ApprovalRouterDeps {
+  /** Mutation surface (with onResolved pub/sub). */
   approvals: IGatewayApprovalStore;
-  approvalRequests?: IApprovalRequestRepository;
+  /**
+   * Read/list surface. Required: `GET /` calls `list(orgId, { scopeFilter })`,
+   * which `IGatewayApprovalStore` doesn't expose. Wired to the same underlying
+   * repo as `approvals` (the EventEmittingApprovalRepository wraps this one
+   * for the mutation pub/sub).
+   */
+  approvalRequests: IApprovalRequestRepository;
   opsConnectors?: IOpsConnectorRepository;
   /**
    * RBAC surface. `AccessControlSurface` is used (not the concrete service)
@@ -33,38 +39,134 @@ export interface ApprovalRouterDeps {
   ac: AccessControlSurface;
 }
 
+/**
+ * Build a per-row `ApprovalScopeFilter` from the user's `ApprovalsRead` grants.
+ *
+ * Returns:
+ *   - `{ kind: 'wildcard' }` if any grant resolves to `approvals:*`.
+ *   - Otherwise a `narrow` filter populated from the user's specific grants
+ *     (uid / connector / namespace / team). Empty narrow set → list returns
+ *     zero rows (T1.1's repo handles this).
+ *
+ * See approvals-multi-team-scope §3.3.
+ */
+function approvalsReadScopeFilter(
+  permissions: readonly ResolvedPermission[],
+): ApprovalScopeFilter {
+  const reads = permissions.filter((p) => p.action === ACTIONS.ApprovalsRead);
+  const uids = new Set<string>();
+  const connectors = new Set<string>();
+  const nsPairs: { connectorId: string; ns: string }[] = [];
+  const teams = new Set<string>();
+  for (const p of reads) {
+    const parsed = parseApprovalScope(p.scope);
+    if (!parsed) continue;
+    if (parsed.kind === 'wildcard') return { kind: 'wildcard' };
+    if (parsed.kind === 'uid') uids.add(parsed.id);
+    else if (parsed.kind === 'connector') connectors.add(parsed.connectorId);
+    else if (parsed.kind === 'namespace') nsPairs.push({ connectorId: parsed.connectorId, ns: parsed.ns });
+    else if (parsed.kind === 'team') teams.add(parsed.teamId);
+  }
+  return { kind: 'narrow', uids, connectors, nsPairs, teams };
+}
+
+/**
+ * True iff the user's permissions include `<action> on approvals:*`.
+ *
+ * Used to decide whether the wildcard scope is added to the per-row candidate
+ * list — see fail-closed invariant in approvals-multi-team-scope §3.4 / R1.
+ */
+function holdsApprovalsWildcard(
+  permissions: readonly ResolvedPermission[],
+  action: string,
+): boolean {
+  return permissions.some(
+    (p) =>
+      p.action === action &&
+      (p.scope === 'approvals:*' || p.scope === 'approvals:*:*' || p.scope === '*' || p.scope === ''),
+  );
+}
+
+/**
+ * Resolve whether the user can perform `action` on `row` per the per-row
+ * scope rules. Builds the row's candidate scopes via `approvalRowScopes`, then
+ * adds `approvals:*` ONLY if the user actually holds that wildcard grant.
+ *
+ * Critical: the naive "always include `approvals:*`" path is what the
+ * fail-closed invariant prohibits. See approvals-multi-team-scope §3.4 / R1.
+ */
+async function evalRowAccess(
+  acc: AccessControlSurface,
+  identity: AuthenticatedRequest['auth'],
+  permissions: readonly ResolvedPermission[],
+  action: string,
+  row: { id: string; opsConnectorId?: string | null; targetNamespace?: string | null; requesterTeamId?: string | null },
+): Promise<boolean> {
+  if (!identity) return false;
+  const candidates = approvalRowScopes(row);
+  if (holdsApprovalsWildcard(permissions, action)) {
+    candidates.push('approvals:*');
+  }
+  const evaluator = ac.any(...candidates.map((s: string) => ac.eval(action, s)));
+  return acc.evaluate(identity, evaluator);
+}
+
 export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
   const router = Router();
   const repo = deps.approvals;
-  const requirePermission = createRequirePermission(deps.ac);
+  const requests = deps.approvalRequests;
+  const accessControl = deps.ac;
 
-  // GET /api/approvals - list pending approvals
+  function authOr401(
+    req: Request,
+    res: Response,
+  ): AuthenticatedRequest['auth'] | null {
+    const auth = (req as AuthenticatedRequest).auth;
+    if (!auth) {
+      res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+      return null;
+    }
+    return auth;
+  }
+
+  // GET /api/approvals — list approvals visible to the caller (per-row filter).
   router.get(
     '/',
     authMiddleware,
-    requirePermission(() => ac.eval(ACTIONS.ApprovalsRead, 'approvals:*')),
-    async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        res.json(await repo.listPending());
+        const auth = authOr401(req, res);
+        if (!auth) return;
+        const perms = await accessControl.ensurePermissions(auth);
+        const scopeFilter = approvalsReadScopeFilter(perms);
+        const rows = await requests.list(auth.orgId, { scopeFilter });
+        res.json(rows);
       } catch (err) {
         next(err);
       }
     },
   );
 
-  // GET /api/approvals/:id - get single approval request
+  // GET /api/approvals/:id — detail with per-row scope check. Deny → 404
+  // (don't leak existence to a user who can't see this row).
   router.get(
     '/:id',
     authMiddleware,
-    requirePermission((req) =>
-      ac.eval(ACTIONS.ApprovalsRead, `approvals:uid:${req.params['id'] ?? ''}`),
-    ),
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        const record = await repo.findById(req.params['id'] ?? '');
+        const auth = authOr401(req, res);
+        if (!auth) return;
+        const id = req.params['id'] ?? '';
+        const record = await repo.findById(id);
+        const notFound: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
         if (!record) {
-          const err: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
-          res.status(404).json(err);
+          res.status(404).json(notFound);
+          return;
+        }
+        const perms = await accessControl.ensurePermissions(auth);
+        const allowed = await evalRowAccess(accessControl, auth, perms, ACTIONS.ApprovalsRead, record);
+        if (!allowed) {
+          res.status(404).json(notFound);
           return;
         }
         res.json(record);
@@ -74,40 +176,39 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
     },
   );
 
-  // POST /api/approvals/:id/approve - approve a pending request (Editor+ via
-  // `approvals:approve`).
+  // POST /api/approvals/:id/approve — Editor+ via per-row `approvals:approve`.
   router.post(
     '/:id/approve',
     authMiddleware,
-    requirePermission((req) =>
-      ac.eval(ACTIONS.ApprovalsApprove, `approvals:uid:${req.params['id'] ?? ''}`),
-    ),
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        const authReq = req as AuthenticatedRequest;
+        const auth = authOr401(req, res);
+        if (!auth) return;
         const id = req.params['id'] ?? '';
-        const resolvedBy = authReq.auth?.userId ?? 'unknown';
-        const resolvedByRoles = authReq.auth?.isServerAdmin
-          ? ['admin']
-          : [legacyOrgRole(authReq.auth?.orgRole)];
+        const record = await repo.findById(id);
+        const notFound: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
+        if (!record) {
+          res.status(404).json(notFound);
+          return;
+        }
+        const perms = await accessControl.ensurePermissions(auth);
+        const allowed = await evalRowAccess(accessControl, auth, perms, ACTIONS.ApprovalsApprove, record);
+        if (!allowed) {
+          res.status(404).json(notFound);
+          return;
+        }
 
+        const resolvedBy = auth.userId ?? 'unknown';
+        const resolvedByRoles = auth.isServerAdmin ? ['admin'] : [legacyOrgRole(auth.orgRole)];
         const updated = await repo.approve(id, resolvedBy, resolvedByRoles);
         if (!updated) {
-          const existing = await repo.findById(id);
-          if (!existing) {
-            const err: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
-            res.status(404).json(err);
-            return;
-          }
-
           const err: ApiError = {
             code: 'CONFLICT',
-            message: `Approval request is already ${existing.status} and cannot be approved`,
+            message: `Approval request is already ${record.status} and cannot be approved`,
           };
           res.status(409).json(err);
           return;
         }
-
         res.json(updated);
       } catch (err) {
         next(err);
@@ -115,40 +216,39 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
     },
   );
 
-  // POST /api/approvals/:id/reject - reject a pending request (Editor+ via
-  // `approvals:approve`; rejection is the symmetric side of approve).
+  // POST /api/approvals/:id/reject — symmetric `approvals:approve` gate.
   router.post(
     '/:id/reject',
     authMiddleware,
-    requirePermission((req) =>
-      ac.eval(ACTIONS.ApprovalsApprove, `approvals:uid:${req.params['id'] ?? ''}`),
-    ),
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        const authReq = req as AuthenticatedRequest;
+        const auth = authOr401(req, res);
+        if (!auth) return;
         const id = req.params['id'] ?? '';
-        const resolvedBy = authReq.auth?.userId ?? 'unknown';
-        const resolvedByRoles = authReq.auth?.isServerAdmin
-          ? ['admin']
-          : [legacyOrgRole(authReq.auth?.orgRole)];
+        const record = await repo.findById(id);
+        const notFound: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
+        if (!record) {
+          res.status(404).json(notFound);
+          return;
+        }
+        const perms = await accessControl.ensurePermissions(auth);
+        const allowed = await evalRowAccess(accessControl, auth, perms, ACTIONS.ApprovalsApprove, record);
+        if (!allowed) {
+          res.status(404).json(notFound);
+          return;
+        }
 
+        const resolvedBy = auth.userId ?? 'unknown';
+        const resolvedByRoles = auth.isServerAdmin ? ['admin'] : [legacyOrgRole(auth.orgRole)];
         const updated = await repo.reject(id, resolvedBy, resolvedByRoles);
         if (!updated) {
-          const existing = await repo.findById(id);
-          if (!existing) {
-            const err: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
-            res.status(404).json(err);
-            return;
-          }
-
           const err: ApiError = {
             code: 'CONFLICT',
-            message: `Approval request is already ${existing.status} and cannot be rejected`,
+            message: `Approval request is already ${record.status} and cannot be rejected`,
           };
           res.status(409).json(err);
           return;
         }
-
         res.json(updated);
       } catch (err) {
         next(err);
@@ -156,30 +256,35 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
     },
   );
 
-  // POST /api/approvals/:id/override - admin override; force-approve regardless
-  // of status (Admin-only via `approvals:override`).
+  // POST /api/approvals/:id/override — Admin force-approve via `approvals:override`.
   router.post(
     '/:id/override',
     authMiddleware,
-    requirePermission((req) =>
-      ac.eval(ACTIONS.ApprovalsOverride, `approvals:uid:${req.params['id'] ?? ''}`),
-    ),
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        const authReq = req as AuthenticatedRequest;
+        const auth = authOr401(req, res);
+        if (!auth) return;
         const id = req.params['id'] ?? '';
-        const resolvedBy = authReq.auth?.userId ?? 'unknown';
-        const resolvedByRoles = authReq.auth?.isServerAdmin
-          ? ['admin']
-          : [legacyOrgRole(authReq.auth?.orgRole)];
-
-        const updated = await repo.override(id, resolvedBy, resolvedByRoles);
-        if (!updated) {
-          const err: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
-          res.status(404).json(err);
+        const record = await repo.findById(id);
+        const notFound: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
+        if (!record) {
+          res.status(404).json(notFound);
+          return;
+        }
+        const perms = await accessControl.ensurePermissions(auth);
+        const allowed = await evalRowAccess(accessControl, auth, perms, ACTIONS.ApprovalsOverride, record);
+        if (!allowed) {
+          res.status(404).json(notFound);
           return;
         }
 
+        const resolvedBy = auth.userId ?? 'unknown';
+        const resolvedByRoles = auth.isServerAdmin ? ['admin'] : [legacyOrgRole(auth.orgRole)];
+        const updated = await repo.override(id, resolvedBy, resolvedByRoles);
+        if (!updated) {
+          res.status(404).json(notFound);
+          return;
+        }
         res.json(updated);
       } catch (err) {
         next(err);
@@ -187,25 +292,30 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
     },
   );
 
-  // POST /api/approvals/:id/execute - execute an already-approved operation.
-  // This is intentionally narrow today: only `ops.run_command` approval
-  // records are executable here, so Kubernetes fixes reuse the existing
-  // approvals table instead of inventing a parallel Ops approval system.
+  // POST /api/approvals/:id/execute — execute an already-approved op.
+  // Reuses the same per-row `approvals:approve` gate: a caller who can
+  // approve the row can also execute it (no additional scope dimension).
   router.post(
     '/:id/execute',
     authMiddleware,
-    requirePermission((req) =>
-      ac.eval(ACTIONS.ApprovalsApprove, `approvals:uid:${req.params['id'] ?? ''}`),
-    ),
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
       try {
-        const authReq = req as AuthenticatedRequest;
-        const auth = authReq.auth;
-        if (!auth) {
-          res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+        const auth = authOr401(req, res);
+        if (!auth) return;
+        const id = req.params['id'] ?? '';
+        const record = await repo.findById(id);
+        const notFound: ApiError = { code: 'NOT_FOUND', message: 'Approval request not found' };
+        if (!record) {
+          res.status(404).json(notFound);
           return;
         }
-        if (!deps.approvalRequests || !deps.opsConnectors) {
+        const perms = await accessControl.ensurePermissions(auth);
+        const allowed = await evalRowAccess(accessControl, auth, perms, ACTIONS.ApprovalsApprove, record);
+        if (!allowed) {
+          res.status(404).json(notFound);
+          return;
+        }
+        if (!deps.opsConnectors) {
           res.status(503).json({
             error: { code: 'NOT_CONFIGURED', message: 'approval execution is not configured' },
           });
@@ -215,7 +325,7 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
           connectors: deps.opsConnectors,
           approvals: deps.approvalRequests,
         }, auth.orgId);
-        const result = await runner.executeApprovedApproval(req.params['id'] ?? '', auth);
+        const result = await runner.executeApprovedApproval(id, auth);
         const status = result.decision === 'executed' ? 200 : 400;
         res.status(status).json(result);
       } catch (err) {

--- a/packages/api-gateway/src/services/ops-command-runner-service.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner-service.test.ts
@@ -64,6 +64,7 @@ describe('OpsCommandRunnerService', () => {
         expiresAt: 'later',
       })),
       findById: vi.fn(),
+      list: vi.fn(),
       listPending: vi.fn(),
       approve: vi.fn(),
       reject: vi.fn(),

--- a/packages/api-gateway/src/services/plan-executor-service.test.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.test.ts
@@ -4,7 +4,7 @@
  * without spawning kubectl.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb, SqliteRemediationPlanRepository, SqliteApprovalRequestRepository } from '@agentic-obs/data-layer';
 import type { SqliteClient, NewRemediationPlan } from '@agentic-obs/data-layer';
 import type { ExecutionAdapter } from '@agentic-obs/adapters';
@@ -337,5 +337,145 @@ describe('PlanExecutorService — audit hook', () => {
     expect(calls[0]?.metadata['verb']).toBe('scale');
     expect(calls[1]?.outcome).toBe('failure');
     expect(calls[1]?.metadata['verb']).toBe('rollout');
+  });
+});
+
+/**
+ * T2.1 acceptance — when plan-executor creates a per-step ApprovalRequest it
+ * stamps the row with `ops_connector_id`, `target_namespace`, and
+ * `requester_team_id`, deriving them from the step's argv and the injected
+ * team resolver. NULL semantics per approvals-multi-team-scope §3.2 / §3.6.
+ */
+describe('PlanExecutorService — approval-row scope enrichment', () => {
+  let db: SqliteClient;
+  let plansRepo: SqliteRemediationPlanRepository;
+  let approvalsRepo: SqliteApprovalRequestRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    plansRepo = new SqliteRemediationPlanRepository(db);
+    approvalsRepo = new SqliteApprovalRequestRepository(db);
+  });
+
+  it('happy path: namespaced ops step + team-owned alert rule → all 3 fields populated', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const resolveRequesterTeamId = vi.fn().mockResolvedValue('t-platform');
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      resolveRequesterTeamId,
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.opsConnectorId).toBe('k8s-prod');
+    expect(approval?.targetNamespace).toBe('app');
+    expect(approval?.requesterTeamId).toBe('t-platform');
+    expect(resolveRequesterTeamId).toHaveBeenCalledWith('org_main', 'inv-1');
+  });
+
+  it('cluster-scoped step (no -n flag): connector set, namespace NULL', async () => {
+    const plan = await plansRepo.create(
+      basePlan({
+        steps: [
+          {
+            kind: 'ops.run_command',
+            commandText: 'kubectl get nodes',
+            paramsJson: { argv: ['get', 'nodes'], connectorId: 'k8s-prod' },
+          },
+        ],
+      }),
+    );
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      resolveRequesterTeamId: async () => 't-platform',
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.opsConnectorId).toBe('k8s-prod');
+    expect(approval?.targetNamespace).toBeNull();
+    expect(approval?.requesterTeamId).toBe('t-platform');
+  });
+
+  it('non-ops step kind: both connector + namespace are NULL', async () => {
+    const plan = await plansRepo.create(
+      basePlan({
+        steps: [
+          {
+            kind: 'alert_rule_write',
+            commandText: 'pause noisy alert rule',
+            paramsJson: { ruleId: 'rule-1', state: 'paused' },
+          },
+        ],
+      }),
+    );
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      resolveRequesterTeamId: async () => 't-platform',
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.opsConnectorId).toBeNull();
+    expect(approval?.targetNamespace).toBeNull();
+    expect(approval?.requesterTeamId).toBe('t-platform');
+  });
+
+  it('chat-driven investigation (no alert rule): requester_team_id is NULL', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      // resolver returns NULL when investigation isn't linked to a rule.
+      resolveRequesterTeamId: async () => null,
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.opsConnectorId).toBe('k8s-prod');
+    expect(approval?.targetNamespace).toBe('app');
+    expect(approval?.requesterTeamId).toBeNull();
+  });
+
+  it('alert rule in folder without team binding: requester_team_id is NULL', async () => {
+    // Identical to the previous case from the executor's perspective — the
+    // resolver folds "no rule", "rule with no folder", and "folder with no
+    // team binding" all into a single `null` return. Pinning this case
+    // separately so a future refactor that introduces a sentinel (e.g.
+    // 'unknown') for the no-team-binding case fails loudly.
+    const plan = await plansRepo.create(basePlan());
+    const resolveRequesterTeamId = vi.fn().mockResolvedValue(null);
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      resolveRequesterTeamId,
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.requesterTeamId).toBeNull();
+    expect(resolveRequesterTeamId).toHaveBeenCalledTimes(1);
+  });
+
+  it('no resolver wired: requester_team_id is NULL (back-compat)', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      approvals: approvalsRepo,
+      adapterFor: async () => fakeAdapter(),
+      // resolveRequesterTeamId omitted entirely.
+    });
+    const outcome = await svc.approve('org_main', plan.id, false, ID);
+    if (outcome.kind !== 'paused_for_approval') throw new Error('expected paused');
+    const approval = await approvalsRepo.findById(outcome.approvalRequestId);
+    expect(approval?.requesterTeamId).toBeNull();
   });
 });

--- a/packages/api-gateway/src/services/plan-executor-service.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.ts
@@ -44,6 +44,7 @@ import type {
   RemediationPlan,
   RemediationPlanStep,
 } from '@agentic-obs/data-layer';
+import { readNamespaceFromArgv } from './plan-namespaces.js';
 
 const log = createLogger('plan-executor');
 
@@ -72,6 +73,19 @@ export interface PlanExecutorOptions {
    * verb in metadata. Boot wiring passes `authSub.audit`; tests omit.
    */
   audit?: AuditWriter;
+  /**
+   * Optional resolver: investigation id → owning team id, for the per-row
+   * `requester_team_id` enrichment (approvals-multi-team-scope §3.6). Wire
+   * this at boot from alertRule.investigationId → folderUid → folder team
+   * binding. Returns NULL when the investigation isn't linked to a rule, the
+   * rule has no folder, or the folder has no owning team. When the option
+   * is omitted entirely, every approval row's `requester_team_id` is NULL
+   * (back-compat for tests / installs that don't wire this yet).
+   */
+  resolveRequesterTeamId?: (
+    orgId: string,
+    investigationId: string,
+  ) => Promise<string | null>;
 }
 
 export type PlanExecutorOutcome =
@@ -304,6 +318,16 @@ export class PlanExecutorService {
       );
     }
     const params = readOpsRunCommandParams(next);
+    // Per-row scope enrichment (approvals-multi-team-scope §3.6). For per-step
+    // approvals the "first ops_run_command step" simply IS the step being
+    // gated; non-ops kinds → both connector + namespace are NULL.
+    const opsConnectorId = params?.connectorId ?? null;
+    const targetNamespace = params
+      ? readNamespaceFromArgv(params.argv)
+      : null;
+    const requesterTeamId = this.opts.resolveRequesterTeamId
+      ? await this.opts.resolveRequesterTeamId(orgId, plan.investigationId)
+      : null;
     const submitted = await this.opts.approvals.submit({
       action: {
         type: 'ops.run_command',
@@ -322,6 +346,9 @@ export class PlanExecutorService {
         // already accepts unknown context fields.
         ...{ planId: plan.id, stepOrdinal: next.ordinal } as Record<string, unknown>,
       },
+      opsConnectorId,
+      targetNamespace,
+      requesterTeamId,
     });
     await this.opts.plans.updateStep(plan.id, next.ordinal, {
       approvalRequestId: submitted.id,

--- a/packages/api-gateway/src/services/plan-namespaces.ts
+++ b/packages/api-gateway/src/services/plan-namespaces.ts
@@ -50,7 +50,7 @@ export function extractPlanNamespaces(plan: RemediationPlan): PlanNamespaceSumma
   return { namespaces: [...namespaces].sort(), hasClusterScoped };
 }
 
-function readNamespaceFromArgv(argv: readonly string[]): string | null {
+export function readNamespaceFromArgv(argv: readonly string[]): string | null {
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i] ?? '';
     if (tok === '-n' || tok === '--namespace') {

--- a/packages/common/src/rbac/fixed-roles-def.ts
+++ b/packages/common/src/rbac/fixed-roles-def.ts
@@ -664,6 +664,40 @@ const APPROVALS_OVERRIDER = def(
   ],
 );
 
+// Multi-team approval scopes (see approvals-multi-team-scope §3.5). The
+// catalog ships with `*` placeholders; admins narrow each grant to a specific
+// connector / namespace / team at bind time, matching how folder-scoped
+// fixed roles like `fixed:dashboards:writer` are bound to specific folders.
+const APPROVALS_CLUSTER_APPROVER = def(
+  'fixed:approvals:cluster_approver',
+  'Cluster approver',
+  'Read and approve cluster-operation approvals scoped to a single ops connector.',
+  'Approvals',
+  [
+    { action: ACTIONS.ApprovalsRead, scope: 'approvals:connector:*' },
+    { action: ACTIONS.ApprovalsApprove, scope: 'approvals:connector:*' },
+  ],
+);
+
+const APPROVALS_NAMESPACE_APPROVER = def(
+  'fixed:approvals:namespace_approver',
+  'Namespace approver',
+  'Read and approve cluster-operation approvals scoped to a single (connector, namespace) pair.',
+  'Approvals',
+  [
+    { action: ACTIONS.ApprovalsRead, scope: 'approvals:namespace:*:*' },
+    { action: ACTIONS.ApprovalsApprove, scope: 'approvals:namespace:*:*' },
+  ],
+);
+
+const APPROVALS_TEAM_VIEWER = def(
+  'fixed:approvals:team_viewer',
+  'Team approval viewer',
+  'Read approvals originated by a single team.',
+  'Approvals',
+  [{ action: ACTIONS.ApprovalsRead, scope: 'approvals:team:*' }],
+);
+
 const PLANS_READER = def(
   'fixed:plans:reader',
   'Plans reader',
@@ -803,6 +837,9 @@ export const FIXED_ROLE_DEFINITIONS: readonly FixedRoleDefinition[] =
     APPROVALS_READER,
     APPROVALS_APPROVER,
     APPROVALS_OVERRIDER,
+    APPROVALS_CLUSTER_APPROVER,
+    APPROVALS_NAMESPACE_APPROVER,
+    APPROVALS_TEAM_VIEWER,
     PLANS_READER,
     PLANS_APPROVER,
     PLANS_AUTO_EDITOR,

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -13,6 +13,7 @@ export type {
   CaseFindAllOptions,
   IApprovalRepository,
   IApprovalRequestRepository,
+  ApprovalScopeFilter,
   IShareRepository,
   IShareLinkRepository,
   IDashboardRepository,

--- a/packages/data-layer/src/repository/interfaces.ts
+++ b/packages/data-layer/src/repository/interfaces.ts
@@ -195,7 +195,17 @@ export type ApprovalScopeFilter =
 
 export interface IApprovalRequestRepository {
   findById(id: string): Promise<ApprovalRequest | undefined>;
-  submit(params: { action: ApprovalAction; context: ApprovalContext; ttlMs?: number }): Promise<ApprovalRequest>;
+  submit(params: {
+    action: ApprovalAction;
+    context: ApprovalContext;
+    ttlMs?: number;
+    /** See approvals-multi-team-scope §3.6. NULL when plan has no ops step. */
+    opsConnectorId?: string | null;
+    /** See approvals-multi-team-scope §3.6. NULL for cluster-scoped plans. */
+    targetNamespace?: string | null;
+    /** See approvals-multi-team-scope §3.6. NULL when no team-owned folder. */
+    requesterTeamId?: string | null;
+  }): Promise<ApprovalRequest>;
   listPending(): Promise<ApprovalRequest[]>;
   /**
    * Org-scoped list with optional per-row scope filter and status filter.

--- a/packages/data-layer/src/repository/postgres/approval.ts
+++ b/packages/data-layer/src/repository/postgres/approval.ts
@@ -36,6 +36,9 @@ export class PostgresApprovalRequestRepository implements IApprovalRequestReposi
     action: ApprovalAction;
     context: ApprovalContext;
     ttlMs?: number;
+    opsConnectorId?: string | null;
+    targetNamespace?: string | null;
+    requesterTeamId?: string | null;
   }): Promise<ApprovalRequest> {
     const now = new Date();
     const expiresAt = new Date(now.getTime() + (params.ttlMs ?? 86400000)).toISOString();
@@ -48,6 +51,9 @@ export class PostgresApprovalRequestRepository implements IApprovalRequestReposi
         status: 'pending',
         expiresAt,
         createdAt: now.toISOString(),
+        opsConnectorId: params.opsConnectorId ?? null,
+        targetNamespace: params.targetNamespace ?? null,
+        requesterTeamId: params.requesterTeamId ?? null,
       })
       .returning();
     return rowToRequest(row!);

--- a/packages/data-layer/src/repository/sqlite/approval.test.ts
+++ b/packages/data-layer/src/repository/sqlite/approval.test.ts
@@ -185,3 +185,41 @@ describe('SqliteApprovalRequestRepository.list', () => {
     expect(out.map((r) => r.id)).not.toContain('other-1');
   });
 });
+
+/**
+ * T2.1 acceptance — submit() persists the three scope columns when provided
+ * and writes NULL when omitted. See approvals-multi-team-scope §3.6.
+ */
+describe('SqliteApprovalRequestRepository.submit — scope enrichment', () => {
+  it('persists opsConnectorId / targetNamespace / requesterTeamId when provided', async () => {
+    const db = createTestDb();
+    const repo = new SqliteApprovalRequestRepository(db);
+    const submitted = await repo.submit({
+      action: { type: 'ops.run_command', targetService: 'k8s-prod', params: {} },
+      context: { requestedBy: 'agent', reason: 'scale up' },
+      opsConnectorId: 'k8s-prod',
+      targetNamespace: 'payments',
+      requesterTeamId: 't-payments',
+    });
+    expect(submitted.opsConnectorId).toBe('k8s-prod');
+    expect(submitted.targetNamespace).toBe('payments');
+    expect(submitted.requesterTeamId).toBe('t-payments');
+
+    const fetched = await repo.findById(submitted.id);
+    expect(fetched?.opsConnectorId).toBe('k8s-prod');
+    expect(fetched?.targetNamespace).toBe('payments');
+    expect(fetched?.requesterTeamId).toBe('t-payments');
+  });
+
+  it('omitted scope fields are persisted as NULL (back-compat)', async () => {
+    const db = createTestDb();
+    const repo = new SqliteApprovalRequestRepository(db);
+    const submitted = await repo.submit({
+      action: { type: 'ops.run_command', targetService: 'k8s-prod', params: {} },
+      context: { requestedBy: 'agent', reason: 'no enrichment' },
+    });
+    expect(submitted.opsConnectorId).toBeNull();
+    expect(submitted.targetNamespace).toBeNull();
+    expect(submitted.requesterTeamId).toBeNull();
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/approval.ts
+++ b/packages/data-layer/src/repository/sqlite/approval.ts
@@ -37,6 +37,9 @@ export class SqliteApprovalRequestRepository implements IApprovalRequestReposito
     action: ApprovalAction;
     context: ApprovalContext;
     ttlMs?: number;
+    opsConnectorId?: string | null;
+    targetNamespace?: string | null;
+    requesterTeamId?: string | null;
   }): Promise<ApprovalRequest> {
     const now = new Date();
     const expiresAt = new Date(now.getTime() + (params.ttlMs ?? 86400000)).toISOString();
@@ -49,6 +52,9 @@ export class SqliteApprovalRequestRepository implements IApprovalRequestReposito
         status: 'pending',
         expiresAt,
         createdAt: now.toISOString(),
+        opsConnectorId: params.opsConnectorId ?? null,
+        targetNamespace: params.targetNamespace ?? null,
+        requesterTeamId: params.requesterTeamId ?? null,
       })
       .returning();
     return rowToRequest(row!);


### PR DESCRIPTION
Phase 2 of multi-team approvals ([design doc #154](https://github.com/openobs/openobs/pull/154), §3.3 + §3.6). Builds on T1.1 ([#155](https://github.com/openobs/openobs/pull/155)) — schema columns, scope grammar, and `list({ scopeFilter })` repo API.

Two halves of the same design intent in one PR — they ship as a unit because:
- T2.2's per-row filter is useless without write-path tags (T2.1) — every row would still be NULL → wildcard-only.
- T2.1's tags are useless without the per-row filter (T2.2) — they'd just be metadata nobody reads.

## Write path (T2.1)

The plan-level approval row is what users see in `/api/approvals` — it needs the scope tags. Two write sites enrich it:

1. **agent-core `remediation_plan_create` handler** — the primary path; this is what a fired alert + auto-investigation produces. Reads `connectorId` + `namespace` from the first ops step's `argv` via `parseKubectlArgv`. `requesterTeamId` stays NULL for now (TODO inline: thread `alertRule → folder → team` via ctx).
2. **plan-executor `submit()` for per-step approvals** — rare; when auto-edit is off and a step needs its own approval. Same connector + namespace logic, plus a `resolveRequesterTeamId` callback hook for api-gateway to wire. Left unwired in this PR — null is the safe default.

Repo `.submit()` in sqlite + postgres + `IApprovalRequestRepository` gets three new **optional** input fields. Existing callers (no params) keep working — rows persist NULL, T1.1 back-compat tests cover that.

`ApprovalRequestStore` in `agent-core/types.ts` also gets the three optional fields so the handler can pass them through without going around the abstraction.

## Read path (T2.2)

`routes/approval.ts` switches from coarse `requirePermission(ApprovalsRead, 'approvals:*')` to per-row scope resolution:

- **LIST** — pulls user's `ApprovalsRead` grants. Wildcard holders → fast path through `repo.list({ kind: 'wildcard' })`. Otherwise builds a `narrow` filter from the user's specific connector / namespace-pair / team grants.
- **DETAIL + actions** — load row first; build candidate scopes via `approvalRowScopes(row)`; **add `approvals:*` to the candidate list ONLY if the user actually holds the wildcard**. Deny → 404 (not 403) so the row's existence isn't leaked to a user who has no business knowing it.

### Fail-closed invariant (R1)

The load-bearing test: a user with only `approvals:read on approvals:connector:dev-eks` requesting a `prod-eks` approval → **404, never wildcard fallback**. This is what makes the feature actually safe for B2B multi-team — without it, a stray grant would silently widen visibility to everything.

### Three new fixed roles
- `fixed:approvals:cluster_approver` — connector-scoped read+approve
- `fixed:approvals:namespace_approver` — connector+namespace read+approve
- `fixed:approvals:team_viewer` — team-scoped read

Default `Editor` / `Viewer` roles **unchanged** — their `approvals:*` grant still matches everything. Multi-team customers opt in by revoking the default and granting the new fixed roles per team.

## Known follow-ups (NOT in this PR)

1. **`requesterTeamId` resolver wiring**: both write sites currently set `null`. The infrastructure to resolve `investigation → alertRule → folder → team` exists (sqlite + dashboard_acl), but threading it into agent-core's ctx and api-gateway's plan-executor is its own task. Until then, team-scoped grants don't match anything; cluster/namespace grants do — which covers the common B2B case.
2. **`/execute` route gate**: reuses the `ApprovalsApprove` per-row gate (no separate scope dimension).

## Test plan
- [x] **+21 new tests across 3 files**:
  - `routes/approval.test.ts` (NEW, +13) — fail-closed invariant; all three scope dimensions; NULL row visibility (back-compat); action gating; override semantics; fixed-role catalog
  - `services/plan-executor-service.test.ts` (+6) — happy path, cluster-scoped, non-ops, no-rule, no-team, no-resolver
  - `repository/sqlite/approval.test.ts` (+2) — submit persists + omits the three columns
- [x] `vitest run packages/{agent-core,api-gateway,common,data-layer}` — **1408 pass / 19 pre-existing pg-skipped / 0 fail**
- [x] `tsc -b` clean (filtering pre-existing chat-service / github-change-source issues unrelated)
- [ ] Manual: revoke Editor's `approvals:*`, grant `fixed:approvals:cluster_approver` to a per-team group bound to `prod-eks`, fire alert in dev → verify the team only sees prod approvals (and 404s on dev rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented scope-based authorization for approvals with per-row access control.
  * Added three new approval management roles for cluster-level, namespace-level, and team-level approval operations.
  * Enhanced approval visibility—users now only see approvals within their authorized scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->