### PR TITLE
Run e2e scenarios serially

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -12,7 +12,8 @@ Local CLIs on `$PATH`:
 - kind
 - kubectl
 - helm
-- chainsaw
+- Kyverno Chainsaw (`brew install kyverno/chainsaw/chainsaw`; Homebrew core
+  has a different `chainsaw` binary that does not support `chainsaw test`)
 - jq
 - node 20+ (and the repo's `npm install`)
 

--- a/tests/e2e/kit.sh
+++ b/tests/e2e/kit.sh
@@ -102,6 +102,12 @@ cmd_run() {
 
   if [[ "${has_chainsaw}" -eq 1 ]]; then
     phase "chainsaw tests"
+    if ! command -v chainsaw >/dev/null 2>&1; then
+      die "chainsaw CLI not found; install Kyverno Chainsaw with: brew install kyverno/chainsaw/chainsaw"
+    fi
+    if ! chainsaw test --help >/dev/null 2>&1; then
+      die "chainsaw CLI on PATH does not support 'chainsaw test'; install Kyverno Chainsaw with: brew install kyverno/chainsaw/chainsaw"
+    fi
     chainsaw test "${E2E_ROOT}/chainsaw/tests"
   else
     warn "no chainsaw tests"

--- a/tests/e2e/vitest.e2e.config.ts
+++ b/tests/e2e/vitest.e2e.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     hookTimeout: 60_000,
     pool: 'forks',
     isolate: true,
+    fileParallelism: false,
+    maxWorkers: 1,
+    minWorkers: 1,
     maxConcurrency: 1,
   },
 });


### PR DESCRIPTION
## Summary
- run Vitest e2e scenario files serially against the shared cluster
- fail fast when PATH contains the wrong chainsaw binary
- document the Kyverno Chainsaw install command

## Verification
- bash -n tests/e2e/kit.sh tests/e2e/lib/env.sh
- npm run typecheck

## Notes
The previous e2e run failed with broad shared-state symptoms: workload scaling races, alert/investigation timeouts, and RBAC timeouts. The config already claimed these scenarios run sequentially, but Vitest was still allowed to execute files in parallel. This PR makes that explicit at the file/worker level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated end-to-end testing prerequisites with Chainsaw installation instructions via Homebrew.

* **Bug Fixes**
  * Added preflight checks to verify Chainsaw CLI is properly installed and configured.
  * Modified test execution settings to ensure sequential test execution for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->