### PR TITLE
T3.1+T3.2: approval routing via NotificationConsumer + UI filters

### DIFF
--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -37,6 +37,7 @@ import type { SetupConfigService } from '../services/setup-config-service.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { GitHubChangeSourceRegistry } from '../services/github-change-source-service.js';
+import type { IApprovalRequestRepository } from '@agentic-obs/data-layer';
 
 const NOOP_CONVERSATION_STORE: IAgentConversationStore = {
   getMessages: async () => [],
@@ -56,6 +57,13 @@ export interface BackgroundOrchestratorFactoryDeps {
   folderRepository?: IFolderRepository;
   /** In-process GitHub/change sources. */
   githubChangeSources?: GitHubChangeSourceRegistry;
+  /**
+   * Override the approval-request repo used by the agent's plan handler.
+   * Wired at boot to a publishing wrapper so plan-level `submit()` calls
+   * publish `approval.created` (T3.1). Falls back to the persistence repo
+   * when omitted (tests / pre-T3.1 callers).
+   */
+  approvalsOverride?: IApprovalRequestRepository;
 }
 
 export type MakeBackgroundOrchestrator = (overrides: {
@@ -109,7 +117,7 @@ export function buildBackgroundOrchestratorFactory(
       allDatasources: toAgentDatasources(datasources),
       ...(opsCommandRunner ? { opsCommandRunner, opsConnectors } : {}),
       remediationPlans: deps.persistence.repos.remediationPlans,
-      approvalRequests: deps.persistence.repos.approvals,
+      approvalRequests: deps.approvalsOverride ?? deps.persistence.repos.approvals,
       // Background runs have no SSE channel; tool events are still logged
       // via the agent's internal logger but not streamed anywhere.
       sendEvent: () => undefined,

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -84,6 +84,12 @@ export interface MountDomainRoutesDeps {
    * Without it the row is created but no agent runs.
    */
   runner?: BackgroundRunnerDeps;
+  /**
+   * Approval-request repo used by PlanExecutorService for per-step approval
+   * submits. Wired at boot to a publishing wrapper so each `submit()`
+   * publishes `approval.created` (T3.1). Falls back to `repos.approvals`.
+   */
+  approvalsForExecutor?: import('@agentic-obs/data-layer').IApprovalRequestRepository;
 }
 
 export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
@@ -197,7 +203,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   mountPlans({
     app,
     plans: repos.remediationPlans,
-    approvals: repos.approvals,
+    approvals: deps.approvalsForExecutor ?? repos.approvals,
     approvalEventStore: eventApprovalStore,
     connectors: repos.opsConnectors,
     ac: accessControl,

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -40,6 +40,8 @@ import { mountDomainRoutes } from './app/domain-routes.js';
 import { startAlerts } from './app/alerts-boot.js';
 import { createEventBusFromEnv } from '@agentic-obs/common/events';
 import { NotificationConsumer } from './services/notification-consumer.js';
+import { PublishingApprovalRepository } from './services/publishing-approval-repository.js';
+import { ApprovalRouter } from './services/approval-router.js';
 import { EventEmittingAlertRuleRepository } from '@agentic-obs/data-layer';
 import { buildBackgroundOrchestratorFactory } from './app/agent-factory.js';
 import { GitHubChangeSourceRegistry } from './services/github-change-source-service.js';
@@ -207,6 +209,17 @@ export async function createApp(): Promise<Application> {
   const eventBus = createEventBusFromEnv();
   app.locals['eventBus'] = eventBus;
 
+  // Wrap the approval-request repo so a successful `submit()` publishes
+  // `approval.created` on the bus (T3.1 / approvals-multi-team-scope §3.7).
+  // Both the agent-core remediation-plan handler (plan-level approvals) and
+  // PlanExecutorService (per-step approvals) write through this wrapper, so
+  // the NotificationConsumer below sees every new approval row.
+  const publishingApprovals = new PublishingApprovalRepository({
+    inner: persistence.repos.approvals,
+    bus: eventBus,
+    orgId: 'org_main',
+  });
+
   // Background-agent runner — shared by both the auto-investigation
   // dispatcher (alert.fired -> agent run) and the manual Investigate
   // button on alert rules. Built once so both paths use the same
@@ -215,6 +228,7 @@ export async function createApp(): Promise<Application> {
     saTokens: bundle.apiKeyService,
     makeOrchestrator: buildBackgroundOrchestratorFactory({
       persistence,
+      approvalsOverride: publishingApprovals,
       setupConfig,
       accessControl,
       audit: bundle.authSub.audit,
@@ -237,6 +251,7 @@ export async function createApp(): Promise<Application> {
     eventAlertRuleStore,
     githubChangeSources,
     runner: backgroundRunner,
+    approvalsForExecutor: publishingApprovals,
   });
 
   // Start the periodic alert evaluator (Phase 0.5 boot path). Behind
@@ -264,10 +279,24 @@ export async function createApp(): Promise<Application> {
   // to `alert.fired` on the same bus. Routing tree + group/repeat windows
   // are read live, so policy edits in the UI take effect on the next fire
   // without restarting.
+  // ApprovalRouter resolves users from RBAC for approval.created routing
+  // (approvals-multi-team-scope §3.7). Shares the auth repos with
+  // AccessControlService — same source of truth for visibility + notify.
+  const approvalRouter = new ApprovalRouter({
+    permissions: persistence.rbacRepos.permissions,
+    roles: persistence.rbacRepos.roles,
+    userRoles: persistence.rbacRepos.userRoles,
+    teamRoles: persistence.rbacRepos.teamRoles,
+    teamMembers: persistence.rbacRepos.teamMembers,
+    orgUsers: bundle.authRepos.orgUsers,
+  });
+
   const notificationConsumer = new NotificationConsumer({
     bus: eventBus,
     notifications: persistence.repos.notifications,
     notificationDispatch: persistence.repos.notificationDispatch,
+    approvalRouter,
+    teamMembers: persistence.rbacRepos.teamMembers,
   });
   notificationConsumer.start();
   app.locals['notificationConsumer'] = notificationConsumer;

--- a/packages/api-gateway/src/services/approval-router.test.ts
+++ b/packages/api-gateway/src/services/approval-router.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Permission,
+  UserRole,
+  TeamRole,
+  TeamMember,
+  BuiltinRole,
+  IPermissionRepository,
+  IRoleRepository,
+  IUserRoleRepository,
+  ITeamRoleRepository,
+  ITeamMemberRepository,
+  IOrgUserRepository,
+} from '@agentic-obs/common';
+import { ApprovalRouter, buildCandidateScopes } from './approval-router.js';
+
+// Tiny shape-mocked repos. Only the methods ApprovalRouter actually calls are
+// implemented; everything else throws if accidentally invoked.
+function notImpl(): never { throw new Error('not implemented'); }
+
+function permRepo(perms: Array<{ id?: string; roleId: string; action: string; scope: string }>): IPermissionRepository {
+  return {
+    listByAction: async (action) =>
+      perms.filter((p) => p.action === action).map((p, i) => ({
+        id: p.id ?? `p_${i}`,
+        roleId: p.roleId,
+        action: p.action,
+        scope: p.scope,
+        kind: p.scope.split(':')[0] ?? '*',
+        attribute: p.scope.split(':')[1] ?? '*',
+        identifier: p.scope.split(':').slice(2).join(':') || '*',
+        created: '',
+        updated: '',
+      })) as Permission[],
+    listByRole: async () => notImpl(),
+    listByRoles: async () => notImpl(),
+    create: async () => notImpl(),
+    createMany: async () => notImpl(),
+    findById: async () => notImpl(),
+    delete: async () => notImpl(),
+    deleteByRole: async () => notImpl(),
+  };
+}
+
+function roleRepo(builtins: Array<{ role: string; roleId: string; orgId: string }>): IRoleRepository {
+  return {
+    listBuiltinRoles: async (orgId) => builtins.filter((b) => b.orgId === orgId).map<BuiltinRole>((b) => ({
+      id: `br_${b.roleId}_${b.role}`,
+      role: b.role,
+      roleId: b.roleId,
+      orgId: b.orgId,
+      created: '',
+      updated: '',
+    })),
+    create: async () => notImpl(),
+    findById: async () => notImpl(),
+    findByUid: async () => notImpl(),
+    findByName: async () => notImpl(),
+    list: async () => notImpl(),
+    update: async () => notImpl(),
+    delete: async () => notImpl(),
+    upsertBuiltinRole: async () => notImpl(),
+    findBuiltinRole: async () => notImpl(),
+    removeBuiltinRole: async () => notImpl(),
+  };
+}
+
+function userRoleRepo(rows: Array<{ orgId: string; userId: string; roleId: string }>): IUserRoleRepository {
+  return {
+    listByRole: async (roleId) => rows.filter((r) => r.roleId === roleId).map<UserRole>((r, i) => ({
+      id: `ur_${i}`, orgId: r.orgId, userId: r.userId, roleId: r.roleId, created: '',
+    })),
+    create: async () => notImpl(),
+    findById: async () => notImpl(),
+    listByUser: async () => notImpl(),
+    delete: async () => notImpl(),
+    remove: async () => notImpl(),
+  };
+}
+
+function teamRoleRepo(rows: Array<{ orgId: string; teamId: string; roleId: string }>): ITeamRoleRepository {
+  return {
+    listByRole: async (roleId) => rows.filter((r) => r.roleId === roleId).map<TeamRole>((r, i) => ({
+      id: `tr_${i}`, orgId: r.orgId, teamId: r.teamId, roleId: r.roleId, created: '',
+    })),
+    create: async () => notImpl(),
+    findById: async () => notImpl(),
+    listByTeam: async () => notImpl(),
+    listByTeams: async () => notImpl(),
+    delete: async () => notImpl(),
+    remove: async () => notImpl(),
+  };
+}
+
+function teamMemberRepo(members: Array<{ teamId: string; userId: string }>): ITeamMemberRepository {
+  return {
+    listByTeam: async (teamId) => members.filter((m) => m.teamId === teamId).map<TeamMember>((m) => ({
+      id: `tm_${m.teamId}_${m.userId}`, teamId: m.teamId, userId: m.userId, permission: 0,
+    } as TeamMember)),
+    listTeamsForUser: async (userId) => members.filter((m) => m.userId === userId).map<TeamMember>((m) => ({
+      id: `tm_${m.teamId}_${m.userId}`, teamId: m.teamId, userId: m.userId, permission: 0,
+    } as TeamMember)),
+    create: async () => notImpl(),
+    findById: async () => notImpl(),
+    findMembership: async () => notImpl(),
+    listByTeamWithProfile: async () => notImpl(),
+    updatePermission: async () => notImpl(),
+    remove: async () => notImpl(),
+    removeAllByUser: async () => notImpl(),
+  };
+}
+
+function orgUserRepo(rows: Array<{ orgId: string; userId: string; role: string }>): IOrgUserRepository {
+  return {
+    listUsersByOrg: async (orgId) => ({
+      items: rows.filter((r) => r.orgId === orgId).map((r) => ({
+        orgId: r.orgId, userId: r.userId, role: r.role,
+        email: `${r.userId}@x`, name: r.userId, login: r.userId, isServiceAccount: false,
+      } as never)),
+      total: rows.length,
+      offset: 0,
+      limit: 10000,
+    }),
+    create: async () => notImpl(),
+    findById: async () => notImpl(),
+    findMembership: async () => notImpl(),
+    listOrgsByUser: async () => notImpl(),
+    listOrgsByUserWithName: async () => notImpl(),
+    updateRole: async () => notImpl(),
+    remove: async () => notImpl(),
+  };
+}
+
+describe('buildCandidateScopes', () => {
+  it('includes uid + connector + namespace + team for the row', () => {
+    const scopes = buildCandidateScopes({
+      id: 'ap_1',
+      opsConnectorId: 'prod-eks',
+      targetNamespace: 'platform',
+      requesterTeamId: 'team_payments',
+    });
+    expect(scopes).toContain('approvals:uid:ap_1');
+    expect(scopes).toContain('approvals:connector:prod-eks');
+    expect(scopes).toContain('approvals:namespace:prod-eks:platform');
+    expect(scopes).toContain('approvals:team:team_payments');
+    // approvals:* is a PERMISSION shape, not a row shape — must not appear here.
+    expect(scopes).not.toContain('approvals:*');
+  });
+
+  it('omits namespace when targetNamespace is null', () => {
+    const scopes = buildCandidateScopes({
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: null, requesterTeamId: null,
+    });
+    expect(scopes.some((s) => s.startsWith('approvals:namespace:'))).toBe(false);
+  });
+
+  it('null row has only uid', () => {
+    const scopes = buildCandidateScopes({ id: 'ap_1' });
+    expect(scopes).toEqual(['approvals:uid:ap_1']);
+  });
+});
+
+describe('ApprovalRouter.findApprovers — single-team / wildcard', () => {
+  it('a user with approvals:* on Editor role gets returned for every approval', async () => {
+    const router = new ApprovalRouter({
+      permissions: permRepo([{ roleId: 'role_editor', action: 'approvals:approve', scope: 'approvals:*' }]),
+      roles: roleRepo([{ role: 'Editor', roleId: 'role_editor', orgId: 'org_main' }]),
+      userRoles: userRoleRepo([]),
+      teamRoles: teamRoleRepo([]),
+      teamMembers: teamMemberRepo([]),
+      orgUsers: orgUserRepo([
+        { orgId: 'org_main', userId: 'u_alice', role: 'Editor' },
+        { orgId: 'org_main', userId: 'u_bob', role: 'Viewer' },
+      ]),
+    });
+    const got = await router.findApprovers('org_main', {
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: 'platform', requesterTeamId: null,
+    });
+    expect(got).toEqual(['u_alice']);
+  });
+
+  it('NULL row routing — only approvals:* holders match', async () => {
+    const router = new ApprovalRouter({
+      permissions: permRepo([
+        { roleId: 'role_editor', action: 'approvals:approve', scope: 'approvals:*' },
+        { roleId: 'role_conn', action: 'approvals:approve', scope: 'approvals:connector:prod-eks' },
+      ]),
+      roles: roleRepo([{ role: 'Editor', roleId: 'role_editor', orgId: 'org_main' }]),
+      userRoles: userRoleRepo([{ orgId: 'org_main', userId: 'u_conn', roleId: 'role_conn' }]),
+      teamRoles: teamRoleRepo([]),
+      teamMembers: teamMemberRepo([]),
+      orgUsers: orgUserRepo([{ orgId: 'org_main', userId: 'u_alice', role: 'Editor' }]),
+    });
+    const got = await router.findApprovers('org_main', { id: 'ap_legacy' }); // all NULL
+    expect(got).toContain('u_alice');
+    expect(got).not.toContain('u_conn');
+  });
+});
+
+describe('ApprovalRouter.findApprovers — multi-team narrow grants', () => {
+  it('connector-narrow grants only match their connector', async () => {
+    const router = new ApprovalRouter({
+      permissions: permRepo([
+        { roleId: 'role_prod', action: 'approvals:approve', scope: 'approvals:connector:prod-eks' },
+        { roleId: 'role_dev', action: 'approvals:approve', scope: 'approvals:connector:dev-eks' },
+      ]),
+      roles: roleRepo([]),
+      userRoles: userRoleRepo([
+        { orgId: 'org_main', userId: 'u_prod', roleId: 'role_prod' },
+        { orgId: 'org_main', userId: 'u_dev', roleId: 'role_dev' },
+      ]),
+      teamRoles: teamRoleRepo([]),
+      teamMembers: teamMemberRepo([]),
+      orgUsers: orgUserRepo([]),
+    });
+    const got = await router.findApprovers('org_main', {
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: null, requesterTeamId: null,
+    });
+    expect(got).toContain('u_prod');
+    expect(got).not.toContain('u_dev');
+  });
+
+  it('namespace-narrow grants distinguish namespace within one connector', async () => {
+    const router = new ApprovalRouter({
+      permissions: permRepo([
+        { roleId: 'role_pf', action: 'approvals:approve', scope: 'approvals:namespace:prod-eks:platform' },
+        { roleId: 'role_ks', action: 'approvals:approve', scope: 'approvals:namespace:prod-eks:kube-system' },
+      ]),
+      roles: roleRepo([]),
+      userRoles: userRoleRepo([
+        { orgId: 'org_main', userId: 'u_pf', roleId: 'role_pf' },
+        { orgId: 'org_main', userId: 'u_ks', roleId: 'role_ks' },
+      ]),
+      teamRoles: teamRoleRepo([]),
+      teamMembers: teamMemberRepo([]),
+      orgUsers: orgUserRepo([]),
+    });
+    const got = await router.findApprovers('org_main', {
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: 'platform', requesterTeamId: null,
+    });
+    expect(got).toEqual(['u_pf']);
+  });
+
+  it('FAIL-CLOSED: a user with non-matching narrow grant is NOT notified, even when they hold OTHER approvals grants in OTHER orgs', async () => {
+    // u_dev holds approvals:approve on connector:dev-eks in org_main and
+    // approvals:* in some other-org. The org isolation must keep them out
+    // of org_main's prod-eks routing list.
+    const router = new ApprovalRouter({
+      permissions: permRepo([
+        { roleId: 'role_dev', action: 'approvals:approve', scope: 'approvals:connector:dev-eks' },
+        { roleId: 'role_other', action: 'approvals:approve', scope: 'approvals:*' },
+      ]),
+      roles: roleRepo([]),
+      userRoles: userRoleRepo([
+        { orgId: 'org_main', userId: 'u_dev', roleId: 'role_dev' },
+        // CROSS-ORG grant: must NOT bleed into org_main routing.
+        { orgId: 'org_other', userId: 'u_dev', roleId: 'role_other' },
+      ]),
+      teamRoles: teamRoleRepo([]),
+      teamMembers: teamMemberRepo([]),
+      orgUsers: orgUserRepo([]),
+    });
+    const got = await router.findApprovers('org_main', {
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: null, requesterTeamId: null,
+    });
+    expect(got).not.toContain('u_dev');
+    expect(got).toEqual([]);
+  });
+
+  it('team-role + team-member fan-out: matching grant on a team role notifies all its members', async () => {
+    const router = new ApprovalRouter({
+      permissions: permRepo([
+        { roleId: 'role_prod', action: 'approvals:approve', scope: 'approvals:connector:prod-eks' },
+      ]),
+      roles: roleRepo([]),
+      userRoles: userRoleRepo([]),
+      teamRoles: teamRoleRepo([{ orgId: 'org_main', teamId: 'team_ops', roleId: 'role_prod' }]),
+      teamMembers: teamMemberRepo([
+        { teamId: 'team_ops', userId: 'u_a' },
+        { teamId: 'team_ops', userId: 'u_b' },
+      ]),
+      orgUsers: orgUserRepo([]),
+    });
+    const got = await router.findApprovers('org_main', {
+      id: 'ap_1', opsConnectorId: 'prod-eks', targetNamespace: null, requesterTeamId: null,
+    });
+    expect(new Set(got)).toEqual(new Set(['u_a', 'u_b']));
+  });
+});

--- a/packages/api-gateway/src/services/approval-router.ts
+++ b/packages/api-gateway/src/services/approval-router.ts
@@ -1,0 +1,172 @@
+/**
+ * ApprovalRouter — finds the users in an org whose `approvals:approve` grant
+ * covers a given approval row's scope.
+ *
+ * This is the routing primitive consumed by NotificationConsumer when an
+ * `approval.created` event lands. The candidate scopes are built via the
+ * shared `approvalRowScopes()` helper plus `approvals:*` (because we're
+ * matching against permission rows, not gating one user's request — wildcard
+ * holders are legitimate recipients here).
+ *
+ * Resolution path (mirrors AccessControlService.getUserPermissions but
+ * inverted: from permissions to users):
+ *
+ *   1. permissions.listByAction('approvals:approve') → all `approve` perms.
+ *   2. Filter to those whose `scope` is covered by ANY candidate scope.
+ *      "Covered by" uses scopeCovers(parent=row-scope, child=perm-scope) —
+ *      a row-scope of `approvals:connector:prod-eks` matches a permission
+ *      with the same scope, OR a permission scoped narrower (uid). We also
+ *      treat `approvals:*` as a parent that matches any row.
+ *   3. Collect roleIds → find users via:
+ *        - builtin_role mapping in this org (Viewer/Editor/Admin → users
+ *          with that role on org_user)
+ *        - user_role direct assignment scoped to this org (or global)
+ *        - team_role assignment + team_members in this org
+ *   4. Return deduped user IDs.
+ *
+ * Fail-closed: a user MUST NOT be returned for a row their grants do not
+ * cover, even if they hold OTHER grants in OTHER orgs. Org-isolation comes
+ * from filtering user_role/team_role/builtin_role/team_members by orgId. See
+ * approvals-multi-team-scope §3.4 / R1.
+ */
+
+import type {
+  IPermissionRepository,
+  IRoleRepository,
+  IUserRoleRepository,
+  ITeamRoleRepository,
+  ITeamMemberRepository,
+  IOrgUserRepository,
+  Permission,
+} from '@agentic-obs/common';
+import { ACTIONS, scopeCovers } from '@agentic-obs/common';
+import { approvalRowScopes } from '@agentic-obs/common';
+
+export interface ApprovalRouterDeps {
+  permissions: IPermissionRepository;
+  roles: IRoleRepository;
+  userRoles: IUserRoleRepository;
+  teamRoles: ITeamRoleRepository;
+  teamMembers: ITeamMemberRepository;
+  orgUsers: IOrgUserRepository;
+}
+
+export interface ApprovalRow {
+  id: string;
+  opsConnectorId?: string | null;
+  targetNamespace?: string | null;
+  requesterTeamId?: string | null;
+}
+
+/**
+ * Build the candidate row scopes — the set of scope strings that *describe*
+ * this row. A user is a recipient if their `approvals:approve` permission
+ * covers ANY of these.
+ *
+ * Note: NEITHER includes `approvals:*` here — that's a *permission* shape,
+ * not a row-shape. A user holding `approvals:*` is matched by coverage
+ * against e.g. `approvals:uid:<id>` (since `scopeCovers('approvals:*',
+ * 'approvals:uid:<id>')` is true). Adding `approvals:*` to the row scopes
+ * would over-match narrow grants like `approvals:connector:dev-eks` to
+ * unrelated prod rows — the fail-closed bug
+ * approvals-multi-team-scope §3.4 / R1 explicitly forbids.
+ */
+export function buildCandidateScopes(row: ApprovalRow): string[] {
+  return approvalRowScopes(row);
+}
+
+/**
+ * True iff a permission scoped to `permScope` is sufficient to act on a row
+ * whose candidate scopes are `candidateScopes`.
+ *
+ * Semantics: `scopeCovers(parent=permission, child=row-scope)`. A permission
+ * `approvals:*` covers row scope `approvals:connector:prod-eks` (wildcard
+ * parent ⊇ narrower child). A permission `approvals:connector:prod-eks`
+ * covers row scope `approvals:uid:ap_1` ONLY if uid is one of the candidate
+ * row scopes that the permission also covers — checked here by iterating
+ * row scopes and asking whether the permission covers any of them.
+ *
+ * Critical: a permission `approvals:connector:dev-eks` MUST NOT match a
+ * prod-eks row's candidate set. The fail-closed invariant
+ * (approvals-multi-team-scope §3.4 / R1) requires this asymmetry — the
+ * row's scopes are the targets; the permission is the gate.
+ */
+function permScopeMatchesRow(permScope: string, candidateScopes: string[]): boolean {
+  for (const candidate of candidateScopes) {
+    if (scopeCovers(permScope, candidate)) return true;
+  }
+  return false;
+}
+
+export class ApprovalRouter {
+  constructor(private readonly deps: ApprovalRouterDeps) {}
+
+  /**
+   * Return the deduped set of user IDs in `orgId` that hold an
+   * `approvals:approve` grant whose scope is covered by any candidate
+   * scope built from `row`.
+   *
+   * Returns the set in deterministic insertion order (helpful for tests).
+   */
+  async findApprovers(orgId: string, row: ApprovalRow): Promise<string[]> {
+    const candidates = buildCandidateScopes(row);
+
+    // 1. All permissions for action='approvals:approve'.
+    const allPerms = await this.deps.permissions.listByAction(ACTIONS.ApprovalsApprove);
+
+    // 2. Filter to those whose scope is covered by the row's candidates.
+    const matching: Permission[] = allPerms.filter((p) =>
+      permScopeMatchesRow(p.scope, candidates),
+    );
+    if (matching.length === 0) return [];
+
+    const matchingRoleIds = new Set(matching.map((p) => p.roleId));
+
+    // 3a. user_role direct assignment, scoped to this org or global ('').
+    const userIds = new Set<string>();
+    for (const roleId of matchingRoleIds) {
+      const rows = await this.deps.userRoles.listByRole(roleId);
+      for (const r of rows) {
+        if (r.orgId === orgId || r.orgId === '') userIds.add(r.userId);
+      }
+    }
+
+    // 3b. team_role + team_member, scoped to this org.
+    for (const roleId of matchingRoleIds) {
+      const rows = await this.deps.teamRoles.listByRole(roleId);
+      const teamIds = rows.filter((r) => r.orgId === orgId || r.orgId === '').map((r) => r.teamId);
+      for (const teamId of teamIds) {
+        const members = await this.deps.teamMembers.listByTeam(teamId);
+        for (const m of members) userIds.add(m.userId);
+      }
+    }
+
+    // 3c. builtin_role mapping — users in this org whose org-role is bound
+    //     to one of the matching roleIds.
+    const builtinRoles = await this.deps.roles.listBuiltinRoles(orgId);
+    const builtinByRoleName = new Map<string, Set<string>>(); // role name -> roleIds
+    for (const m of builtinRoles) {
+      if (!builtinByRoleName.has(m.role)) builtinByRoleName.set(m.role, new Set());
+      builtinByRoleName.get(m.role)!.add(m.roleId);
+    }
+    const matchingBuiltinRoleNames = new Set<string>();
+    for (const [roleName, roleIds] of builtinByRoleName) {
+      for (const id of roleIds) {
+        if (matchingRoleIds.has(id)) {
+          matchingBuiltinRoleNames.add(roleName);
+          break;
+        }
+      }
+    }
+    if (matchingBuiltinRoleNames.size > 0) {
+      // Fan out across all members of the org; keep those whose org_user.role
+      // matches one of the matching builtin role names.
+      const page = await this.deps.orgUsers.listUsersByOrg(orgId, { limit: 10_000 });
+      for (const u of page.items) {
+        if (matchingBuiltinRoleNames.has(u.role)) userIds.add(u.userId);
+      }
+    }
+
+    return [...userIds];
+  }
+}

--- a/packages/api-gateway/src/services/notification-consumer.test.ts
+++ b/packages/api-gateway/src/services/notification-consumer.test.ts
@@ -359,6 +359,174 @@ describe('NotificationConsumer', () => {
     expect(dispatchRepo.rows).toHaveLength(1);
   });
 
+  // -- Approval routing (T3.1) --------------------------------------
+  //
+  // Reuses the same NotificationConsumer; injects an ApprovalRouter stub
+  // that returns a fixed user list, plus a teamMembers stub that maps
+  // users to teams. The policy tree keys on `team` labels exactly the
+  // same way it does for alert.fired routing — no second source of truth.
+
+  it('approval.created — routes to contact points belonging to teams of matched users', async () => {
+    const tree = nodeOf({
+      id: 'root',
+      contactPointId: '',
+      children: [
+        nodeOf({ id: 'c1', matchers: [{ label: 'team', operator: '=', value: 'team_payments' }], contactPointId: 'cp-pay' }),
+        nodeOf({ id: 'c2', matchers: [{ label: 'team', operator: '=', value: 'team_storage' }], contactPointId: 'cp-stor' }),
+      ],
+    });
+    const i1: ContactPointIntegration = { id: 'slack-pay', type: 'slack', name: 's', settings: { url: 'https://hooks/abc' } };
+    const i2: ContactPointIntegration = { id: 'slack-stor', type: 'slack', name: 's', settings: { url: 'https://hooks/abc' } };
+
+    const consumer = new NotificationConsumer({
+      bus,
+      notifications: new FakeNotifRepo(tree, [cpWith('cp-pay', [i1]), cpWith('cp-stor', [i2])]) as unknown as INotificationRepository,
+      notificationDispatch: dispatchRepo,
+      senders: () => async (integration) => { calls.push({ integrationId: integration.id, payload: basePayload() }); return { ok: true, message: 'ok' }; },
+      clock: () => new Date('2026-05-03T00:00:00Z'),
+      approvalRouter: { findApprovers: async () => ['u_alice'] } as unknown as import('./approval-router.js').ApprovalRouter,
+      teamMembers: {
+        listTeamsForUser: async (userId: string) => userId === 'u_alice' ? [{ teamId: 'team_payments', userId } as never] : [],
+      } as unknown as import('@agentic-obs/common').ITeamMemberRepository,
+    });
+
+    await consumer.handleApprovalCreated({
+      id: 'env_1',
+      type: 'approval.created',
+      timestamp: '2026-05-03T00:00:00Z',
+      payload: {
+        approvalId: 'ap_1',
+        orgId: 'org_main',
+        opsConnectorId: 'prod-eks',
+        targetNamespace: 'platform',
+        requesterTeamId: null,
+        summary: 's',
+        createdAt: '2026-05-03T00:00:00Z',
+      },
+    });
+
+    expect(calls.map((c) => c.integrationId)).toEqual(['slack-pay']);
+  });
+
+  it('approval.created — idempotent: a duplicate publish for the same approvalId does not re-notify', async () => {
+    const tree = nodeOf({
+      id: 'root',
+      contactPointId: '',
+      children: [
+        nodeOf({ id: 'c1', matchers: [{ label: 'team', operator: '=', value: 'team_payments' }], contactPointId: 'cp-pay' }),
+      ],
+    });
+    const i1: ContactPointIntegration = { id: 'slack-pay', type: 'slack', name: 's', settings: { url: 'https://hooks/abc' } };
+
+    const consumer = new NotificationConsumer({
+      bus,
+      notifications: new FakeNotifRepo(tree, [cpWith('cp-pay', [i1])]) as unknown as INotificationRepository,
+      notificationDispatch: dispatchRepo,
+      senders: () => async (integration) => { calls.push({ integrationId: integration.id, payload: basePayload() }); return { ok: true, message: 'ok' }; },
+      clock: () => new Date('2026-05-03T00:00:00Z'),
+      approvalRouter: { findApprovers: async () => ['u_alice'] } as unknown as import('./approval-router.js').ApprovalRouter,
+      teamMembers: {
+        listTeamsForUser: async () => [{ teamId: 'team_payments', userId: 'u_alice' } as never],
+      } as unknown as import('@agentic-obs/common').ITeamMemberRepository,
+    });
+
+    const env = {
+      id: 'env_1', type: 'approval.created', timestamp: '2026-05-03T00:00:00Z',
+      payload: {
+        approvalId: 'ap_dup', orgId: 'org_main',
+        opsConnectorId: null, targetNamespace: null, requesterTeamId: null,
+        summary: 's', createdAt: '2026-05-03T00:00:00Z',
+      },
+    } as const;
+
+    await consumer.handleApprovalCreated(env);
+    await consumer.handleApprovalCreated(env);
+    // The notification_dispatch dedup key is (orgId, fingerprint=approvalId,
+    // contactPointId, groupKey). The first send writes it; the second falls
+    // into the within-groupInterval window and skips.
+    expect(calls).toHaveLength(1);
+    expect(dispatchRepo.rows).toHaveLength(1);
+    expect(dispatchRepo.rows[0]!.fingerprint).toBe('ap_dup');
+  });
+
+  it('approval.created — fail-closed: a non-matching narrow grant is NOT notified (router decides; consumer trusts)', async () => {
+    // Router returns an empty user list — simulating ApprovalRouter
+    // correctly excluding a user whose grant scope did not cover the row.
+    const tree = nodeOf({
+      id: 'root',
+      contactPointId: '',
+      children: [
+        nodeOf({ id: 'c1', matchers: [{ label: 'team', operator: '=', value: 'team_payments' }], contactPointId: 'cp-pay' }),
+      ],
+    });
+    const i1: ContactPointIntegration = { id: 'slack-pay', type: 'slack', name: 's', settings: { url: 'https://hooks/abc' } };
+
+    const consumer = new NotificationConsumer({
+      bus,
+      notifications: new FakeNotifRepo(tree, [cpWith('cp-pay', [i1])]) as unknown as INotificationRepository,
+      notificationDispatch: dispatchRepo,
+      senders: () => async (integration) => { calls.push({ integrationId: integration.id, payload: basePayload() }); return { ok: true, message: 'ok' }; },
+      clock: () => new Date('2026-05-03T00:00:00Z'),
+      approvalRouter: { findApprovers: async () => [] } as unknown as import('./approval-router.js').ApprovalRouter,
+      teamMembers: { listTeamsForUser: async () => [] } as unknown as import('@agentic-obs/common').ITeamMemberRepository,
+    });
+
+    await consumer.handleApprovalCreated({
+      id: 'env_1', type: 'approval.created', timestamp: '2026-05-03T00:00:00Z',
+      payload: {
+        approvalId: 'ap_1', orgId: 'org_main',
+        opsConnectorId: 'prod-eks', targetNamespace: null, requesterTeamId: null,
+        summary: 's', createdAt: '2026-05-03T00:00:00Z',
+      },
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(dispatchRepo.rows).toHaveLength(0);
+  });
+
+  it('approval.created — sender error isolation: one slack throws, other senders still fire', async () => {
+    const tree = nodeOf({
+      id: 'root',
+      contactPointId: '',
+      children: [
+        nodeOf({ id: 'c1', matchers: [{ label: 'team', operator: '=', value: 'team_payments' }], contactPointId: 'cp-pay' }),
+      ],
+    });
+    const broken: ContactPointIntegration = { id: 'broken', type: 'slack', name: 's', settings: { url: 'https://hooks/abc' } };
+    const ok: ContactPointIntegration = { id: 'ok', type: 'webhook', name: 'w', settings: { url: 'https://hooks/abc' } };
+
+    const senderImpl: Sender = vi.fn(async (integration) => {
+      if (integration.id === 'broken') throw new Error('boom');
+      calls.push({ integrationId: integration.id, payload: basePayload() });
+      return { ok: true, message: 'ok' };
+    });
+
+    const consumer = new NotificationConsumer({
+      bus,
+      notifications: new FakeNotifRepo(tree, [cpWith('cp-pay', [broken, ok])]) as unknown as INotificationRepository,
+      notificationDispatch: dispatchRepo,
+      senders: () => senderImpl,
+      clock: () => new Date('2026-05-03T00:00:00Z'),
+      approvalRouter: { findApprovers: async () => ['u_alice'] } as unknown as import('./approval-router.js').ApprovalRouter,
+      teamMembers: {
+        listTeamsForUser: async () => [{ teamId: 'team_payments', userId: 'u_alice' } as never],
+      } as unknown as import('@agentic-obs/common').ITeamMemberRepository,
+    });
+
+    await consumer.handleApprovalCreated({
+      id: 'env_1', type: 'approval.created', timestamp: '2026-05-03T00:00:00Z',
+      payload: {
+        approvalId: 'ap_1', orgId: 'org_main',
+        opsConnectorId: null, targetNamespace: null, requesterTeamId: null,
+        summary: 's', createdAt: '2026-05-03T00:00:00Z',
+      },
+    });
+
+    expect(senderImpl).toHaveBeenCalledTimes(2);
+    expect(calls.map((c) => c.integrationId)).toEqual(['ok']);
+    expect(dispatchRepo.rows).toHaveLength(1);
+  });
+
   it('start/stop subscribes and unsubscribes from the bus', () => {
     // Use the bus's underlying EventEmitter listenerCount as ground truth.
     // The consumer's subscribe handler wraps handle() in `void` (fire-and-

--- a/packages/api-gateway/src/services/notification-consumer.ts
+++ b/packages/api-gateway/src/services/notification-consumer.ts
@@ -28,6 +28,7 @@ import type {
 import {
   EventTypes,
   type AlertFiredEventPayload,
+  type ApprovalCreatedEventPayload,
 } from '@agentic-obs/common/events';
 import type {
   INotificationRepository,
@@ -36,6 +37,8 @@ import type {
 import { createLogger } from '@agentic-obs/common/logging';
 import { senderFor } from './notification-senders/index.js';
 import type { Sender } from './notification-senders/index.js';
+import type { ApprovalRouter, ApprovalRow } from './approval-router.js';
+import type { ITeamMemberRepository } from '@agentic-obs/common';
 
 const log = createLogger('notification-consumer');
 
@@ -52,6 +55,20 @@ export interface NotificationConsumerOptions {
   clock?: () => Date;
   /** Topic name; defaults to EventTypes.ALERT_FIRED. */
   topic?: string;
+  /**
+   * Optional approval-routing surface. When wired, the consumer also
+   * subscribes to `approval.created` and fans out to users whose
+   * `approvals:approve` grant covers the approval's scope. Without it,
+   * approval routing is silently disabled (alert.fired path unaffected).
+   * See approvals-multi-team-scope §3.7.
+   */
+  approvalRouter?: ApprovalRouter;
+  /**
+   * Required when `approvalRouter` is set — used to resolve a recipient
+   * user's teams so the policy tree (which keys on `team` labels) can
+   * locate their contact points.
+   */
+  teamMembers?: ITeamMemberRepository;
 }
 
 interface MatchedRoute {
@@ -175,7 +192,8 @@ export function decideDispatch(
 }
 
 export class NotificationConsumer {
-  private unsubscribe: (() => void) | null = null;
+  private unsubscribeAlert: (() => void) | null = null;
+  private unsubscribeApproval: (() => void) | null = null;
   private readonly clock: () => Date;
   private readonly senders: (type: ContactPointIntegration['type']) => Sender | null;
   private readonly topic: string;
@@ -187,19 +205,33 @@ export class NotificationConsumer {
   }
 
   start(): void {
-    if (this.unsubscribe) return;
-    this.unsubscribe = this.opts.bus.subscribe<AlertFiredEventPayload>(
-      this.topic,
-      (env) => {
-        void this.handle(env);
-      },
-    );
+    if (!this.unsubscribeAlert) {
+      this.unsubscribeAlert = this.opts.bus.subscribe<AlertFiredEventPayload>(
+        this.topic,
+        (env) => {
+          void this.handle(env);
+        },
+      );
+    }
+    if (!this.unsubscribeApproval && this.opts.approvalRouter) {
+      this.unsubscribeApproval = this.opts.bus.subscribe<ApprovalCreatedEventPayload>(
+        EventTypes.APPROVAL_CREATED,
+        (env) => {
+          void this.handleApprovalCreated(env);
+        },
+      );
+    }
   }
 
   stop(): void {
-    if (!this.unsubscribe) return;
-    this.unsubscribe();
-    this.unsubscribe = null;
+    if (this.unsubscribeAlert) {
+      this.unsubscribeAlert();
+      this.unsubscribeAlert = null;
+    }
+    if (this.unsubscribeApproval) {
+      this.unsubscribeApproval();
+      this.unsubscribeApproval = null;
+    }
   }
 
   /** Public for tests; production callers go via subscribe(). */
@@ -354,6 +386,120 @@ export class NotificationConsumer {
           'failed to persist notification_dispatch row',
         );
       }
+    }
+  }
+
+  /**
+   * Handle an `approval.created` event: find users whose `approvals:approve`
+   * grant covers the row, look up each user's teams, walk the policy tree
+   * keyed on `team` labels to find their contact points, and fan out.
+   *
+   * Idempotency: uses the approvalId as the dispatch fingerprint, so a
+   * duplicate publish (e.g. retry) does not re-notify (T3.1 acceptance #7).
+   *
+   * Fail-closed: callers MUST NOT fall back to broader scopes — the router
+   * already enforces this; here we just trust the recipient list it returns.
+   */
+  async handleApprovalCreated(
+    env: EventEnvelope<ApprovalCreatedEventPayload>,
+  ): Promise<void> {
+    if (!this.opts.approvalRouter || !this.opts.teamMembers) {
+      log.warn({ approvalId: env.payload.approvalId }, 'approval router not wired; skipping');
+      return;
+    }
+    const payload = env.payload;
+    const row: ApprovalRow = {
+      id: payload.approvalId,
+      opsConnectorId: payload.opsConnectorId,
+      targetNamespace: payload.targetNamespace,
+      requesterTeamId: payload.requesterTeamId,
+    };
+
+    let userIds: string[];
+    try {
+      userIds = await this.opts.approvalRouter.findApprovers(payload.orgId, row);
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), approvalId: payload.approvalId },
+        'failed to resolve approvers for approval.created',
+      );
+      return;
+    }
+
+    if (userIds.length === 0) {
+      log.info({ approvalId: payload.approvalId }, 'no users matched approval scope; skipping');
+      return;
+    }
+
+    let tree: NotificationPolicyNode;
+    try {
+      tree = await this.opts.notifications.getPolicyTree();
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), approvalId: payload.approvalId },
+        'failed to load notification policy tree',
+      );
+      return;
+    }
+
+    // For each user: find their teams, ask the policy tree for routes
+    // matching `{ team: <teamId> }` per team. Dedup contact points across
+    // users so two recipients sharing a team channel only get one send.
+    const seenContactPoints = new Set<string>();
+    const routes: MatchedRoute[] = [];
+    for (const userId of userIds) {
+      let memberships;
+      try {
+        memberships = await this.opts.teamMembers.listTeamsForUser(userId, payload.orgId);
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), userId },
+          'failed to list teams for user; skipping',
+        );
+        continue;
+      }
+      for (const m of memberships) {
+        const matched = collectMatchingRoutes(tree, { team: m.teamId });
+        for (const r of matched) {
+          if (!r.contactPointId) continue;
+          if (seenContactPoints.has(r.contactPointId)) continue;
+          seenContactPoints.add(r.contactPointId);
+          routes.push(r);
+        }
+      }
+    }
+
+    if (routes.length === 0) {
+      log.info(
+        { approvalId: payload.approvalId, userCount: userIds.length },
+        'no contact points reachable for matched approvers; skipping',
+      );
+      return;
+    }
+
+    // Adapt the approval payload to the existing Sender shape (which takes
+    // an AlertFiredEventPayload). Senders use `ruleName`/`severity`/`labels`
+    // for body text — synthesize equivalents from the approval row.
+    const adapted: AlertFiredEventPayload = {
+      ruleId: payload.approvalId,
+      ruleName: `Approval pending: ${payload.summary}`,
+      orgId: payload.orgId,
+      severity: payload.severity ?? 'medium',
+      value: 0,
+      threshold: 0,
+      operator: 'pending',
+      labels: {
+        approvalId: payload.approvalId,
+        ...(payload.opsConnectorId ? { connector: payload.opsConnectorId } : {}),
+        ...(payload.targetNamespace ? { namespace: payload.targetNamespace } : {}),
+        ...(payload.requesterTeamId ? { team: payload.requesterTeamId } : {}),
+      },
+      firedAt: payload.createdAt,
+      fingerprint: payload.approvalId,
+    };
+
+    for (const route of routes) {
+      await this.dispatchToContactPoint(adapted, route);
     }
   }
 }

--- a/packages/api-gateway/src/services/publishing-approval-repository.test.ts
+++ b/packages/api-gateway/src/services/publishing-approval-repository.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryEventBus, EventTypes, type ApprovalCreatedEventPayload, type EventEnvelope } from '@agentic-obs/common/events';
+import type {
+  ApprovalAction,
+  ApprovalContext,
+  ApprovalRequest,
+  ApprovalScopeFilter,
+  ApprovalStatus,
+  IApprovalRequestRepository,
+} from '@agentic-obs/data-layer';
+import { PublishingApprovalRepository } from './publishing-approval-repository.js';
+
+class FakeRepo implements IApprovalRequestRepository {
+  rows: ApprovalRequest[] = [];
+  shouldThrow = false;
+
+  async findById(id: string) { return this.rows.find((r) => r.id === id); }
+
+  async submit(params: {
+    action: ApprovalAction;
+    context: ApprovalContext;
+    ttlMs?: number;
+    opsConnectorId?: string | null;
+    targetNamespace?: string | null;
+    requesterTeamId?: string | null;
+  }): Promise<ApprovalRequest> {
+    if (this.shouldThrow) throw new Error('boom');
+    const row: ApprovalRequest = {
+      id: `ap_${this.rows.length + 1}`,
+      action: params.action,
+      context: params.context,
+      status: 'pending',
+      createdAt: '2026-05-03T00:00:00.000Z',
+      expiresAt: '2026-05-04T00:00:00.000Z',
+      opsConnectorId: params.opsConnectorId ?? null,
+      targetNamespace: params.targetNamespace ?? null,
+      requesterTeamId: params.requesterTeamId ?? null,
+    };
+    this.rows.push(row);
+    return row;
+  }
+
+  async listPending() { return this.rows.filter((r) => r.status === 'pending'); }
+  async list(_orgId: string, _opts?: { scopeFilter?: ApprovalScopeFilter; status?: ApprovalStatus | ApprovalStatus[] }) {
+    return [...this.rows];
+  }
+  async approve(id: string) { return this.findById(id); }
+  async reject(id: string) { return this.findById(id); }
+  async override(id: string) { return this.findById(id); }
+}
+
+describe('PublishingApprovalRepository.submit', () => {
+  it('publishes approval.created AFTER a successful commit, with all scope tags on the payload', async () => {
+    const bus = new InMemoryEventBus();
+    const inner = new FakeRepo();
+    const seen: EventEnvelope<ApprovalCreatedEventPayload>[] = [];
+    bus.subscribe<ApprovalCreatedEventPayload>(EventTypes.APPROVAL_CREATED, (env) => {
+      seen.push(env);
+    });
+
+    const repo = new PublishingApprovalRepository({ inner, bus, orgId: 'org_main' });
+
+    const result = await repo.submit({
+      action: { type: 'plan', targetService: 'remediation-plan', params: { planId: 'plan_1', summary: 's', stepCount: 1 } },
+      context: { investigationId: 'inv_9', requestedBy: 'agent', reason: 'fix prod-eks pod crashloop' },
+      opsConnectorId: 'prod-eks',
+      targetNamespace: 'platform',
+      requesterTeamId: 'team_payments',
+    });
+
+    expect(result.id).toBe('ap_1');
+    expect(seen).toHaveLength(1);
+    const payload = seen[0]!.payload;
+    expect(payload.approvalId).toBe('ap_1');
+    expect(payload.orgId).toBe('org_main');
+    expect(payload.opsConnectorId).toBe('prod-eks');
+    expect(payload.targetNamespace).toBe('platform');
+    expect(payload.requesterTeamId).toBe('team_payments');
+    expect(payload.planId).toBe('plan_1');
+    expect(payload.investigationId).toBe('inv_9');
+    expect(payload.summary).toBe('fix prod-eks pod crashloop');
+  });
+
+  it('does NOT publish when the underlying submit throws', async () => {
+    const bus = new InMemoryEventBus();
+    const inner = new FakeRepo();
+    inner.shouldThrow = true;
+    const seen: unknown[] = [];
+    bus.subscribe(EventTypes.APPROVAL_CREATED, (env) => { seen.push(env); });
+
+    const repo = new PublishingApprovalRepository({ inner, bus, orgId: 'org_main' });
+
+    await expect(repo.submit({
+      action: { type: 'plan', targetService: 'x', params: {} },
+      context: { requestedBy: 'agent', reason: 'r' },
+    })).rejects.toThrow('boom');
+
+    expect(seen).toHaveLength(0);
+    expect(inner.rows).toHaveLength(0);
+  });
+
+  it('per-step approvals carry planId from context.planId', async () => {
+    const bus = new InMemoryEventBus();
+    const inner = new FakeRepo();
+    const seen: EventEnvelope<ApprovalCreatedEventPayload>[] = [];
+    bus.subscribe<ApprovalCreatedEventPayload>(EventTypes.APPROVAL_CREATED, (env) => { seen.push(env); });
+
+    const repo = new PublishingApprovalRepository({ inner, bus, orgId: 'org_main' });
+
+    await repo.submit({
+      action: { type: 'ops.run_command', targetService: 'prod-eks', params: { argv: [] } },
+      context: { requestedBy: 'agent', reason: 'r', planId: 'plan_42', stepOrdinal: 2 } as ApprovalContext,
+      opsConnectorId: 'prod-eks',
+      targetNamespace: null,
+      requesterTeamId: null,
+    });
+
+    expect(seen[0]!.payload.planId).toBe('plan_42');
+    expect(seen[0]!.payload.targetNamespace).toBeNull();
+  });
+});

--- a/packages/api-gateway/src/services/publishing-approval-repository.ts
+++ b/packages/api-gateway/src/services/publishing-approval-repository.ts
@@ -1,0 +1,123 @@
+/**
+ * PublishingApprovalRepository — wraps `IApprovalRequestRepository.submit` so
+ * a successful row-commit publishes an `approval.created` event on the shared
+ * IEventBus. All other methods delegate to the wrapped repo.
+ *
+ * Design choice: a thin adapter over the data-layer repo (mirrors the
+ * EventEmittingApprovalRepository pattern). Keeps agent-core unaware of the
+ * bus — the agent's `ApprovalRequestStore` interface needs no new fields.
+ *
+ * Publish ordering: ONLY after `submit()` resolves. A throwing submit → no
+ * publish. See approvals-multi-team-scope §3.7 / T3.1 acceptance #1.
+ */
+
+import type {
+  IApprovalRequestRepository,
+  ApprovalScopeFilter,
+  ApprovalStatus,
+  ApprovalRequest,
+  ApprovalAction,
+  ApprovalContext,
+} from '@agentic-obs/data-layer';
+import type { IEventBus } from '@agentic-obs/common';
+import {
+  EventTypes,
+  createEvent,
+  type ApprovalCreatedEventPayload,
+} from '@agentic-obs/common/events';
+import { createLogger } from '@agentic-obs/common/logging';
+
+const log = createLogger('publishing-approval-repo');
+
+export interface PublishingApprovalRepoDeps {
+  inner: IApprovalRequestRepository;
+  bus: IEventBus;
+  /** OrgId injected at construction (per-request scoping isn't applicable;
+   *  the inner repo is org-keyed via the row write itself). */
+  orgId: string;
+}
+
+function deriveSummary(action: ApprovalAction, context: ApprovalContext): string {
+  if (typeof context.reason === 'string' && context.reason.length > 0) return context.reason;
+  return `${action.type} on ${action.targetService}`;
+}
+
+function derivePlanId(action: ApprovalAction, context: ApprovalContext): string | null {
+  // Plan-level approval: action.type === 'plan' and params.planId is the plan.
+  // Per-step approval: action.type === 'ops.run_command' and context.planId is the plan.
+  if (action.type === 'plan') {
+    const p = (action.params ?? {})['planId'];
+    return typeof p === 'string' ? p : null;
+  }
+  const p = (context as Record<string, unknown>)['planId'];
+  return typeof p === 'string' ? p : null;
+}
+
+export class PublishingApprovalRepository implements IApprovalRequestRepository {
+  constructor(private readonly deps: PublishingApprovalRepoDeps) {}
+
+  findById(id: string): Promise<ApprovalRequest | undefined> {
+    return this.deps.inner.findById(id);
+  }
+
+  async submit(params: {
+    action: ApprovalAction;
+    context: ApprovalContext;
+    ttlMs?: number;
+    opsConnectorId?: string | null;
+    targetNamespace?: string | null;
+    requesterTeamId?: string | null;
+  }): Promise<ApprovalRequest> {
+    const row = await this.deps.inner.submit(params);
+    // Publish after commit. A failure to publish is logged but does NOT
+    // unwind the row — the row exists, the missed notification is the
+    // operator's recoverable problem.
+    const payload: ApprovalCreatedEventPayload = {
+      approvalId: row.id,
+      orgId: this.deps.orgId,
+      planId: derivePlanId(params.action, params.context),
+      investigationId: params.context.investigationId ?? null,
+      opsConnectorId: params.opsConnectorId ?? null,
+      targetNamespace: params.targetNamespace ?? null,
+      requesterTeamId: params.requesterTeamId ?? null,
+      summary: deriveSummary(params.action, params.context),
+      severity: null,
+      createdAt: row.createdAt,
+    };
+    try {
+      await this.deps.bus.publish(
+        EventTypes.APPROVAL_CREATED,
+        createEvent(EventTypes.APPROVAL_CREATED, payload),
+      );
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), approvalId: row.id },
+        'failed to publish approval.created event',
+      );
+    }
+    return row;
+  }
+
+  listPending(): Promise<ApprovalRequest[]> {
+    return this.deps.inner.listPending();
+  }
+
+  list(
+    orgId: string,
+    opts?: { scopeFilter?: ApprovalScopeFilter; status?: ApprovalStatus | ApprovalStatus[] },
+  ): Promise<ApprovalRequest[]> {
+    return this.deps.inner.list(orgId, opts);
+  }
+
+  approve(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined> {
+    return this.deps.inner.approve(id, by, roles);
+  }
+
+  reject(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined> {
+    return this.deps.inner.reject(id, by, roles);
+  }
+
+  override(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined> {
+    return this.deps.inner.override(id, by, roles);
+  }
+}

--- a/packages/common/src/events/types.ts
+++ b/packages/common/src/events/types.ts
@@ -45,6 +45,9 @@ export const EventTypes = {
 
   // Alert lifecycle
   ALERT_FIRED: 'alert.fired',
+
+  // Approval lifecycle
+  APPROVAL_CREATED: 'approval.created',
 } as const;
 
 export type EventType = (typeof EventTypes)[keyof typeof EventTypes];
@@ -82,6 +85,31 @@ export interface FeedItemEventPayload {
   itemId: string;
   type: string;
   investigationId?: string;
+}
+
+/**
+ * `approval.created` payload — published when an ApprovalRequest row commits.
+ * Routing identical for plan-level and per-step approvals; the optional
+ * `planId` distinguishes them.
+ *
+ * Scope tags mirror the row columns from approvals-multi-team-scope §3.2 so
+ * the NotificationConsumer can find recipients via the same scope resolver
+ * the read path (T2.2) uses.
+ */
+export interface ApprovalCreatedEventPayload {
+  approvalId: string;
+  orgId: string;
+  /** Plan-level approval if non-null (action.type === 'plan'); per-step otherwise. */
+  planId?: string | null;
+  investigationId?: string | null;
+  opsConnectorId: string | null;
+  targetNamespace: string | null;
+  requesterTeamId: string | null;
+  /** Short summary for the notification body. */
+  summary: string;
+  /** Severity hint when the approval traces back to an alert. */
+  severity?: 'low' | 'medium' | 'high' | 'critical' | null;
+  createdAt: string;
 }
 
 export interface AlertFiredEventPayload {

--- a/packages/web/src/pages/ActionCenter.tsx
+++ b/packages/web/src/pages/ActionCenter.tsx
@@ -1,9 +1,21 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { apiClient, plansApi } from '../api/client.js';
 import type { RemediationPlan } from '../api/client.js';
+import { opsApi, type OpsConnector } from '../api/ops-api.js';
 import { relativeTime } from '../utils/time.js';
 import { useAuth } from '../contexts/AuthContext.js';
+import {
+  applyFilters,
+  distinctConnectorIds,
+  distinctNamespaces,
+  distinctTeamIds,
+  isAnyFilterActive,
+  NONE_SENTINEL,
+  parseFiltersFromParams,
+  writeFiltersToParams,
+  type ApprovalFilters,
+} from './action-center-filters.js';
 
 // Types
 
@@ -31,6 +43,16 @@ interface ApprovalRequest {
   expiresAt?: string;
   resolvedAt?: string;
   resolvedBy?: string;
+  // Multi-team scope tags (T2.1). NULL on legacy / non-ops rows. Used by the
+  // filter chip strips to narrow within the user's already-permitted set.
+  opsConnectorId?: string | null;
+  targetNamespace?: string | null;
+  requesterTeamId?: string | null;
+}
+
+interface TeamLite {
+  id: string;
+  name: string;
 }
 
 // Helpers
@@ -149,6 +171,60 @@ function ActionCard({ request, processing, onApprove, onReject, canApprove }: Ac
   );
 }
 
+// Filter chip strip (single-select within group, "All" clears it).
+//
+// Visual style mirrors the state-filter pills in `Alerts.tsx` (bg-surface-high
+// pill container, primary highlight on active). No shared chip component
+// exists in this codebase; if/when one is extracted these strips should
+// migrate to it.
+
+interface ChipStripProps {
+  label: string;
+  values: readonly (string | typeof NONE_SENTINEL)[];
+  active: string | null;
+  onChange: (next: string | null) => void;
+  display: (value: string | typeof NONE_SENTINEL) => string;
+}
+
+function ChipStrip({ label, values, active, onChange, display }: ChipStripProps) {
+  if (values.length === 0) return null;
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-[var(--color-outline)] uppercase tracking-wide">{label}</span>
+      <div className="flex gap-1 bg-surface-high rounded-lg p-0.5 flex-wrap">
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className={`px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors ${
+            active === null
+              ? 'bg-[var(--color-surface-high)] text-[var(--color-on-surface)]'
+              : 'text-[var(--color-outline)] hover:text-[var(--color-on-surface-variant)]'
+          }`}
+        >
+          All
+        </button>
+        {values.map((v) => {
+          const isActive = active === v;
+          return (
+            <button
+              key={v}
+              type="button"
+              onClick={() => onChange(v)}
+              className={`px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                isActive
+                  ? 'bg-[var(--color-primary)]/15 text-[var(--color-primary)]'
+                  : 'text-[var(--color-outline)] hover:text-[var(--color-on-surface-variant)]'
+              }`}
+            >
+              {display(v)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 // Main component
 
 export default function ActionCenter() {
@@ -190,6 +266,52 @@ export default function ActionCenter() {
     setTabState((prev) => (prev === next ? prev : next));
   }, [searchParams]);
   const [plans, setPlans] = useState<RemediationPlan[]>([]);
+
+  // Filter chip state (T3.2). Lives in the URL so deep links survive refresh
+  // and can be linked to from other pages (team detail "See all").
+  const filters: ApprovalFilters = useMemo(() => parseFiltersFromParams(searchParams), [searchParams]);
+  const setFilter = useCallback(
+    (slot: keyof ApprovalFilters, next: string | null) => {
+      const params = new URLSearchParams(searchParams);
+      const updated = { ...parseFiltersFromParams(params), [slot]: next };
+      // Picking a different connector invalidates the namespace selection.
+      if (slot === 'connector') updated.namespace = null;
+      writeFiltersToParams(params, updated);
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  // One-shot lookups for human-readable names. Connector + team lists are
+  // small, so we pull each once and join client-side rather than per-row.
+  const [connectors, setConnectors] = useState<OpsConnector[]>([]);
+  const [teams, setTeams] = useState<TeamLite[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await opsApi.listConnectors();
+        if (!cancelled) setConnectors(list);
+      } catch {
+        // Names are nice-to-have — fall back to ids on failure.
+      }
+      const res = await apiClient.get<{ items?: TeamLite[]; teams?: TeamLite[] }>('/teams/search?perpage=200');
+      if (!cancelled && !res.error) {
+        const list = res.data.items ?? res.data.teams ?? [];
+        setTeams(list);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const connectorName = useCallback((id: string) => {
+    const c = connectors.find((x) => x.id === id);
+    return c ? `${c.name} (${id})` : id;
+  }, [connectors]);
+  const teamName = useCallback((id: string) => {
+    const t = teams.find((x) => x.id === id);
+    return t ? `${t.name} (${id})` : id;
+  }, [teams]);
 
   const loadApprovals = useCallback(async () => {
     const res = await apiClient.get<ApprovalRequest[]>('/approvals');
@@ -268,7 +390,13 @@ export default function ActionCenter() {
     }
   }, [loadApprovals]);
 
-  const approvalsDisplayed = tab === 'pending' ? pending : tab === 'resolved' ? resolved : [];
+  const approvalsForTab = tab === 'pending' ? pending : tab === 'resolved' ? resolved : [];
+  const approvalsDisplayed = useMemo(() => applyFilters(approvalsForTab, filters), [approvalsForTab, filters]);
+  const showFilters = tab !== 'plans';
+  const connectorOptions = useMemo(() => distinctConnectorIds(approvalsForTab), [approvalsForTab]);
+  const namespaceOptions = useMemo(() => distinctNamespaces(approvalsForTab, filters.connector), [approvalsForTab, filters.connector]);
+  const teamOptions = useMemo(() => distinctTeamIds(approvalsForTab), [approvalsForTab]);
+  const filtersActive = isAnyFilterActive(filters);
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-4 bg-[var(--color-surface-lowest)] min-h-full">
@@ -337,6 +465,41 @@ export default function ActionCenter() {
         ))}
       </div>
 
+      {/* Filter chip strips (T3.2). Hidden on the Plans tab — those rows
+          come from /api/plans and don't carry the scope tags this filter
+          targets. */}
+      {showFilters && (connectorOptions.length > 0 || namespaceOptions.length > 0 || teamOptions.length > 0) && (
+        <div className="space-y-2">
+          {connectorOptions.length > 0 && (
+            <ChipStrip
+              label="Connector"
+              values={connectorOptions}
+              active={filters.connector}
+              onChange={(v) => setFilter('connector', v)}
+              display={(v) => (v === NONE_SENTINEL ? '(no connector)' : connectorName(v))}
+            />
+          )}
+          {namespaceOptions.length > 0 && (
+            <ChipStrip
+              label="Namespace"
+              values={namespaceOptions}
+              active={filters.namespace}
+              onChange={(v) => setFilter('namespace', v)}
+              display={(v) => (v === NONE_SENTINEL ? '(cluster-scoped)' : v)}
+            />
+          )}
+          {teamOptions.length > 0 && (
+            <ChipStrip
+              label="Team"
+              values={teamOptions}
+              active={filters.team}
+              onChange={(v) => setFilter('team', v)}
+              display={(v) => (v === NONE_SENTINEL ? '(no team)' : teamName(v))}
+            />
+          )}
+        </div>
+      )}
+
       {/* Action error toast */}
       {actionError && (
         <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-[#EF4444]/10 border border-[#EF4444]/20 text-sm text-[#EF4444]">
@@ -400,7 +563,9 @@ export default function ActionCenter() {
         )
       ) : approvalsDisplayed.length === 0 ? (
         <div className="text-center py-16 text-[var(--color-outline)] text-sm">
-          {tab === 'pending' ? 'No pending approvals' : 'No resolved actions yet'}
+          {filtersActive
+            ? 'No pending approvals match the current filters.'
+            : tab === 'pending' ? 'No pending approvals' : 'No resolved actions yet'}
         </div>
       ) : (
         <div className="space-y-3">

--- a/packages/web/src/pages/action-center-filters.test.ts
+++ b/packages/web/src/pages/action-center-filters.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the Action Center approvals filter helpers (T3.2).
+ *
+ * Covers the acceptance bullets in the task brief:
+ *   1. Renders rows unfiltered → all 3 visible.
+ *   2. Connector filter narrows.
+ *   3. Namespace filter narrows.
+ *   4. Team filter narrows.
+ *   5. NONE-pill matches NULL.
+ *   6. AND across groups.
+ *   7. URL state round-trip.
+ *   8. Empty state under filter (driven by `applyFilters([...]).length`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyFilters,
+  distinctConnectorIds,
+  distinctNamespaces,
+  distinctTeamIds,
+  EMPTY_FILTERS,
+  isAnyFilterActive,
+  NONE_SENTINEL,
+  parseFiltersFromParams,
+  writeFiltersToParams,
+  type ApprovalScopeFields,
+} from './action-center-filters.js';
+
+const rows: ApprovalScopeFields[] = [
+  { opsConnectorId: 'prod-eks',  targetNamespace: 'platform', requesterTeamId: 'platform' },
+  { opsConnectorId: 'prod-eks',  targetNamespace: 'payments', requesterTeamId: 'payments' },
+  { opsConnectorId: 'dev-eks',   targetNamespace: 'platform', requesterTeamId: 'platform' },
+  { opsConnectorId: null,         targetNamespace: null,        requesterTeamId: null },
+];
+
+describe('applyFilters', () => {
+  it('returns all rows when no filter is set (acceptance #1)', () => {
+    expect(applyFilters(rows, EMPTY_FILTERS)).toHaveLength(rows.length);
+  });
+
+  it('connector filter narrows (acceptance #2)', () => {
+    const out = applyFilters(rows, { ...EMPTY_FILTERS, connector: 'prod-eks' });
+    expect(out).toHaveLength(2);
+    expect(out.every((r) => r.opsConnectorId === 'prod-eks')).toBe(true);
+  });
+
+  it('namespace filter narrows (acceptance #3)', () => {
+    const out = applyFilters(rows, { ...EMPTY_FILTERS, namespace: 'payments' });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.targetNamespace).toBe('payments');
+  });
+
+  it('team filter narrows (acceptance #4)', () => {
+    const out = applyFilters(rows, { ...EMPTY_FILTERS, team: 'platform' });
+    expect(out).toHaveLength(2);
+    expect(out.every((r) => r.requesterTeamId === 'platform')).toBe(true);
+  });
+
+  it('NONE sentinel matches NULL on connector (acceptance #5)', () => {
+    const out = applyFilters(rows, { ...EMPTY_FILTERS, connector: NONE_SENTINEL });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.opsConnectorId).toBeNull();
+  });
+
+  it('NONE sentinel matches NULL on namespace and team', () => {
+    const ns = applyFilters(rows, { ...EMPTY_FILTERS, namespace: NONE_SENTINEL });
+    expect(ns).toHaveLength(1);
+    expect(ns[0]!.targetNamespace).toBeNull();
+    const team = applyFilters(rows, { ...EMPTY_FILTERS, team: NONE_SENTINEL });
+    expect(team).toHaveLength(1);
+    expect(team[0]!.requesterTeamId).toBeNull();
+  });
+
+  it('AND across groups: connector=prod-eks + team=platform → only matching row (acceptance #6)', () => {
+    const out = applyFilters(rows, { connector: 'prod-eks', namespace: null, team: 'platform' });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ opsConnectorId: 'prod-eks', requesterTeamId: 'platform' });
+  });
+
+  it('produces zero rows when filter excludes everything (acceptance #8)', () => {
+    const out = applyFilters(rows, { ...EMPTY_FILTERS, connector: 'no-such-connector' });
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('distinct value helpers', () => {
+  it('distinctConnectorIds includes NONE sentinel for NULL rows', () => {
+    const ids = distinctConnectorIds(rows);
+    expect(ids).toContain('prod-eks');
+    expect(ids).toContain('dev-eks');
+    expect(ids).toContain(NONE_SENTINEL);
+    // NONE pill always sorts last.
+    expect(ids[ids.length - 1]).toBe(NONE_SENTINEL);
+  });
+
+  it('distinctNamespaces is scoped by the active connector filter', () => {
+    const all = distinctNamespaces(rows, null);
+    expect(all).toEqual(expect.arrayContaining(['platform', 'payments', NONE_SENTINEL]));
+
+    const prodOnly = distinctNamespaces(rows, 'prod-eks');
+    expect(prodOnly).toEqual(expect.arrayContaining(['platform', 'payments']));
+    expect(prodOnly).not.toContain(NONE_SENTINEL);
+  });
+
+  it('distinctTeamIds collects all teams plus NONE for NULL', () => {
+    const ids = distinctTeamIds(rows);
+    expect(ids).toEqual(expect.arrayContaining(['platform', 'payments', NONE_SENTINEL]));
+  });
+});
+
+describe('URL state round-trip (acceptance #7)', () => {
+  it('parses connector / namespace / team query params', () => {
+    const p = new URLSearchParams('?connector=prod-eks&namespace=platform&team=platform');
+    expect(parseFiltersFromParams(p)).toEqual({
+      connector: 'prod-eks',
+      namespace: 'platform',
+      team: 'platform',
+    });
+  });
+
+  it('missing params resolve to All (null)', () => {
+    expect(parseFiltersFromParams(new URLSearchParams(''))).toEqual(EMPTY_FILTERS);
+  });
+
+  it('writeFiltersToParams sets and clears keys', () => {
+    const p = new URLSearchParams('?tab=pending&connector=stale');
+    writeFiltersToParams(p, { connector: 'prod-eks', namespace: null, team: 'platform' });
+    expect(p.get('connector')).toBe('prod-eks');
+    expect(p.get('namespace')).toBeNull();
+    expect(p.get('team')).toBe('platform');
+    // Pre-existing unrelated params are preserved.
+    expect(p.get('tab')).toBe('pending');
+  });
+
+  it('round-trips state through write → parse', () => {
+    const p = new URLSearchParams();
+    const filters = { connector: 'prod-eks', namespace: NONE_SENTINEL, team: null };
+    writeFiltersToParams(p, filters);
+    expect(parseFiltersFromParams(p)).toEqual(filters);
+  });
+});
+
+describe('isAnyFilterActive', () => {
+  it('returns false for the empty filter', () => {
+    expect(isAnyFilterActive(EMPTY_FILTERS)).toBe(false);
+  });
+  it('returns true when any slot is set', () => {
+    expect(isAnyFilterActive({ ...EMPTY_FILTERS, team: 't' })).toBe(true);
+  });
+});

--- a/packages/web/src/pages/action-center-filters.ts
+++ b/packages/web/src/pages/action-center-filters.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure filter helpers for the Action Center approvals list.
+ *
+ * Per docs/design/approvals-multi-team-scope.md §5: operators filter approvals
+ * by connector / namespace / team. The API already gates rows the user can see
+ * (T2.2 per-row scope). These helpers only narrow the already-permitted set
+ * client-side.
+ *
+ * The sentinel `__none__` represents the "(no <X>)" / "(cluster-scoped)" pill
+ * that matches NULL on that dimension. `null` for a filter slot means "All".
+ */
+
+export const NONE_SENTINEL = '__none__';
+
+export interface ApprovalScopeFields {
+  opsConnectorId?: string | null;
+  targetNamespace?: string | null;
+  requesterTeamId?: string | null;
+}
+
+export interface ApprovalFilters {
+  /** null = All; NONE_SENTINEL = NULL rows; otherwise specific connector id. */
+  connector: string | null;
+  namespace: string | null;
+  team: string | null;
+}
+
+export const EMPTY_FILTERS: ApprovalFilters = {
+  connector: null,
+  namespace: null,
+  team: null,
+};
+
+function matchesOne(value: string | null | undefined, filter: string | null): boolean {
+  if (filter === null) return true;
+  if (filter === NONE_SENTINEL) return value == null;
+  return value === filter;
+}
+
+/** True when the row passes all three filter slots (AND across groups). */
+export function matchesFilters(row: ApprovalScopeFields, f: ApprovalFilters): boolean {
+  return (
+    matchesOne(row.opsConnectorId ?? null, f.connector)
+    && matchesOne(row.targetNamespace ?? null, f.namespace)
+    && matchesOne(row.requesterTeamId ?? null, f.team)
+  );
+}
+
+export function applyFilters<T extends ApprovalScopeFields>(rows: readonly T[], f: ApprovalFilters): T[] {
+  return rows.filter((r) => matchesFilters(r, f));
+}
+
+/**
+ * Distinct values for a given field across rows. `null`/missing collapses to
+ * the NONE sentinel so the caller can render a single "(no X)" pill.
+ *
+ * Connector-namespace coupling: the namespace pill list is built only from
+ * rows that already pass the connector filter, so e.g. picking connector A
+ * doesn't show namespaces that only exist under connector B.
+ */
+export function distinctConnectorIds(rows: readonly ApprovalScopeFields[]): (string | typeof NONE_SENTINEL)[] {
+  const seen = new Set<string | typeof NONE_SENTINEL>();
+  for (const r of rows) {
+    seen.add(r.opsConnectorId ?? NONE_SENTINEL);
+  }
+  return Array.from(seen).sort(sortNoneLast);
+}
+
+export function distinctNamespaces(
+  rows: readonly ApprovalScopeFields[],
+  connectorFilter: string | null,
+): (string | typeof NONE_SENTINEL)[] {
+  const seen = new Set<string | typeof NONE_SENTINEL>();
+  for (const r of rows) {
+    if (!matchesOne(r.opsConnectorId ?? null, connectorFilter)) continue;
+    seen.add(r.targetNamespace ?? NONE_SENTINEL);
+  }
+  return Array.from(seen).sort(sortNoneLast);
+}
+
+export function distinctTeamIds(rows: readonly ApprovalScopeFields[]): (string | typeof NONE_SENTINEL)[] {
+  const seen = new Set<string | typeof NONE_SENTINEL>();
+  for (const r of rows) {
+    seen.add(r.requesterTeamId ?? NONE_SENTINEL);
+  }
+  return Array.from(seen).sort(sortNoneLast);
+}
+
+function sortNoneLast(a: string, b: string): number {
+  if (a === NONE_SENTINEL) return 1;
+  if (b === NONE_SENTINEL) return -1;
+  return a.localeCompare(b);
+}
+
+// ─── URL state ────────────────────────────────────────────────────────────
+
+const PARAM_KEYS = {
+  connector: 'connector',
+  namespace: 'namespace',
+  team: 'team',
+} as const;
+
+/**
+ * Read filter state from URLSearchParams. Empty / missing → null (All).
+ * Recognised values are returned verbatim; the chip strip will render the
+ * value as "(unknown)" if it doesn't match any row, which is fine — picking
+ * a different chip clears it.
+ */
+export function parseFiltersFromParams(params: URLSearchParams): ApprovalFilters {
+  return {
+    connector: params.get(PARAM_KEYS.connector) || null,
+    namespace: params.get(PARAM_KEYS.namespace) || null,
+    team: params.get(PARAM_KEYS.team) || null,
+  };
+}
+
+/** Mutate a URLSearchParams instance to reflect the given filter state. */
+export function writeFiltersToParams(params: URLSearchParams, f: ApprovalFilters): void {
+  if (f.connector === null) params.delete(PARAM_KEYS.connector);
+  else params.set(PARAM_KEYS.connector, f.connector);
+  if (f.namespace === null) params.delete(PARAM_KEYS.namespace);
+  else params.set(PARAM_KEYS.namespace, f.namespace);
+  if (f.team === null) params.delete(PARAM_KEYS.team);
+  else params.set(PARAM_KEYS.team, f.team);
+}
+
+export function isAnyFilterActive(f: ApprovalFilters): boolean {
+  return f.connector !== null || f.namespace !== null || f.team !== null;
+}

--- a/packages/web/src/pages/admin/Teams.tsx
+++ b/packages/web/src/pages/admin/Teams.tsx
@@ -248,7 +248,7 @@ function CreateTeamModal({
 
 // ────────────────────────────────────────────────────────────────────────────
 
-type DrawerTab = 'members' | 'roles' | 'preferences';
+type DrawerTab = 'members' | 'roles' | 'preferences' | 'approvals';
 
 function TeamDrawer({
   team,
@@ -273,7 +273,7 @@ function TeamDrawer({
         </div>
       )}
       <div className="flex gap-1 border-b border-outline mb-4">
-        {(['members', 'roles', 'preferences'] as const).map((t) => (
+        {(['members', 'roles', 'preferences', 'approvals'] as const).map((t) => (
           <button
             key={t}
             type="button"
@@ -298,8 +298,122 @@ function TeamDrawer({
       {tab === 'preferences' && (
         <TeamPreferencesTab team={team} disabled={disabled} />
       )}
+      {tab === 'approvals' && <TeamApprovalsSection teamId={team.id} />}
     </Drawer>
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Pending approvals from this team (T3.2). Reads `GET /approvals` and filters
+// client-side by `requesterTeamId` — the API already enforces per-row
+// visibility (T2.2), so this view never shows rows the caller couldn't see in
+// the Action Center directly.
+
+export interface TeamApprovalRow {
+  id: string;
+  status: string;
+  createdAt: string;
+  requesterTeamId?: string | null;
+  action?: { type?: string };
+}
+
+const TEAM_APPROVALS_PREVIEW_LIMIT = 5;
+
+/** Pure helper: filter the list to pending rows owned by `teamId`. */
+export function pendingApprovalsForTeam(
+  rows: readonly TeamApprovalRow[],
+  teamId: string,
+): TeamApprovalRow[] {
+  return rows.filter((r) => r.status === 'pending' && r.requesterTeamId === teamId);
+}
+
+/** Pure helper: build the "See all" link href for a given team. */
+export function teamApprovalsSeeAllHref(teamId: string): string {
+  return `/actions?team=${encodeURIComponent(teamId)}`;
+}
+
+/** Pure helper: produce the See-all link label given total + preview slice. */
+export function teamApprovalsSeeAllLabel(total: number, previewLimit: number): string {
+  const overflow = total - Math.min(total, previewLimit);
+  return overflow > 0
+    ? `See all (${overflow} more) approvals from this team`
+    : 'See all approvals from this team';
+}
+
+export function TeamApprovalsSection({
+  teamId,
+  fetchApprovals = defaultFetchApprovals,
+  previewLimit = TEAM_APPROVALS_PREVIEW_LIMIT,
+}: {
+  teamId: string;
+  fetchApprovals?: () => Promise<TeamApprovalRow[]>;
+  previewLimit?: number;
+}): React.ReactElement {
+  const [rows, setRows] = useState<TeamApprovalRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await fetchApprovals();
+        if (cancelled) return;
+        setRows(pendingApprovalsForTeam(list, teamId));
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load approvals');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId, fetchApprovals]);
+
+  if (error) {
+    return (
+      <div className="text-xs text-error rounded-lg border border-error/40 bg-error/5 px-3 py-2">
+        {error}
+      </div>
+    );
+  }
+  if (rows === null) return <LoadingRow />;
+  if (rows.length === 0) {
+    return <EmptyState label="No pending approvals from this team." />;
+  }
+
+  const visible = rows.slice(0, previewLimit);
+
+  return (
+    <div data-testid="team-approvals-section">
+      <div className="space-y-2 mb-3">
+        {visible.map((r) => (
+          <div
+            key={r.id}
+            className="flex items-center gap-2 p-2 rounded-lg border border-outline"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-mono text-on-surface truncate">
+                {r.action?.type ?? 'approval'}
+              </div>
+              <div className="text-xs text-on-surface-variant">{r.createdAt}</div>
+            </div>
+            <Badge variant="neutral">pending</Badge>
+          </div>
+        ))}
+      </div>
+      <a
+        href={teamApprovalsSeeAllHref(teamId)}
+        data-testid="see-all-approvals-link"
+        className="text-xs text-primary hover:opacity-80"
+      >
+        {teamApprovalsSeeAllLabel(rows.length, previewLimit)}
+      </a>
+    </div>
+  );
+}
+
+async function defaultFetchApprovals(): Promise<TeamApprovalRow[]> {
+  const data = await api.get<TeamApprovalRow[]>('/approvals');
+  return Array.isArray(data) ? data : [];
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/web/src/pages/admin/__tests__/team-approvals-section.test.tsx
+++ b/packages/web/src/pages/admin/__tests__/team-approvals-section.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tests for the "Pending approvals from this team" section on the team
+ * detail drawer (T3.2). Acceptance bullets #9 and #10 from the task brief.
+ *
+ * The web package doesn't pull in jsdom, so we test the pure helpers that
+ * back the section (filter logic, link href, see-all label). The component
+ * shell is a thin wrapper around these.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  pendingApprovalsForTeam,
+  teamApprovalsSeeAllHref,
+  teamApprovalsSeeAllLabel,
+  type TeamApprovalRow,
+} from '../Teams.js';
+
+const rows: TeamApprovalRow[] = [
+  { id: 'a1', status: 'pending', createdAt: '2026-05-03T10:00:00Z', requesterTeamId: 'platform', action: { type: 'ops.run_command' } },
+  { id: 'a2', status: 'pending', createdAt: '2026-05-03T11:00:00Z', requesterTeamId: 'platform' },
+  { id: 'a3', status: 'approved', createdAt: '2026-05-03T11:00:00Z', requesterTeamId: 'platform' },
+  { id: 'a4', status: 'pending', createdAt: '2026-05-03T12:00:00Z', requesterTeamId: 'payments' },
+  { id: 'a5', status: 'pending', createdAt: '2026-05-03T13:00:00Z', requesterTeamId: null },
+];
+
+describe('pendingApprovalsForTeam (acceptance #9)', () => {
+  it('returns only pending rows whose requesterTeamId matches', () => {
+    const out = pendingApprovalsForTeam(rows, 'platform');
+    expect(out.map((r) => r.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('returns empty when no rows match', () => {
+    expect(pendingApprovalsForTeam(rows, 'no-such-team')).toEqual([]);
+  });
+
+  it('does not match NULL requesterTeamId by accident', () => {
+    expect(pendingApprovalsForTeam(rows, '')).toEqual([]);
+  });
+});
+
+describe('teamApprovalsSeeAllHref (acceptance #10)', () => {
+  it('builds /actions?team=<teamId>', () => {
+    expect(teamApprovalsSeeAllHref('platform')).toBe('/actions?team=platform');
+  });
+
+  it('encodes special characters in the team id', () => {
+    expect(teamApprovalsSeeAllHref('team a&b')).toBe('/actions?team=team%20a%26b');
+  });
+});
+
+describe('teamApprovalsSeeAllLabel', () => {
+  it('drops the overflow count when total fits inside the preview', () => {
+    expect(teamApprovalsSeeAllLabel(2, 5)).toBe('See all approvals from this team');
+    expect(teamApprovalsSeeAllLabel(5, 5)).toBe('See all approvals from this team');
+  });
+
+  it('shows the overflow count when total exceeds the preview', () => {
+    expect(teamApprovalsSeeAllLabel(8, 5)).toBe('See all (3 more) approvals from this team');
+  });
+
+  it('treats zero rows as "no overflow"', () => {
+    expect(teamApprovalsSeeAllLabel(0, 5)).toBe('See all approvals from this team');
+  });
+});


### PR DESCRIPTION
Phase 3 of multi-team approvals ([design doc #154](https://github.com/openobs/openobs/pull/154)). Closes the loop after T1.1 ([#155](https://github.com/openobs/openobs/pull/155), schema + grammar) and T2.x ([#156](https://github.com/openobs/openobs/pull/156), write path + per-row read scope).

## T3.1 — approval routing

- **`EventTypes.APPROVAL_CREATED` + payload** in `@agentic-obs/common/events` carries the three scope tags so consumers can filter with the same helpers T2.2 uses for visibility — single source of truth.
- **`PublishingApprovalRepository`** adapter wraps `IApprovalRequestRepository.submit()` and publishes **after** the row commits (mirrors the existing `EventEmittingApprovalRepository` pattern). Submit-throws → no publish, pinned by test.
- **`ApprovalRouter`** enumerates users whose `approvals:approve` grant covers the row's scope. Walks permissions → roles → builtin/user/team-role assignments with strict org isolation.
- **NotificationConsumer extended** to also subscribe to `approval.created` — single class, two topics. Reuses `dispatchToContactPoint` so dedup-by-fingerprint and sender-error isolation come for free.

### Fail-closed invariant (R1, the load-bearing test)

A user with `approve on approvals:connector:dev-eks` in `org_main` AND `approvals:*` in `org_other` is **not** returned as a recipient for a `prod-eks` approval in `org_main`. No silent wildcard fallback, no cross-org leak.

### Idempotency

A duplicate envelope for the same approvalId produces one send + one dispatch row. Pinned by test.

## T3.2 — UI filters

- **Three chip filter strips** (connector / namespace / team) above pending + resolved approval lists in ActionCenter. Single-select per group, AND across groups.
- **"(no connector)" / "(cluster-scoped)" / "(no team)" pills** explicitly match NULL — back-compat rows stay visible without pretending they have tags.
- **URL state** via `useSearchParams` → `?connector=prod-eks&team=platform` for deep-links.
- **Bulk fetch** of connectors + teams once; client-side join for display names. No per-row fetches.
- **Team detail drawer** (`admin/Teams.tsx`) gets a 4th tab "Approvals" with pending approvals from this team + "See all (N more)" link to the filtered ActionCenter.

## Deviations

Design doc references `/admin/approvals` and `/admin/teams/:id`; the actual code routes approvals through `/actions` (ActionCenter) and team detail through a Drawer. Per the brief's "don't change routing structure" — added chips to ActionCenter and the team section as a 4th drawer tab. "See all" link points to `/actions?team=<id>` to match.

## Test plan

- [x] **41 new tests** across 4 files:
  - `services/publishing-approval-repository.test.ts` — 3 (publish-after-commit, no-publish-on-throw, planId extraction)
  - `services/approval-router.test.ts` — 9 (candidate scopes, single-team, NULL row, connector / namespace / team narrowing, team-role fan-out, **fail-closed R1**)
  - `services/notification-consumer.test.ts` — 4 added (approval fanout, idempotency, fail-closed-via-router, sender error isolation)
  - `pages/action-center-filters.test.ts` — 17 (filter logic, URL round-trip, AND across groups)
  - `pages/admin/__tests__/team-approvals-section.test.tsx` — 8 (section helpers)
- [x] `vitest run packages/{api-gateway,common,web,agent-core}` — **1203 pass / 0 fail**
- [x] `tsc -b` clean
- [ ] Manual: revoke `Editor`'s `approvals:*`, grant `fixed:approvals:cluster_approver` to a per-team group bound to `prod-eks`, fire alert in dev → verify the team only sees prod approvals AND only gets prod Slack notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval filtering in Action Center by connector, namespace, and team.
  * Teams can now view pending approvals in the admin dashboard.
  * Implemented approval-based notification routing to relevant users and teams.

* **Tests**
  * Added comprehensive test coverage for approval routing, filtering, and notification dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->