### PR TITLE
Friendly listen errors instead of EADDRINUSE crash

### DIFF
--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -336,6 +336,32 @@ export async function startServer(port = 3000): Promise<void> {
   const wsDeps = app.locals['websocketGatewayDeps'] as WebSocketGatewayDeps | undefined;
   const { httpServer, gateway } = createWebSocketGateway(app, createEventBusFromEnv(), wsDeps);
 
+  // Friendly listen errors. Without an `error` handler, Node crashes the
+  // process with an unhandled-event stack trace on EADDRINUSE — bad UX for
+  // the common "I already have something on :3000" case. Catch the two
+  // listen errors a user can actually do something about and print a
+  // prescriptive one-liner instead of the raw trace.
+  httpServer.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      process.stderr.write(
+        `\nopenobs: port ${port} is already in use.\n\n` +
+        `  • Kill what's holding it:   lsof -ti :${port} | xargs kill\n` +
+        `  • Or run on another port:   PORT=${port + 1} openobs\n\n`,
+      );
+      process.exit(1);
+    }
+    if (err.code === 'EACCES') {
+      process.stderr.write(
+        `\nopenobs: permission denied to bind port ${port}.\n` +
+        `Pick a port ≥1024 or run with elevated privileges.\n` +
+        `  PORT=8080 openobs\n\n`,
+      );
+      process.exit(1);
+    }
+    log.fatal({ err: err.message, code: err.code }, 'listen failed');
+    process.exit(1);
+  });
+
   httpServer.listen(port, () => {
     log.info({ port }, 'API gateway listening');
   });


### PR DESCRIPTION
## Summary
Surface `EADDRINUSE` and `EACCES` listen failures as a friendly one-liner with the fix command, instead of an unhandled-error Node stack trace.

## Why
First-run UX bug: a user installs \`openobs\` from npm, runs it, has something else on \`:3000\` (often a previous \`openobs\` session), and gets:

\`\`\`
Error: listen EADDRINUSE: address already in use :::3000
    at Server.setupListenHandle [as _listen2] (node:net:2008:16)
    at listenInCluster (node:net:2065:12)
    at Server.listen (node:net:2170:7)
    at startServer (file:///opt/homebrew/lib/node_modules/openobs/dist/server.mjs:49124:14)
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:2044:8)
    ...
\`\`\`

Now they get:

\`\`\`
openobs: port 3000 is already in use.

  • Kill what's holding it:   lsof -ti :3000 | xargs kill
  • Or run on another port:   PORT=3001 openobs
\`\`\`

Same treatment for \`EACCES\` (binding a privileged port without permission). Other listen errors fall through to the existing structured \`log.fatal\` so ops still get the JSON line they expect.

## What changed
- [packages/api-gateway/src/server.ts](packages/api-gateway/src/server.ts) — attach an \`error\` handler on \`httpServer\` BEFORE \`listen()\`. Without this, Node emits the error on an unhandled event and crashes with the stack trace shown above.

## Why not just catch in main.ts
The existing \`startServer(port).catch(...)\` in [main.ts:40](packages/api-gateway/src/main.ts:40) doesn't catch listen errors because \`listen()\` returns synchronously and emits the error asynchronously on the server's \`error\` event. The promise resolves before the error fires. The handler has to be on the server itself.

## Test plan
- [ ] Start a placeholder on :3000 (\`python3 -m http.server 3000\`), run \`openobs\` — confirm the friendly message appears, no stack trace, exit code 1
- [ ] Confirm \`PORT=3001 openobs\` works as the message advertises
- [ ] (Linux box, optional) Try \`PORT=80 openobs\` as non-root — confirm the EACCES branch fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for the API Gateway server startup process with improved error messages for common failure scenarios. Now provides clear, user-friendly feedback when ports are unavailable or permissions are denied, with proper logging and graceful exit behavior to help users quickly resolve startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->