### PR TITLE
Fix investigation report rendering regression after #95

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -175,13 +175,13 @@ User: "Alert me when error rate goes above 5%"
 ## Investigation
 When the user asks "why is X high/slow/broken" or "investigate X", debug it the way you'd walk a teammate through it in Slack: lead with what you saw and the numbers, work through what you suspected and what you queried, follow the trail (including dead ends), and end with what's most likely going on.
 
-The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Don't pre-name sections "Hypothesis 1 / Conclusion / Next Steps". Pick headings (or no headings) that fit the case, and let the prose carry the structure.
+The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Start each text section with a short markdown heading that names the beat (e.g. \`## Symptom\`, \`## Deployment history\`, \`## Fix\`). Pick headings that fit this case — don't reach for a fixed template like \`## Initial Assessment\` / \`## Hypothesis Testing\` by reflex.
 
 ### How to write it
 - Lead with what you saw and the numbers ("p99 jumped from ~50ms baseline to 99ms around 14:30; sustained for the last hour").
 - For each thing you suspected: state it, say what you queried, what came back, and whether that killed or supported the suspicion. Allow detours and dead ends — real debugging isn't linear.
 - Connect the dots explicitly: "Since traffic is stable AND errors are zero, the cost is in per-request work, not load."
-- End with what's most likely going on — or "I couldn't tell" if you can't. Don't force a Conclusion heading; the last paragraph IS the conclusion.
+- End with what's most likely going on — or "I couldn't tell" if you can't. The last section carries the conclusion; pick a heading that names what it's saying (e.g. \`## Likely cause\`, \`## What to try next\`) rather than the generic word "Conclusion".
 - If the user can act on it, say what they should try next, specifically. If everything is healthy, say so cleanly and stop.
 - Specific numbers inline: not "high", but "120ms vs <50ms baseline".
 - Complete paragraphs, not bullet lists.
@@ -196,7 +196,7 @@ If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_com
 
 ### Mechanics
 - Use \`investigation_add_section({type: "text"})\` for prose; \`{type: "evidence"}\` to attach the chart that supports a paragraph. Section order = display order.
-- Choose your own headings (or none). Don't reach for "## Initial Assessment" / "## Hypothesis Testing" by reflex — fit the heading to what you're actually saying.
+- Start each text section with a short \`## heading\` that names the beat. Fit the heading to what you're actually saying — don't reach for a fixed template by reflex.
 - Interleave querying and writing. Query → write a paragraph → query more → write more → drop in the evidence panel next to the prose it supports. Don't do all the queries first and then the writing.
 - Evidence panels sparingly — 2–4 total. Each one earns its place next to the paragraph that interprets it.
 - MUST call \`investigation_complete\` at the end. Without it, sections are lost. Don't end the turn with plain text before completing.
@@ -206,15 +206,15 @@ User: "Why is p99 latency so high?"
   1. datasources_list(signalType: "metrics") → id: prom-prod
   2. investigation_create(question: "Why is p99 latency high?") → inv-789
   3. metrics_query(p99) → 99ms; metrics_query(p50) → 50ms
-  4. investigation_add_section(type: "text", content: "p99 is sitting at 99ms vs ~50ms p50 — about 2× the median, sustained over the last hour. Worth chasing.")
+  4. investigation_add_section(type: "text", content: "## Symptom\n\np99 is sitting at 99ms vs ~50ms p50 — about 2× the median, sustained over the last hour. Worth chasing.")
   5. metrics_range_query(query: request rate, duration_minutes: 60) → stable 0.19 req/s
   6. metrics_query(error rate) → 0 errors
-  7. investigation_add_section(type: "text", content: "First thought: load. Rate is flat at 0.19 req/s with a peak of 0.25 at 14:30, well within normal range. Errors are zero. So it isn't load-driven and it isn't a fault path — the cost is in per-request work somewhere.")
+  7. investigation_add_section(type: "text", content: "## Ruling out load\n\nFirst thought: load. Rate is flat at 0.19 req/s with a peak of 0.25 at 14:30, well within normal range. Errors are zero. So it isn't load-driven and it isn't a fault path — the cost is in per-request work somewhere.")
   8. metrics_query(p99 by handler) → /api/v1/query_range=120ms, others <50ms
   9. investigation_add_section(type: "evidence", content: "p99 by handler", panel: {...})
-  10. investigation_add_section(type: "text", content: "Breaking down by handler points the finger: /api/v1/query_range sits at 120ms p99 while every other handler is under 50ms. That one handler is the entire delta.")
+  10. investigation_add_section(type: "text", content: "## Hotspot: /api/v1/query_range\n\nBreaking down by handler points the finger: /api/v1/query_range sits at 120ms p99 while every other handler is under 50ms. That one handler is the entire delta.")
   11. changes_list_recent(service: "api-gateway", window_minutes: 120) → no deploys in window
-  12. investigation_add_section(type: "text", content: "No deploys in the last 2h, so this isn't a regression from a code change — most likely an expensive query pattern or upstream slowdown specific to /query_range. To pin it down, profile a slow request, check incoming PromQL complexity for that endpoint, and see whether the slowness tracks a particular tenant or query shape.")
+  12. investigation_add_section(type: "text", content: "## Likely cause and what to try\n\nNo deploys in the last 2h, so this isn't a regression from a code change — most likely an expensive query pattern or upstream slowdown specific to /query_range. To pin it down, profile a slow request, check incoming PromQL complexity for that endpoint, and see whether the slowness tracks a particular tenant or query shape.")
   13. investigation_complete(summary: "p99 is driven by /api/v1/query_range alone (120ms vs <50ms others). No deploy correlation. Profile that handler and look at PromQL complexity per-tenant.")
 </example>
 

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -606,7 +606,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     extendedPrompt:
       `Interleave querying and writing: query → add_section(text) interpreting that result → query more → another section → drop in an evidence panel next to the prose that cites it. Do NOT batch all queries first then dump prose at the end — the report loses the actual reasoning shape.\n` +
       `type=evidence is reserved for the 2–4 panels that carry the conclusion; not "every panel I ran". Each evidence section earns its place next to the paragraph that interprets it.\n` +
-      `Headings are optional and free-form. Don't reflexively reach for "## Initial Assessment" / "## Hypothesis 1" — fit the heading (or absence) to what the paragraph actually says.`,
+      `Every text section MUST start with a short \`## heading\` that names the beat (e.g. \`## Symptom\`, \`## Ruling out load\`, \`## Hotspot: /foo\`). Without headings the rendered report collapses into one wall of text under "Summary" and the user can't tell sections apart. Headings are free-form — fit them to what the paragraph actually says, don't reflexively reach for "## Initial Assessment" / "## Hypothesis 1".`,
     schema: {
       name: 'investigation_add_section',
       description:


### PR DESCRIPTION
## Summary
- Investigation reports rendered as a single wall of text under "Summary" — no visible section headings, even though sections were persisted correctly (`json_array_length(sections)` returns 3+).
- Root cause: [#95](https://github.com/openobs/openobs/pull/95) loosened the rigid 4-section template ("Initial Assessment / Hypothesis Testing / Conclusion / Next Steps") and the wording overshot. Phrases like "Pick headings (or no headings) that fit the case" and "Don't force a Conclusion heading; the last paragraph IS the conclusion" cumulatively read as "don't write headings". Combined with worked-example sections whose `content` was plain prose with no markdown heading, Opus 4.7 emits naked paragraphs that `MarkdownText` renders verbatim under "Summary".
- Fix preserves #95's freedom (any heading that fits, no fixed template) but **requires** a heading per text section and updates the worked example so the model has a concrete pattern to imitate.

## Why
The bug is upstream **content**, not the renderer. `InvestigationReportView.tsx` is correct — `TextSection` passes `section.content` straight through `MarkdownText`. Without `## ` lines in the content, there is no visual chrome between sections. Restoring the rigid 4-section template would walk back #95; this fix only restores the heading expectation.

## Concrete edits (all in `packages/agent-core/src/agent/`)
- `orchestrator-prompt.ts:178` — replace "Pick headings (or no headings) that fit the case" with "Start each text section with a short markdown heading that names the beat (e.g. `## Symptom`, `## Deployment history`, `## Fix`). Pick headings that fit this case — don't reach for a fixed template by reflex."
- `orchestrator-prompt.ts:184` — drop the "Don't force a Conclusion heading" contradiction. The last section still carries the conclusion; pick a heading naming what it's saying ("## Likely cause", "## What to try next").
- `orchestrator-prompt.ts:199` (### Mechanics) — "Start each text section with a short `## heading` that names the beat. Fit the heading to what you're actually saying — don't reach for a fixed template by reflex."
- Worked Investigation example — prepend `## <beat>\n\n` to every `investigation_add_section(type: "text", ...)` content. Beats: `## Symptom` / `## Ruling out load` / `## Hotspot: /api/v1/query_range` / `## Likely cause and what to try`. Agents imitate examples more reliably than rules.
- `tool-schema-registry.ts` — flip the contradicting line in `investigation_add_section.extendedPrompt` (added in [#159](https://github.com/openobs/openobs/pull/159)) from "Headings are optional and free-form" to "Every text section MUST start with a short `## heading` ...", with a one-line note about why (rendered report collapses without them).

## Non-goals / scope
- Do **not** restore the fixed "Initial Assessment / Hypothesis Testing / Conclusion / Next Steps" template — #95's intent was to kill that rigidity, this fix preserves it.
- Do **not** change the persisted shape of `investigation_reports.sections`; this is prose-level, not schema.
- Dashboard / alert / chat authoring prompts are unaffected.
- `InvestigationReportView.tsx` is untouched.

## Test plan
- [x] `npx vitest run packages/agent-core` — 184/184 pass
- [ ] Trigger any alert-based investigation (e.g. scale demo-api to 0 or set a bad image). Wait for `status=completed`.
- [ ] Confirm `sqlite3 .openobs/openobs.db "SELECT content FROM investigation_reports ORDER BY created_at DESC LIMIT 1;"` shows each section's content starting with a `## ` line.
- [ ] Open the investigation in the UI — sections should render with visible subheadings beneath the Summary block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Investigation reports now require each section to begin with a descriptive markdown heading (e.g., `## Symptom`). The reporting structure enforces consistent section naming throughout reports, replacing optional heading guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->