### PR TITLE
tool_search: parse name parts + OR scoring (48%→4% zero-hit)

### DIFF
--- a/packages/agent-core/src/agent/tool-search.test.ts
+++ b/packages/agent-core/src/agent/tool-search.test.ts
@@ -43,12 +43,20 @@ describe('searchTools — keyword search', () => {
     expect(result.map((d) => d.name).sort()).toEqual(['metrics_query', 'metrics_range_query']);
   });
 
-  it('requires every term to match', () => {
+  it('OR-matches any term and ranks tools matching MORE distinct terms first', () => {
+    // OR semantics: 'logs query' returns logs_query (matches both terms) FIRST,
+    // then metrics_query and metrics_range_query (each matches only "query").
+    // This is the regression fix — under the old AND semantics, only logs_query
+    // came back, hiding the metrics tools entirely.
     const result = searchTools('logs query', REGISTRY);
-    expect(result.map((d) => d.name)).toEqual(['logs_query']);
+    expect(result.map((d) => d.name)).toEqual([
+      'logs_query',           // matches both "logs" + "query" via name parts = 2 terms
+      'metrics_query',        // matches "query" via name parts = 1 term
+      'metrics_range_query',  // matches "query" via name parts = 1 term
+    ]);
   });
 
-  it('ranks name-hits above description-only hits', () => {
+  it('ranks name-hits above description-only hits when termsHit ties', () => {
     const result = searchTools('query', REGISTRY);
     // metrics_query, metrics_range_query, logs_query all hit name; alert_rule_list does not.
     expect(result.map((d) => d.name)).toEqual([
@@ -56,6 +64,39 @@ describe('searchTools — keyword search', () => {
       'metrics_query',
       'metrics_range_query',
     ]);
+  });
+
+  it('matches via tool-name parts even when the term is absent from the description', () => {
+    // The flagship regression case: 'complete investigation' should surface
+    // investigation_complete via name-part parsing. Under the old algorithm
+    // this returned 0 because "complete" appears in no description.
+    const investRegistry: Record<string, ToolDefinition> = {
+      investigation_create: def('investigation_create', 'Start a new investigation record.'),
+      investigation_complete: def('investigation_complete', 'Finalize the active investigation.'),
+      metrics_query: def('metrics_query', 'Run an instant PromQL query.'),
+    };
+    const result = searchTools('complete investigation', investRegistry);
+    // investigation_complete matches both "complete" (name part) and
+    // "investigation" (name part); investigation_create matches only one.
+    expect(result.map((d) => d.name)).toEqual([
+      'investigation_complete',
+      'investigation_create',
+    ]);
+  });
+
+  it('exact tool-name fast path returns just that tool', () => {
+    const result = searchTools('metrics_query', REGISTRY);
+    expect(result.map((d) => d.name)).toEqual(['metrics_query']);
+  });
+
+  it('word-boundary matching prevents false positives from substrings', () => {
+    const localRegistry: Record<string, ToolDefinition> = {
+      operate_thing: def('operate_thing', 'A tool that operates on something.'),
+      rate_limiter: def('rate_limiter', 'Limits the rate of requests.'),
+    };
+    // Term "rate" must NOT match "operate" via substring. Old algorithm did.
+    const result = searchTools('rate', localRegistry);
+    expect(result.map((d) => d.name)).toEqual(['rate_limiter']);
   });
 
   it('routes select: prefix to selectTools', () => {

--- a/packages/agent-core/src/agent/tool-search.ts
+++ b/packages/agent-core/src/agent/tool-search.ts
@@ -49,11 +49,71 @@ export function selectTools(
 }
 
 /**
- * Keyword search over tool names + descriptions. Splits the query on
- * whitespace; a tool matches when every term appears (case-insensitively)
- * in either its name or description. Results are ranked by name-match first,
- * then by how many terms hit, then alphabetically — deterministic so tests
- * can pin order.
+ * Split a tool name into searchable parts. `investigation_complete` →
+ * `["investigation", "complete"]`. CamelCase also gets split (e.g.
+ * `RangeQuery` → `["range", "query"]`) for parity with non-snake_case
+ * tool naming.
+ *
+ * Why this matters: without name-part parsing, a query like "complete
+ * investigation" returns nothing because the literal substring "complete"
+ * doesn't appear in any tool's description — even though
+ * `investigation_complete` is exactly the tool the model wants. Mirrors
+ * the approach Anthropic's claude-code takes in its server-side
+ * tool_search beta.
+ */
+function parseNameParts(name: string): string[] {
+  return name
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_.]/g, ' ')
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Pre-compile word-boundary regexes for description matching. Word
+ * boundaries (\b…\b) prevent false positives like the term "rate"
+ * matching tools whose descriptions mention "operate" — naive substring
+ * matching catches both, which inflates the result set with noise.
+ */
+function compileTermPatterns(terms: string[]): Map<string, RegExp> {
+  const patterns = new Map<string, RegExp>();
+  for (const term of terms) {
+    if (!patterns.has(term)) {
+      patterns.set(term, new RegExp(`\\b${escapeRegExp(term)}\\b`));
+    }
+  }
+  return patterns;
+}
+
+/**
+ * Keyword search over tool names + descriptions.
+ *
+ * Three improvements over the previous AND-substring algorithm — each
+ * justified by hit-rate measurement on real natural-language queries:
+ *
+ * 1. **Tool-name parsing.** `investigation_complete` is decomposed into
+ *    `["investigation", "complete"]` so a query "complete investigation"
+ *    hits BOTH name parts. Previously this returned 0 results because
+ *    "complete" was nowhere in any tool description.
+ * 2. **OR with score-based ranking.** A tool matches if ANY term hits
+ *    its name parts, full name, or description. Tools matching MORE
+ *    distinct terms — and matching them in higher-signal locations —
+ *    rank first. The MAX_RESULTS cap clips low-relevance noise.
+ * 3. **Word-boundary description matching.** The query term "rate"
+ *    only matches the word "rate" in a description, not "operate" or
+ *    "iterate".
+ *
+ * Plus an exact-name fast path: if the query is exactly a tool name
+ * (case-insensitive), skip scoring and return the tool directly.
+ *
+ * Empirical hit-rate (25 representative queries):
+ *   - Old AND-substring:           48% zero-hit
+ *   - This algorithm:              ~4% zero-hit (only genuinely-no-match queries)
  */
 export function searchTools(
   query: string,
@@ -71,34 +131,79 @@ export function searchTools(
     return selectTools(csv.split(','), registry);
   }
 
-  const terms = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+  const queryLower = trimmed.toLowerCase();
+
+  // Fast path: query is exactly a tool name. Handles models emitting a
+  // bare tool name as the query instead of using the `select:` prefix.
+  for (const def of Object.values(registry)) {
+    if (def.name.toLowerCase() === queryLower) return [def];
+  }
+
+  // Fast path 2: query is a tool-name prefix containing an underscore
+  // (e.g. "alert_rule" → match every alert_rule_* tool). The model often
+  // queries by family stem when it wants the whole group; without this
+  // the underscore-containing query is treated as one opaque token and
+  // misses everything.
+  if (queryLower.includes('_') && !queryLower.includes(' ')) {
+    const prefixMatches = Object.values(registry)
+      .filter((d) => d.name.toLowerCase().startsWith(queryLower))
+      .slice(0, MAX_RESULTS);
+    if (prefixMatches.length > 0) return prefixMatches;
+  }
+
+  const terms = queryLower.split(/\s+/).filter(Boolean);
   if (terms.length === 0) return [];
 
-  type Scored = { def: ToolDefinition; nameHits: number; descHits: number };
+  const termPatterns = compileTermPatterns(terms);
+
+  // Score weights — mirrors claude-code's tuning. Name-part exact match
+  // is the strongest signal (the model named the concept correctly);
+  // name-part prefix is weaker; description word-boundary hit is weakest.
+  // These constants only matter relative to each other.
+  const W_NAME_PART_EXACT = 10;
+  const W_NAME_PART_PREFIX = 5;
+  const W_DESC_WORD = 2;
+
+  type Scored = { def: ToolDefinition; score: number; termsHit: number };
   const scored: Scored[] = [];
 
   for (const def of Object.values(registry)) {
-    const name = def.name.toLowerCase();
-    const desc = def.description.toLowerCase();
-    let nameHits = 0;
-    let descHits = 0;
-    let allMatched = true;
+    const nameParts = parseNameParts(def.name);
+    const descLower = def.description.toLowerCase();
+    let score = 0;
+    let termsHit = 0;
     for (const term of terms) {
-      const inName = name.includes(term);
-      const inDesc = desc.includes(term);
-      if (!inName && !inDesc) {
-        allMatched = false;
-        break;
+      let termScored = false;
+      // Name-part match — strongest signal. Prefix-only (startsWith, not
+      // includes) so "rate" doesn't match the part "operate" via mid-word
+      // substring, while still letting "metric" match the part "metrics"
+      // via legit prefix. The full-name (joined) fallback is intentionally
+      // dropped — it would re-introduce mid-substring false positives via
+      // `name.includes(term)` and the model rarely queries the joined form.
+      if (nameParts.includes(term)) {
+        score += W_NAME_PART_EXACT;
+        termScored = true;
+      } else if (nameParts.some((p) => p.startsWith(term))) {
+        score += W_NAME_PART_PREFIX;
+        termScored = true;
       }
-      if (inName) nameHits++;
-      if (inDesc) descHits++;
+      // Description word-boundary match — separate add so a term can score
+      // both via name and description (rare but matters for ranking).
+      const pattern = termPatterns.get(term)!;
+      if (pattern.test(descLower)) {
+        score += W_DESC_WORD;
+        termScored = true;
+      }
+      if (termScored) termsHit++;
     }
-    if (allMatched) scored.push({ def, nameHits, descHits });
+    if (score > 0) scored.push({ def, score, termsHit });
   }
 
   scored.sort((a, b) => {
-    if (a.nameHits !== b.nameHits) return b.nameHits - a.nameHits;
-    if (a.descHits !== b.descHits) return b.descHits - a.descHits;
+    // Distinct-term coverage dominates so a tool matching 3 of 5 terms
+    // ranks above one matching 1 term across many places.
+    if (a.termsHit !== b.termsHit) return b.termsHit - a.termsHit;
+    if (a.score !== b.score) return b.score - a.score;
     return a.def.name.localeCompare(b.def.name);
   });
 

--- a/tests/scripts/measure-tool-search-hit-rate.ts
+++ b/tests/scripts/measure-tool-search-hit-rate.ts
@@ -1,0 +1,130 @@
+/**
+ * Static hit-rate analysis for tool_search.
+ *
+ * No LLM calls — runs realistic natural-language queries the model is
+ * likely to emit through the actual searchTools() logic (AND match,
+ * whitespace tokenization, case-insensitive substring on name+desc).
+ *
+ * Output: per-query hit count + sample matches. Aggregates the miss rate
+ * to size whether AND matching is actually the limiting factor for
+ * tool_search hit rate.
+ */
+import { TOOL_SCHEMAS } from '../../packages/agent-core/src/agent/tool-schema-registry.js';
+import { searchTools } from '../../packages/agent-core/src/agent/tool-search.js';
+
+// Queries grouped by what the model is plausibly looking for. Mix of:
+//  - exact tool-name fragments (should always hit)
+//  - natural-language phrasing matching tool description style
+//  - natural-language phrasing using user-vocabulary, NOT tool-vocabulary
+//  - investigation-flow queries where the model knows what it wants but
+//    not the exact tool name
+const QUERIES: { intent: string; query: string }[] = [
+  // --- Exact name fragments (sanity baseline, expect 1+) ---
+  { intent: 'load metrics_query by name fragment', query: 'metrics_query' },
+  { intent: 'load investigation tools by stem', query: 'investigation' },
+  { intent: 'load alert tools', query: 'alert_rule' },
+
+  // --- Natural-language, vocabulary aligned with descriptions ---
+  { intent: 'query metrics', query: 'query metrics' },
+  { intent: 'add panel to dashboard', query: 'add panel dashboard' },
+  { intent: 'list dashboards', query: 'list dashboard' },
+
+  // --- Natural-language, user vocabulary (latency / errors / cpu) ---
+  { intent: 'check latency', query: 'check latency' },
+  { intent: 'query metrics for http latency', query: 'query metrics for http latency' },
+  { intent: 'investigate error rate', query: 'investigate error rate' },
+  { intent: 'cpu usage query', query: 'cpu usage query' },
+
+  // --- Investigation-flow specific (the case the user is complaining about) ---
+  { intent: 'add a section to the investigation', query: 'add section investigation' },
+  { intent: 'finish or complete investigation', query: 'finish investigation' },
+  { intent: 'mark investigation as done', query: 'investigation done' },
+  { intent: 'write narrative to investigation', query: 'write narrative investigation' },
+
+  // --- Recent changes ---
+  { intent: 'find recent deploys', query: 'recent deploys' },
+  { intent: 'list recent changes', query: 'list recent changes' },
+  { intent: 'changes in the last hour', query: 'changes last hour' },
+
+  // --- Logs ---
+  { intent: 'search logs', query: 'search logs' },
+  { intent: 'query logs for errors', query: 'logs errors' },
+
+  // --- Range queries ---
+  { intent: 'range query over time', query: 'range query time' },
+  { intent: 'time series', query: 'time series' },
+
+  // --- Validation ---
+  { intent: 'validate a promql query', query: 'validate promql' },
+
+  // --- Web search (the second user complaint) ---
+  { intent: 'web search for redis exporter metrics', query: 'web search redis exporter' },
+  { intent: 'find best practices online', query: 'best practices online' },
+  { intent: 'lookup vendor documentation', query: 'lookup vendor documentation' },
+];
+
+interface Row {
+  intent: string;
+  query: string;
+  hitCount: number;
+  topHits: string[];
+}
+
+function run(): Row[] {
+  return QUERIES.map(({ intent, query }) => {
+    const matches = searchTools(query, TOOL_SCHEMAS);
+    return {
+      intent,
+      query,
+      hitCount: matches.length,
+      topHits: matches.slice(0, 3).map((m) => m.name),
+    };
+  });
+}
+
+function main(): void {
+  const rows = run();
+  console.log('=== tool_search hit-rate analysis ===\n');
+  console.log('Query strategy: AND of whitespace-split terms vs name + description (case-insensitive substring).\n');
+
+  const w = (s: string, n: number) => s.padEnd(n).slice(0, n);
+  console.log(w('Intent', 50) + w('Query', 45) + w('Hits', 6) + 'Top matches');
+  console.log('─'.repeat(120));
+
+  let zeros = 0;
+  let lows = 0; // 1-2 hits
+  for (const r of rows) {
+    const top = r.topHits.length > 0 ? r.topHits.join(', ') : '(none)';
+    console.log(w(r.intent, 50) + w(r.query, 45) + w(String(r.hitCount), 6) + top);
+    if (r.hitCount === 0) zeros++;
+    else if (r.hitCount <= 2) lows++;
+  }
+
+  console.log('\n=== Summary ===');
+  console.log(`Total queries: ${rows.length}`);
+  console.log(`Zero hits:     ${zeros}  (${((zeros / rows.length) * 100).toFixed(1)}%)`);
+  console.log(`1-2 hits:      ${lows}  (${((lows / rows.length) * 100).toFixed(1)}%)`);
+  console.log(`3+ hits:       ${rows.length - zeros - lows}  (${(((rows.length - zeros - lows) / rows.length) * 100).toFixed(1)}%)`);
+
+  // Single-term comparison: how would each query do with OR matching?
+  console.log('\n=== Counterfactual: same queries with OR matching (any term hits) ===');
+  const orHits = rows.map((r) => {
+    const terms = r.query.toLowerCase().split(/\s+/).filter(Boolean);
+    const matchCount = Object.values(TOOL_SCHEMAS).filter((def) => {
+      const name = def.name.toLowerCase();
+      const desc = def.description.toLowerCase();
+      return terms.some((t) => name.includes(t) || desc.includes(t));
+    }).length;
+    return { intent: r.intent, query: r.query, andHits: r.hitCount, orHits: matchCount };
+  });
+  let orZeros = 0;
+  for (const r of orHits) {
+    if (r.orHits === 0) orZeros++;
+    if (r.andHits === 0 && r.orHits > 0) {
+      console.log(`  AND=0 → OR=${r.orHits}: "${r.query}"`);
+    }
+  }
+  console.log(`OR strategy zero-hit rate: ${orZeros}  (${((orZeros / rows.length) * 100).toFixed(1)}%)`);
+}
+
+main();


### PR DESCRIPTION
## 概要
旧的 AND-substring 算法在自然语言 query 上 zero-hit 率 **48%**。本 PR 把 [packages/agent-core/src/agent/tool-search.ts](packages/agent-core/src/agent/tool-search.ts) 改成 **OR + 加权评分 + 工具名称分词**，借鉴 [claude-code 的 ToolSearchTool](https://github.com/anthropics/claude-code) 的核心做法。zero-hit 降到 **4%**。

## 实测对照
脚本：[tests/scripts/measure-tool-search-hit-rate.ts](tests/scripts/measure-tool-search-hit-rate.ts)（25 条代表性 query，纯静态、无 LLM）

| | Zero hits | 1-2 hits | 3+ hits |
|---|----:|----:|----:|
| 旧算法 (AND-substring) | **12 (48%)** | 8 (32%) | 5 (20%) |
| 本 PR | **1 (4%)** | 6 (24%) | 18 (72%) |

被解决的典型案例：
- `"finish investigation"` → 旧 0 hits；新 → \`investigation_complete\` + \`investigation_create\`
- `"complete investigation"` → 旧 0；新 → 同上
- `"query metrics for http latency"` → 旧 0；新 → \`metrics_query\`, \`metrics_range_query\`, \`metrics_validate\` ...
- `"alert_rule"` (家族前缀 query) → 旧 0；新 → 全部 \`alert_rule_*\`

## 改动
3 条算法改动，每条都对照 claude-code 的实现：

1. **工具名分词** ([parseNameParts](packages/agent-core/src/agent/tool-search.ts)) — \`investigation_complete\` 拆成 \`["investigation", "complete"]\`，term \"complete\" 直接命中。CamelCase + underscore 都拆。对应 claude-code 的 \`parseToolName()\`。
2. **OR + 加权评分** — 任一 term 命中就纳入候选，按 \`termsHit\`（命中的 term 数）→ score → 字典序 排序。权重：name-exact=10, name-prefix=5, desc-word=2。多 term 命中的工具排前面。停词（"for"/"the"）不会主导，因为只贡献单 term 单工具的低分。
3. **描述用 word-boundary 正则** (\\\\brate\\\\b) — \"rate\" 不会因为 substring 匹配到 \"operate\"。对应 claude-code 的 \`compileTermPatterns()\`。

加两条 fast path：
- **Exact name** — query 完全等于工具名，直接返回，跳过评分。
- **Underscore prefix** — query 含下划线无空格（如 \`alert_rule\`），返回所有以它开头的工具。

## 故意没做（留下个 PR）
**\`searchHint\` 字段**。claude-code 给每个工具一个 curated capability phrase（如 kubectl 工具的 hint = \`"list containers describe pods get logs"\`），覆盖词汇 mismatch 场景：\"check latency\" 这种用户用 SRE 词汇但工具用通用词汇（\`metrics_query\`）的 query。本 PR 后剩下的唯一 zero-hit 就是这一类（\`"check latency"\`）。加 \`searchHint\` 要动每个 registry entry，单独 PR 更聚焦。

## 没改 web_search 触发 (issue #2)
用户报告还有第二个问题：\"现在不会上网搜搜最佳实践了\"。本 PR 只解决 tool_search 命中率（issue #1）。web_search 是 always-on，不走 tool_search，不命中是 prompt 层问题（PR-3 [#161](https://github.com/openobs/openobs/pull/161) 加的 \`extendedPrompt\` 触发块在 \`# Tool Behaviors\` 段，被 200 行 \`# Examples\` 段压在后面，模型读起来像 reference 不像 directive）。下个 PR 把 web_search 强提示从 Tool Behaviors 段移到 \`# Doing Tasks\` 顶部的 Decision flow 里，提到祈使句的位置。

## 测试
- \`npx vitest run packages/agent-core\` — 189/189 通过
- 1 个旧测试断言 AND 行为（\"requires every term to match\"），重写为新的 OR-with-coverage 期待
- 3 个新测试：name-part 匹配、exact-name fast path、word-boundary false-positive 防护
- \`npx tsx tests/scripts/measure-tool-search-hit-rate.ts\` — 命中率脚本可重复跑验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool search with more flexible matching strategy and improved result ranking based on multiple search criteria.
  * Added fast-path matching for exact tool names and prefix-based queries.

* **Tests**
  * Expanded test coverage with regression tests validating search behavior, result ranking, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->