### PR TITLE
e2e: investigation completes when CPU saturates

### DIFF
--- a/tests/e2e/scenarios/investigations/cpu-saturated.test.ts
+++ b/tests/e2e/scenarios/investigations/cpu-saturated.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Scenario — CPU saturation triggers an investigation that completes.
+ *
+ * Companion to investigation-completes.test.ts (which uses scale-to-0 / no
+ * traffic as the firing condition). Here the symptom is the opposite:
+ * the target is up and serving, but its process is pinned against its
+ * container CPU limit. Exercises the agent's investigation flow on a
+ * "service is alive but degraded" failure mode rather than "service is
+ * absent".
+ *
+ * Setup:
+ * 1. Pin web-api to a single replica so the CPU pressure concentrates
+ *    on one process (otherwise rate is averaged across pods and won't
+ *    cross threshold reliably).
+ * 2. Scale load-200 way up — many curl pods hammering /, enough request
+ *    volume to saturate the Go process's 200m CPU limit.
+ * 3. `process_cpu_seconds_total{app="web-api"}` is auto-exposed by the Go
+ *    runtime metrics in prometheus-example-app, so no fixture changes
+ *    are needed. Threshold 0.05 cores/sec is comfortably above idle
+ *    baseline (~0.005) and below the 0.2 limit ceiling.
+ *
+ * Assertion: rule fires, dispatcher links an investigationId onto the
+ * rule, and the investigation reaches `completed` within the budget.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { apiPost, apiGet, apiDelete } from '../helpers/api-client.js';
+import { pollUntil } from '../helpers/wait.js';
+import { scaleDeployment } from '../helpers/scale.js';
+
+const NS = 'openobs-e2e';
+const TARGET = 'web-api';
+const LOAD = 'load-200';
+const BASELINE_TARGET_REPLICAS = 3;
+const BASELINE_LOAD_REPLICAS = 1;
+const SATURATING_LOAD_REPLICAS = 30;
+
+interface AlertRule {
+  id: string;
+  state: 'normal' | 'pending' | 'firing' | 'resolved' | 'disabled';
+  investigationId?: string;
+}
+interface Investigation {
+  id: string;
+  status: 'planning' | 'investigating' | 'evidencing' | 'explaining' | 'acting' | 'verifying' | 'completed' | 'failed';
+}
+
+describe.skipIf(!process.env['OPENOBS_TEST_LLM_API_KEY'])('cpu-saturated investigation', () => {
+  let ruleId: string | null = null;
+
+  beforeAll(async () => {
+    // Concentrate load on one pod so per-process CPU rate crosses threshold.
+    await scaleDeployment(NS, TARGET, 1);
+    await scaleDeployment(NS, LOAD, BASELINE_LOAD_REPLICAS);
+  }, 180_000);
+
+  afterAll(async () => {
+    if (ruleId) {
+      try { await apiDelete(`/api/alert-rules/${ruleId}`); } catch { /* noop */ }
+    }
+    // Best-effort restore. Either step failing must not mask test failure.
+    try { await scaleDeployment(NS, LOAD, BASELINE_LOAD_REPLICAS); } catch { /* noop */ }
+    try { await scaleDeployment(NS, TARGET, BASELINE_TARGET_REPLICAS); } catch { /* noop */ }
+  }, 180_000);
+
+  it('CPU-saturation alert drives investigation to completion', async () => {
+    // Spell out the PromQL explicitly so the alert generator preserves it
+    // verbatim instead of inventing a different expression. Threshold 0.05
+    // = 50m CPU sustained for 30s on a single pod under heavy load.
+    const prompt =
+      'create alert web-api-cpu-saturated: ' +
+      'PromQL rate(process_cpu_seconds_total{app="web-api"}[1m]) > 0.05 ' +
+      'for 30s severity high';
+    const created = await apiPost<AlertRule>('/api/alert-rules/generate', { prompt });
+    expect(created.id).toBeTruthy();
+    ruleId = created.id;
+
+    // Fan load-200 out — each curl pod sustains ~5 RPS hitting the single
+    // web-api pod, driving its Go runtime + http handler past the 50m
+    // threshold within one or two scrape cycles.
+    await scaleDeployment(NS, LOAD, SATURATING_LOAD_REPLICAS);
+
+    // Fire budget: ~5s scrape + 30s `for` + jitter under load = 60-120s.
+    // Generous 180s buffer handles slow rollouts on resource-tight CI nodes.
+    const fired = await pollUntil<AlertRule>(
+      async () => {
+        const rule = await apiGet<AlertRule>(`/api/alert-rules/${ruleId}`);
+        return rule.state === 'firing' ? rule : null;
+      },
+      { timeoutMs: 180_000, intervalMs: 3000, label: 'cpu rule -> firing' },
+    );
+    expect(fired.state).toBe('firing');
+
+    // Dispatcher links investigationId onto the rule on the firing transition.
+    const linked = await pollUntil<AlertRule>(
+      async () => {
+        const rule = await apiGet<AlertRule>(`/api/alert-rules/${ruleId}`);
+        return rule.investigationId ? rule : null;
+      },
+      { timeoutMs: 60_000, intervalMs: 2000, label: 'rule.investigationId set' },
+    );
+    expect(linked.investigationId).toBeTruthy();
+
+    // Investigation reaches `completed`. CPU-saturation flow tends to do
+    // more queries than the scale-to-0 case (the rate isn't 0, so the
+    // agent has actual data to chase), so use the same 180s budget.
+    const inv = await pollUntil<Investigation>(
+      async () => {
+        const i = await apiGet<Investigation>(`/api/investigations/${linked.investigationId}`);
+        return i.status === 'completed' ? i : null;
+      },
+      { timeoutMs: 180_000, intervalMs: 3000, label: 'investigation -> completed' },
+    );
+    expect(inv.status).toBe('completed');
+  }, 480_000);
+});


### PR DESCRIPTION
## Summary
Companion to [tests/e2e/scenarios/investigation-completes.test.ts](tests/e2e/scenarios/investigation-completes.test.ts). The existing scenario asserts the "service is absent" path (scale to 0 → no traffic → vector-zero alert fires). This one covers the inverse failure mode: **service is alive but degraded** — pod is up and serving, but its Go process is pinned against its 200m container CPU limit under heavy load.

The investigation flow has actual non-zero data to chase here, so the agent's behavior on this path is materially different from the no-data case.

## How
- Pin `web-api` to **one** replica so per-process CPU rate concentrates rather than averages out across pods.
- Scale `load-200` from 1 to 30 replicas (each curl pod ~5 RPS = ~150 RPS hammering the single `web-api` pod).
- Alert on `rate(process_cpu_seconds_total{app="web-api"}[1m]) > 0.05 for 30s severity high`.
  - Metric is auto-exposed by `prometheus-example-app`'s Go runtime — **no fixture changes needed**.
  - Threshold is well above idle baseline (~0.005) and well below the 0.2 limit ceiling.

## Assertions
1. Rule transitions to `firing` within 180s
2. Dispatcher links an `investigationId` onto the rule within 60s of firing
3. Investigation reaches `status: completed` within 180s

Total budget: 480s. Cleanup restores `web-api` → 3 replicas and `load-200` → 1 in `afterAll` regardless of outcome.

## Skip behavior
Same as the existing investigation scenario — `describe.skipIf(!process.env['OPENOBS_TEST_LLM_API_KEY'])`. Runs only when the e2e harness has an LLM key configured.

## Test plan
- [ ] `npm run e2e:full` (or `e2e:run` against an existing cluster) on a Mac with kind + LLM key — verify the test passes
- [ ] Confirm threshold 0.05 fires reliably under the 30-replica load (if not, lower to 0.02 — still > 4× idle)
- [ ] Confirm afterAll cleanup actually restores state when the assertion fails midway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for CPU-saturation investigation workflows. Tests validate alert creation and management via API, targeted load simulation on service components, investigation status monitoring, and automated cleanup of test resources to ensure proper system state isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->