### PR TITLE
Prompt PR-3: web_search positive triggers + dashboard_add_panels pre-flight

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.test.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.test.ts
@@ -218,7 +218,7 @@ describe('buildSystemPrompt — # Tool Behaviors (per-tool extendedPrompt)', () 
     const prompt = buildSystemPrompt(null, [], [], null, [], {
       hasPrometheus: false,
       now: '2026-04-18T00:00:00.000Z',
-      allowedTools: ['datasources_list', 'metrics_query', 'web_search'],
+      allowedTools: ['datasources_list', 'metrics_query', 'logs_query'],
     });
     expect(prompt).not.toContain('# Tool Behaviors');
   });
@@ -243,6 +243,28 @@ describe('buildSystemPrompt — # Tool Behaviors (per-tool extendedPrompt)', () 
     expect(prompt).toContain('## remediation_plan_create');
     expect(prompt).toContain('## remediation_plan_create_rescue');
     expect(prompt).toContain('## ops_run_command');
+  });
+
+  it('emits a web_search behavior block with positive triggers when web_search is allowed', () => {
+    const prompt = buildSystemPrompt(null, [], [], null, [], {
+      hasPrometheus: false,
+      now: '2026-04-18T00:00:00.000Z',
+      allowedTools: ['web_search', 'metrics_query'],
+    });
+    expect(prompt).toContain('## web_search');
+    expect(prompt).toContain('Named-system dashboard');
+    expect(prompt).toContain('unfamiliar metric');
+  });
+
+  it('emits a dashboard_add_panels pre-flight block warning about training-data priors', () => {
+    const prompt = buildSystemPrompt(null, [], [], null, [], {
+      hasPrometheus: false,
+      now: '2026-04-18T00:00:00.000Z',
+      allowedTools: ['dashboard_add_panels', 'web_search'],
+    });
+    expect(prompt).toContain('## dashboard_add_panels');
+    expect(prompt).toContain('call web_search FIRST');
+    expect(prompt).toContain('training-data priors');
   });
 
   it('places the # Tool Behaviors section in the static block (before the dynamic boundary)', () => {

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -199,6 +199,7 @@ If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_com
 - Start each text section with a short \`## heading\` that names the beat. Fit the heading to what you're actually saying — don't reach for a fixed template by reflex.
 - Interleave querying and writing. Query → write a paragraph → query more → write more → drop in the evidence panel next to the prose it supports. Don't do all the queries first and then the writing.
 - Evidence panels sparingly — 2–4 total. Each one earns its place next to the paragraph that interprets it.
+- When you hit an unfamiliar metric, label, or vendor behavior mid-investigation, call \`web_search\` before guessing — see the web_search behavior block above for triggers.
 - MUST call \`investigation_complete\` at the end. Without it, sections are lost. Don't end the turn with plain text before completing.
 
 <example>

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -470,6 +470,10 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   },
   'dashboard_add_panels': {
     category: 'always-on',
+    extendedPrompt:
+      `Pre-flight before calling: if the dashboard targets a NAMED system (Redis, Kafka, Postgres, nginx, ...) AND no exporter metric names appear anywhere in the conversation context, call web_search FIRST to get the canonical exporter metric naming + a reference layout. Carve-out: skip web_search only when the exact metric names you're about to use are already quoted in the current conversation (user pasted them, an earlier metrics_discover returned them, etc.).\n` +
+      `Skipping the pre-flight is the dominant failure mode: training-data priors invent plausible-looking names → metrics_validate rejects → re-plan → wasted turns. The web_search round trip is one cheap read; the rebuild is several mutations.\n` +
+      `Validate every non-trivial query through metrics_validate before this call. Pre-deployment dashboards (metrics don't exist yet) skip metrics_validate but STILL benefit from the web_search step — that's where the canonical names come from.`,
     schema: {
       name: 'dashboard_add_panels',
       description:
@@ -730,6 +734,13 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   // -------------------------------------------------------------------------
   'web_search': {
     category: 'always-on',
+    extendedPrompt:
+      `Cheap read — same cost class as metrics_discover. Spend it liberally; the model's training-data priors on metric names go stale.\n` +
+      `Positive triggers (call BEFORE the next tool):\n` +
+      `1. Named-system dashboard — user names a standard system (Redis, Kafka, Postgres, nginx, etcd, ...). Search for the canonical exporter + reference layout BEFORE constructing panel queries. Skip ONLY if the exact exporter metric names already appear in the conversation.\n` +
+      `2. Investigation hits an unfamiliar metric / label / vendor behavior — when you hit a name like \`redis_aof_rewrite_in_progress\` or \`kafka_consumergroup_lag\` and you can't say what it means in one line from context, search before guessing. Same for "is this a known upstream bug" hypotheses — vendor docs / GitHub issues are the disambiguator.\n` +
+      `3. Best-practice panel layout for an in-house service pattern (HTTP server, gRPC, queue consumer, batch job) when the worked example doesn't already cover it.\n` +
+      `Anti-pattern: skipping the search and inventing metric names from training-data priors. The downstream cost is dashboard_add_panels → metrics_validate failure → wasted turns; cheaper to web_search up front.`,
     schema: {
       name: 'web_search',
       description:


### PR DESCRIPTION
## Summary
- `web_search` was effectively dead code: across 20+ Opus 4.7 runs (dashboard creation + alert-triggered investigations), `"action":"web_search"` appeared **0 times** in react-loop logs. The tool is always-on and the global prompt suggests it, but the model falls back to training-data priors for metric names → `metrics_validate` failures → wasted turns.
- Fix puts decision-density on the tools themselves, per the PR-2 pattern ([#159](https://github.com/openobs/openobs/pull/159)) — extendedPrompt blocks on `web_search` (positive triggers) and `dashboard_add_panels` (negative trigger / pre-flight). One-line cross-reference in the Investigation Mechanics block.

## Why
Reasoning at the point of *whether to call* lives next to the tool, not in the global static prompt. The existing global guidance in Dashboard design and DoingTasks was insufficient for Opus 4.7 — it read as soft suggestion and the model shipped its priors. extendedPrompt is what the model sees adjacent to the tool list at decision time, so it's the right placement.

## What changed
- **`web_search.extendedPrompt`** — frames as cheap-read class (DoingTasks "spend reads liberally" already applies); enumerates 3 positive triggers:
  1. Named-system dashboard (Redis, Kafka, Postgres, ...) — search canonical exporter + reference layout BEFORE constructing panel queries
  2. Mid-investigation unfamiliar metric / label / vendor behavior (e.g. `redis_aof_rewrite_in_progress`, "is this a known upstream bug")
  3. Best-practice layout for an in-house service pattern not covered by the worked example
  - Carve-out: skip when the exact metric names already appear in conversation
- **`dashboard_add_panels.extendedPrompt`** — pre-flight rule: if targeting a named system AND no exporter metric names appear in context, call `web_search` FIRST. Names the dominant failure mode (priors → validate rejects → re-plan) so the model can self-check.
- **Investigation Mechanics** (`orchestrator-prompt.ts:201`) — one-line cross-reference pointing at the web_search behavior block. No content duplication; the trigger catalog lives on `web_search`.

## Why not the alternative
The intuitive fix is to thicken the global Dashboard design and Investigation sections in `orchestrator-prompt.ts`. Two reasons against:
1. **Decision-density should be at point of use.** Once Opus 4.7 is reasoning about the next tool call, the always-on tool list is the surface it's looking at — extendedPrompt sits right there.
2. **Don't echo "cheap read".** The cost-asymmetry framing already exists in DoingTasks ("spend reads liberally, spend mutations carefully"). Repeating it in two more places would violate the surgical-change principle in [CLAUDE.md](CLAUDE.md).

## Scope
- No schema change, no allowlist change. Pure prompt + extendedPrompt.
- Independent of any "tool_search returns 0" issue — `web_search` is always-on, visible to the model on every call. The bug is the model choosing not to invoke it.
- Other flows (alert rule creation, chat Q&A) are not nudged toward `web_search` — they don't need it.

## Test plan
- [x] `npx vitest run packages/agent-core` — 186/186 pass (2 new tests, 1 updated)
- [x] `npx tsc --noEmit -p packages/agent-core/tsconfig.json` clean
- [ ] Run a dashboard creation for a named system (e.g. "build a Redis dashboard") and an investigation where a metric name is ambiguous; expect at least one `"action":"web_search"` per trace. Zero calls = still broken.

## Related
- Stacks on top of [#158](https://github.com/openobs/openobs/pull/158) (action framing + cache boundary), [#159](https://github.com/openobs/openobs/pull/159) (per-tool extendedPrompt mechanism), [#160](https://github.com/openobs/openobs/pull/160) (investigation heading regression). Independent of the heading fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent behavior to automatically search for information when encountering unfamiliar metrics or vendor behavior during investigations.

* **Tests**
  * Updated test suite to verify proper tool behavior and validation workflows for search and dashboard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->