### PR TITLE
fix(ui): replace <datalist> model picker with filterable combobox

### DIFF
--- a/packages/web/src/components/ModelCombobox.tsx
+++ b/packages/web/src/components/ModelCombobox.tsx
@@ -115,6 +115,18 @@ export function ModelCombobox({
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
         className={inputClassName}
+        // Suppress browser password / contact / address autofill — this is a
+        // model-id picker, not a credential field. Chrome historically ignores
+        // bare `off` but respects "off" + a synthetic name; password managers
+        // (1Password, LastPass, Bitwarden) read the data-* hints.
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        name="model-id-picker"
+        data-1p-ignore="true"
+        data-lpignore="true"
+        data-form-type="other"
         aria-autocomplete="list"
         aria-expanded={open}
       />

--- a/packages/web/src/components/ModelCombobox.tsx
+++ b/packages/web/src/components/ModelCombobox.tsx
@@ -35,7 +35,10 @@ interface ModelComboboxProps {
   className?: string;
 }
 
-const MAX_VISIBLE_OPTIONS = 80;
+// No render cap — even 1000-row providers (the realistic worst case for
+// OpenRouter today is ~370) render fast enough as plain <li>. The user-
+// scrollable popup with overflow-auto is the right UX; capping silently
+// hides options below the cap and surprises users.
 
 export function ModelCombobox({
   value,
@@ -72,8 +75,8 @@ export function ModelCombobox({
   const q = value.trim().toLowerCase();
   const isExactMatch = q.length > 0 && options.some((o) => o.id.toLowerCase() === q);
   const filtered = q.length === 0 || isExactMatch
-    ? options.slice(0, MAX_VISIBLE_OPTIONS)
-    : options.filter((o) => o.id.toLowerCase().includes(q) || o.label.toLowerCase().includes(q)).slice(0, MAX_VISIBLE_OPTIONS);
+    ? options
+    : options.filter((o) => o.id.toLowerCase().includes(q) || o.label.toLowerCase().includes(q));
 
   function commit(next: string) {
     onChange(next);
@@ -117,7 +120,7 @@ export function ModelCombobox({
       />
       {open && filtered.length > 0 && (
         <ul
-          className="absolute z-20 mt-1 left-0 right-0 max-h-72 overflow-auto rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] shadow-lg text-sm"
+          className="absolute z-20 mt-1 left-0 right-0 max-h-96 overflow-auto rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] shadow-lg text-sm"
           role="listbox"
         >
           {filtered.map((opt, i) => (
@@ -142,9 +145,9 @@ export function ModelCombobox({
               )}
             </li>
           ))}
-          {filtered.length === MAX_VISIBLE_OPTIONS && (
-            <li className="px-3 py-1.5 text-xs text-tertiary border-t border-[var(--color-outline-variant)]/50">
-              Showing first {MAX_VISIBLE_OPTIONS} matches — type to narrow.
+          {filtered.length > 50 && (
+            <li className="px-3 py-1.5 text-xs text-tertiary border-t border-[var(--color-outline-variant)]/50 sticky bottom-0 bg-[var(--color-surface-high)]">
+              {filtered.length} options — type to narrow.
             </li>
           )}
         </ul>

--- a/packages/web/src/components/ModelCombobox.tsx
+++ b/packages/web/src/components/ModelCombobox.tsx
@@ -60,12 +60,18 @@ export function ModelCombobox({
     return () => document.removeEventListener('mousedown', onDocClick);
   }, [open]);
 
-  // Filter: case-insensitive substring on id + label. When input is
-  // empty, show all options (capped). Result is capped at
-  // MAX_VISIBLE_OPTIONS so a 370-item provider doesn't render a
-  // multi-thousand-pixel popup.
+  // Filter: case-insensitive substring on id + label. Two cases skip the
+  // filter and show all options (capped):
+  //   - empty input — first-time browse
+  //   - input value is EXACTLY a known option id — the user already picked
+  //     one and is opening the popup to switch. Without this, opening the
+  //     dropdown after a previous pick shows ONLY that option (the value
+  //     trivially matches itself), hiding the other 369 entries.
+  // Result is capped at MAX_VISIBLE_OPTIONS so a 370-item provider doesn't
+  // render a multi-thousand-pixel popup.
   const q = value.trim().toLowerCase();
-  const filtered = q.length === 0
+  const isExactMatch = q.length > 0 && options.some((o) => o.id.toLowerCase() === q);
+  const filtered = q.length === 0 || isExactMatch
     ? options.slice(0, MAX_VISIBLE_OPTIONS)
     : options.filter((o) => o.id.toLowerCase().includes(q) || o.label.toLowerCase().includes(q)).slice(0, MAX_VISIBLE_OPTIONS);
 

--- a/packages/web/src/components/ModelCombobox.tsx
+++ b/packages/web/src/components/ModelCombobox.tsx
@@ -1,0 +1,148 @@
+/**
+ * Filterable combobox for picking a model id.
+ *
+ * Replaces the old `<input list="...">`/`<datalist>` pattern, which
+ * silently breaks in Chrome when the option list grows past ~100
+ * entries (OpenRouter returns ~370 models). The native dropdown stops
+ * appearing — the user sees the ▼ glyph but clicking does nothing.
+ *
+ * This is a minimal controlled combobox: a free-text input with an
+ * absolutely-positioned filtered popup. Same interaction model as the
+ * old datalist (type to filter, click to pick, free-text fallback when
+ * the model id isn't in the list), but the popup renders independently
+ * of browser quirks.
+ *
+ * Keyboard:
+ *   - ↑/↓: move highlight
+ *   - Enter: select highlighted option
+ *   - Esc: close popup, keep current input value
+ */
+import { useEffect, useRef, useState } from 'react';
+
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+interface ModelComboboxProps {
+  value: string;
+  onChange: (next: string) => void;
+  options: ModelOption[];
+  placeholder?: string;
+  /** Tailwind classes applied to the wrapped <input>. */
+  inputClassName?: string;
+  /** Tailwind classes applied to the outer wrapper (controls popup positioning). */
+  className?: string;
+}
+
+const MAX_VISIBLE_OPTIONS = 80;
+
+export function ModelCombobox({
+  value,
+  onChange,
+  options,
+  placeholder,
+  inputClassName,
+  className,
+}: ModelComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Close when clicking outside the wrapper.
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  // Filter: case-insensitive substring on id + label. When input is
+  // empty, show all options (capped). Result is capped at
+  // MAX_VISIBLE_OPTIONS so a 370-item provider doesn't render a
+  // multi-thousand-pixel popup.
+  const q = value.trim().toLowerCase();
+  const filtered = q.length === 0
+    ? options.slice(0, MAX_VISIBLE_OPTIONS)
+    : options.filter((o) => o.id.toLowerCase().includes(q) || o.label.toLowerCase().includes(q)).slice(0, MAX_VISIBLE_OPTIONS);
+
+  function commit(next: string) {
+    onChange(next);
+    setOpen(false);
+    inputRef.current?.blur();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      setOpen(true);
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      setHighlight((h) => Math.min(filtered.length - 1, h + 1));
+      e.preventDefault();
+    } else if (e.key === 'ArrowUp') {
+      setHighlight((h) => Math.max(0, h - 1));
+      e.preventDefault();
+    } else if (e.key === 'Enter' && open && filtered[highlight]) {
+      commit(filtered[highlight].id);
+      e.preventDefault();
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={wrapperRef} className={`relative ${className ?? ''}`}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => { onChange(e.target.value); setOpen(true); setHighlight(0); }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        className={inputClassName}
+        aria-autocomplete="list"
+        aria-expanded={open}
+      />
+      {open && filtered.length > 0 && (
+        <ul
+          className="absolute z-20 mt-1 left-0 right-0 max-h-72 overflow-auto rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] shadow-lg text-sm"
+          role="listbox"
+        >
+          {filtered.map((opt, i) => (
+            <li
+              key={opt.id}
+              role="option"
+              aria-selected={i === highlight}
+              // mousedown not click — fires before input.blur, preventing the
+              // focus race that would close the popup before the click lands.
+              onMouseDown={(e) => { e.preventDefault(); commit(opt.id); }}
+              onMouseEnter={() => setHighlight(i)}
+              className={`px-3 py-1.5 cursor-pointer truncate ${
+                i === highlight
+                  ? 'bg-[var(--color-primary)]/10 text-[var(--color-on-surface)]'
+                  : 'text-[var(--color-on-surface)] hover:bg-[var(--color-surface)]'
+              }`}
+              title={opt.label}
+            >
+              <span className="font-mono">{opt.id}</span>
+              {opt.label && opt.label !== opt.id && (
+                <span className="ml-2 text-xs text-tertiary">{opt.label}</span>
+              )}
+            </li>
+          ))}
+          {filtered.length === MAX_VISIBLE_OPTIONS && (
+            <li className="px-3 py-1.5 text-xs text-tertiary border-t border-[var(--color-outline-variant)]/50">
+              Showing first {MAX_VISIBLE_OPTIONS} matches — type to narrow.
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import {
 } from '../api/ops-api.js';
 import { githubChangeSourcesApi, type GitHubChangeSource } from '../api/github-change-sources-api.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
+import { ModelCombobox } from '../components/ModelCombobox.js';
 import { datasourceUrlPlaceholder, llmBaseUrlPlaceholder } from '../constants/placeholders.js';
 import { DATASOURCE_TYPES, datasourceInfo } from '../constants/datasource-types.js';
 import { LLM_PROVIDERS } from './setup/types.js';
@@ -1265,16 +1266,14 @@ function LlmTab({ canWrite }: { canWrite: boolean }) {
       <div>
         <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Default Model</label>
         <div className="flex gap-2">
-          <input
-            list="llm-model-options"
+          <ModelCombobox
             value={config.model}
-            onChange={(e) => setConfig((prev) => ({ ...prev, model: e.target.value }))}
+            onChange={(next) => setConfig((prev) => ({ ...prev, model: next }))}
+            options={availableModels}
             placeholder="model id"
-            className={inputCls + ' flex-1'}
+            inputClassName={inputCls + ' w-full'}
+            className="flex-1 min-w-0"
           />
-          <datalist id="llm-model-options">
-            {availableModels.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
-          </datalist>
           {provider.supportsModelFetch && (
             <button type="button" onClick={() => void handleFetchModels()} disabled={fetchingModels || (provider.needsKey && !config.apiKey)} className={btnSecondary + ' whitespace-nowrap'}>
               {fetchingModels ? 'Loading...' : 'Fetch Models'}

--- a/packages/web/src/pages/setup/StepLlm.tsx
+++ b/packages/web/src/pages/setup/StepLlm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../api/client.js';
 import { llmBaseUrlPlaceholder } from '../../constants/placeholders.js';
+import { ModelCombobox } from '../../components/ModelCombobox.js';
 import { LLM_PROVIDERS } from './types.js';
 import type { LlmConfig, ModelInfo } from './types.js';
 
@@ -266,20 +267,14 @@ export function StepLlm({
         <div>
           <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Default Model</label>
           <div className="flex gap-2 items-stretch min-w-0">
-            <input
-              list="step-llm-model-options"
+            <ModelCombobox
               value={config.model}
-              onChange={(e) => onChange({ model: e.target.value })}
+              onChange={(next) => onChange({ model: next })}
+              options={availableModels}
               placeholder="model id"
-              className="flex-1 min-w-0 w-full px-3 py-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 focus:border-[var(--color-primary)] truncate"
+              inputClassName="w-full px-3 py-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 focus:border-[var(--color-primary)] truncate"
+              className="flex-1 min-w-0"
             />
-            <datalist id="step-llm-model-options">
-              {availableModels.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.label}
-                </option>
-              ))}
-            </datalist>
             {provider.supportsModelFetch && (
               <button
                 type="button"


### PR DESCRIPTION
## Bug
\`Default Model\` 选择器（[Settings.tsx](packages/web/src/pages/Settings.tsx) + [setup/StepLlm.tsx](packages/web/src/pages/setup/StepLlm.tsx)）用的是 HTML5 \`<input list>\` + \`<datalist>\`。Chrome 在 datalist option 数量超过 ~100 时会**静默 drop dropdown** — 用户看到 ▼ glyph 但点击没反应。OpenRouter 有 ~370 model，这个 picker 实际不可用。

用户报告截图显示 "Found 368 models from provider" 但下拉打不开。

## Fix
最小受控 combobox：input + 绝对定位 filtered popup。交互模型保持一样（type 过滤、click 选择、不在 list 里也能输入 free-text），但 render 走 React 不受浏览器 datalist 性能 quirk 影响。

- **新增** [packages/web/src/components/ModelCombobox.tsx](packages/web/src/components/ModelCombobox.tsx) — 通用组件
  - 过滤结果 cap 在 \`MAX_VISIBLE_OPTIONS = 80\`，超过显示 "type to narrow" hint
  - 键盘：↑/↓ 导航、Enter 选中、Esc 关闭
  - Click-outside 自动关闭
  - \`onMouseDown\` 而非 \`onClick\` 避免 input.blur 竞争 race（那会导致 click 还没生效 popup 就关了）
- **改** [Settings.tsx:1265](packages/web/src/pages/Settings.tsx) — 替换 datalist 为 \`<ModelCombobox>\`，Fetch Models 按钮位置/行为不变
- **改** [setup/StepLlm.tsx:266](packages/web/src/pages/setup/StepLlm.tsx) — 同样替换

## Test plan
- [ ] Setup wizard：选 OpenRouter provider + 输入 key + Fetch Models → confirm 下拉显示 ~370 models, 能滚动 + 能点选
- [ ] 选完后 free-text 编辑 input value 也能正常工作（保持原 datalist 的"半受控"行为）
- [ ] Settings 页面同样验证
- [ ] 键盘：↑↓ 高亮、Enter 选中、Esc 关闭
- [ ] Provider 切换时 popup 不应漂移

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filterable, case-insensitive, keyboard- and mouse-navigable model selection combobox with Enter-to-select, Escape-to-close, and click-out dismissal; shows a “type to narrow” hint when many matches.

* **Refactor**
  * Replaced free-text model pickers in Settings and setup flows with the new combobox for a consistent, improved model selection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->