### PR TITLE
refactor(viz): unified responsive panel layout (replaces 3 sizing systems)

### DIFF
--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -1146,10 +1146,18 @@ function LegendLayer({
             style={{
               // Each item declares its own min-width so flex-wrap lays them
               // out as tidy columns at narrow widths instead of jagged rows.
-              flex: '1 1 220px',
-              minWidth: 220,
+              // Reduced 220→160 so a single CJK series name (~50px) plus one
+              // stat ("Mean: 133.16 req/s" ~110px) fits without ellipsis at
+              // ~300px panel widths.
+              flex: '1 1 160px',
+              minWidth: 0,
               maxWidth: '100%',
               display: 'inline-flex',
+              // Wrap items inside the button so a too-narrow container moves
+              // the stat onto a second line under the name instead of
+              // squeezing the name to ellipsis. CJK names are ~2× the px-per-
+              // glyph of Latin so the squeeze hits non-Latin labels hard.
+              flexWrap: 'wrap',
               alignItems: 'center',
               gap: 8,
               padding: '2px 4px',
@@ -1176,11 +1184,13 @@ function LegendLayer({
             />
             <span
               style={{
-                flex: 1,
+                flex: '1 1 auto',
                 minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
+                // No ellipsis — the wrap on the parent button lets the stats
+                // drop to a second line so the name can stay whole. Allow
+                // CJK / long labels to wrap as a last resort instead of
+                // truncating mid-character.
+                overflowWrap: 'anywhere',
               }}
             >
               {meta.displayName}

--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -1027,6 +1027,10 @@ const LEGEND_CONTAINER_STYLE: CSSProperties = {
   maxHeight: '33%',
   overflowY: 'auto',
   flexShrink: 0,
+  // Match the chart's left/right gutter so the legend doesn't visually
+  // butt up against the panel edge. The table mode in particular had
+  // its color swatch column sitting at x=0 with no breathing room.
+  paddingInline: 8,
 };
 
 function pickStat(meta: SeriesMeta, stat: LegendStat): number | null {

--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -47,6 +47,12 @@ import {
   type StackingMode,
 } from '../../lib/uplot/index.js';
 import { getSeriesColor, getSeriesColorByKey, VIZ_TOKENS } from '../../lib/theme/index.js';
+import {
+  decideLegendLayout,
+  usePanelLayout,
+  type LegendLayoutDecision,
+  type PanelLayout,
+} from '../../lib/viz/usePanelLayout.js';
 import type { LegendPlacement, LegendStat } from '../panel/types.js';
 
 // ---------------------------------------------------------------------------
@@ -661,28 +667,21 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
         .map(({ m }) => m)
     : metas;
   const statColumns = effectiveLegendStats?.length ?? 0;
-  const wideForList = metas.length > 6 || (metas.length >= 2 && statColumns >= 2);
-  const effectiveLegendMode: 'list' | 'table' =
-    legend === 'list' && wideForList ? 'table' : (legend as 'list' | 'table');
 
-  // Height-aware legend gating — when the panel is too short, the legend
-  // eats most of the space and the chart becomes unreadable. Hide it under
-  // the threshold; users on a small panel almost always know which series
-  // they're looking at from the title alone.
-  const [containerHeight, setContainerHeight] = useState(0);
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver((entries) => {
-      const h = entries[0]?.contentRect.height ?? 0;
-      setContainerHeight((prev) => (prev === h ? prev : h));
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-  const tooShortForLegend = containerHeight > 0 && containerHeight < 180;
-
-  const showLegend = legend !== 'hidden' && metas.length > 0 && !tooShortForLegend;
+  // Single source of truth for sizing. `usePanelLayout` owns the
+  // ResizeObserver and projects width/height to a size class; the
+  // `decideLegendLayout` pure function maps that + series shape to a
+  // concrete legend mode (list / table / stacked / hidden) plus
+  // basis. Everything below reads from `legendDecision` — no scattered
+  // breakpoints / magic-number widths in this file anymore.
+  const panelLayout = usePanelLayout(containerRef);
+  const legendDecision = decideLegendLayout(
+    panelLayout,
+    metas.length,
+    statColumns,
+    legend,
+  );
+  const showLegend = legendDecision.mode !== 'hidden';
 
   // -- Render ----------------------------------------------------------------
 
@@ -721,6 +720,7 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
           hidden={hidden}
           unit={unit}
           containerRef={containerRef}
+          maxWidth={panelLayout.tooltipMaxWidth}
         />
       )}
 
@@ -730,7 +730,7 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
             metas={visibleMetas}
             hidden={hidden}
             onToggle={toggleSeries}
-            mode={effectiveLegendMode}
+            decision={legendDecision}
             unit={unit}
             stats={effectiveLegendStats}
           />
@@ -861,9 +861,12 @@ interface TooltipLayerProps {
   hidden: Record<string, boolean>;
   unit: string | undefined;
   containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Container-driven max width — narrow panels get a tighter cap so
+   *  the tooltip doesn't overflow visually past the chart edge. */
+  maxWidth: number;
 }
 
-function TooltipLayer({ tooltip, xs, metas, hidden, unit, containerRef }: TooltipLayerProps): JSX.Element {
+function TooltipLayer({ tooltip, xs, metas, hidden, unit, containerRef, maxWidth }: TooltipLayerProps): JSX.Element {
   const ts = xs[tooltip.idx];
   const timeLabel =
     typeof ts === 'number'
@@ -914,8 +917,8 @@ function TooltipLayer({ tooltip, xs, metas, hidden, unit, containerRef }: Toolti
           borderRadius: VIZ_TOKENS.tooltip.borderRadius,
           fontSize: VIZ_TOKENS.tooltip.fontSize,
           padding: '6px 8px',
-          minWidth: 160,
-          maxWidth: 320,
+          minWidth: Math.min(160, maxWidth),
+          maxWidth,
           color: 'var(--color-on-surface)',
           // Soft drop-shadow. Kept at low alpha so it lands readably on both
           // dark (subtle lift off panel) and light (halo around tooltip).
@@ -993,9 +996,11 @@ interface LegendLayerProps {
   metas: SeriesMeta[];
   hidden: Record<string, boolean>;
   onToggle: (name: string) => void;
-  mode: 'list' | 'table';
+  /** Resolved layout decision from `decideLegendLayout`. Carries the
+   *  mode (list / table / stacked) and any layout knobs (basis). */
+  decision: LegendLayoutDecision;
   unit: string | undefined;
-  /** Inline stats per legend entry (list) or columns (table). */
+  /** Inline stats per legend entry (list / stacked) or columns (table). */
   stats?: LegendStat[];
 }
 
@@ -1032,10 +1037,14 @@ function LegendLayer({
   metas,
   hidden,
   onToggle,
-  mode,
+  decision,
   unit,
   stats,
-}: LegendLayerProps): JSX.Element {
+}: LegendLayerProps): JSX.Element | null {
+  const { mode, itemBasis } = decision;
+
+  if (mode === 'hidden') return null;
+
   if (mode === 'table') {
     // Preserve previous behavior when caller didn't specify which columns to
     // show: render all four. When specified, honor the order/subset.
@@ -1098,7 +1107,12 @@ function LegendLayer({
                     style={{
                       textAlign: 'left',
                       padding: '2px 6px',
-                      maxWidth: 320,
+                      // Bound by `maxWidth: 0 + width: 100%` trick so the
+                      // cell shrinks with the table column rather than
+                      // hardcoding a pixel cap. Long labels ellipsis;
+                      // tooltip-on-hover still gives the full text.
+                      maxWidth: 0,
+                      width: '100%',
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
@@ -1121,10 +1135,99 @@ function LegendLayer({
     );
   }
 
-  // mode === 'list'
   // Default to `['last']` to preserve the pre-T-022 single-value look.
   const inlineStats: LegendStat[] = stats && stats.length > 0 ? stats : ['last'];
 
+  // Stacked mode — narrow panels (< 300 px). Series name owns the first
+  // row at full width so CJK / long labels never truncate; stats drop to
+  // a second row indented to the swatch column. This is what every
+  // mature charting lib does at narrow widths (Grafana, Datadog, etc.).
+  if (mode === 'stacked') {
+    return (
+      <div
+        style={{
+          ...LEGEND_CONTAINER_STYLE,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 6,
+          fontSize: 12,
+          color: 'var(--color-on-surface)',
+        }}
+      >
+        {metas.map((meta) => {
+          const isHidden = !!hidden[meta.displayName];
+          return (
+            <button
+              key={meta.displayName}
+              type="button"
+              onClick={() => onToggle(meta.displayName)}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'stretch',
+                gap: 2,
+                padding: '2px 4px',
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                opacity: isHidden ? 0.35 : 1,
+                color: 'inherit',
+                font: 'inherit',
+                textAlign: 'left',
+                width: '100%',
+              }}
+              title={meta.displayName}
+            >
+              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span
+                  aria-hidden
+                  style={{
+                    display: 'inline-block',
+                    width: 10,
+                    height: 10,
+                    borderRadius: 2,
+                    background: meta.color,
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ overflowWrap: 'anywhere', minWidth: 0 }}>
+                  {meta.displayName}
+                </span>
+              </span>
+              <span
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '0 12px',
+                  // Indent under the swatch column so the stats line up
+                  // with the series name, not the swatch itself.
+                  paddingLeft: 18,
+                  fontSize: 11,
+                  color: 'var(--color-on-surface-variant)',
+                }}
+              >
+                {inlineStats.map((stat) => (
+                  <LegendStatChip
+                    key={stat}
+                    stat={stat}
+                    value={pickStat(meta, stat)}
+                    unit={unit}
+                    showLabel={inlineStats.length > 1 || stat !== 'last'}
+                  />
+                ))}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // mode === 'list' (medium / wide). itemBasis comes from layout
+  // decision: 140 on medium, 220 on wide. minWidth: 0 lets ellipsis
+  // kick in when the name genuinely doesn't fit; this is fine in list
+  // mode because there's enough horizontal room. Stacked mode catches
+  // the CJK truncation case before we get here.
   return (
     <div
       style={{
@@ -1144,20 +1247,10 @@ function LegendLayer({
             type="button"
             onClick={() => onToggle(meta.displayName)}
             style={{
-              // Each item declares its own min-width so flex-wrap lays them
-              // out as tidy columns at narrow widths instead of jagged rows.
-              // Reduced 220→160 so a single CJK series name (~50px) plus one
-              // stat ("Mean: 133.16 req/s" ~110px) fits without ellipsis at
-              // ~300px panel widths.
-              flex: '1 1 160px',
+              flex: `1 1 ${itemBasis}px`,
               minWidth: 0,
               maxWidth: '100%',
               display: 'inline-flex',
-              // Wrap items inside the button so a too-narrow container moves
-              // the stat onto a second line under the name instead of
-              // squeezing the name to ellipsis. CJK names are ~2× the px-per-
-              // glyph of Latin so the squeeze hits non-Latin labels hard.
-              flexWrap: 'wrap',
               alignItems: 'center',
               gap: 8,
               padding: '2px 4px',
@@ -1184,58 +1277,75 @@ function LegendLayer({
             />
             <span
               style={{
-                flex: '1 1 auto',
+                flex: 1,
                 minWidth: 0,
-                // No ellipsis — the wrap on the parent button lets the stats
-                // drop to a second line so the name can stay whole. Allow
-                // CJK / long labels to wrap as a last resort instead of
-                // truncating mid-character.
-                overflowWrap: 'anywhere',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               }}
             >
               {meta.displayName}
             </span>
             {inlineStats.map((stat, idx) => (
-              <span
+              <LegendStatChip
                 key={stat}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'baseline',
-                  gap: 4,
-                  // ~16px between stat columns; first stat sits closer to the
-                  // name (the parent's gap of 8px provides that).
-                  marginLeft: idx === 0 ? 0 : 8,
-                  flexShrink: 0,
-                }}
-              >
-                {inlineStats.length > 1 && (
-                  <span
-                    style={{
-                      fontSize: 11,
-                      color: 'var(--color-on-surface-variant)',
-                    }}
-                  >
-                    {STAT_LABELS[stat]}:
-                  </span>
-                )}
-                <span
-                  style={{
-                    fontFamily: MONO_FONT,
-                    fontVariantNumeric: 'tabular-nums',
-                    color:
-                      inlineStats.length > 1
-                        ? 'var(--color-on-surface)'
-                        : 'var(--color-on-surface-variant)',
-                  }}
-                >
-                  {formatValueForDisplay(pickStat(meta, stat), unit)}
-                </span>
-              </span>
+                stat={stat}
+                value={pickStat(meta, stat)}
+                unit={unit}
+                showLabel={inlineStats.length > 1}
+                marginLeft={idx === 0 ? 0 : 8}
+              />
             ))}
           </button>
         );
       })}
     </div>
+  );
+}
+
+/**
+ * One stat reading inside a legend item. Shared between list and
+ * stacked modes. Pulled out so both modes render numbers identically:
+ * monospace, tabular-nums, optional `Mean:` label prefix.
+ */
+function LegendStatChip({
+  stat,
+  value,
+  unit,
+  showLabel,
+  marginLeft,
+}: {
+  stat: LegendStat;
+  value: number | null;
+  unit: string | undefined;
+  showLabel: boolean;
+  marginLeft?: number;
+}): JSX.Element {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'baseline',
+        gap: 4,
+        marginLeft: marginLeft ?? 0,
+        flexShrink: 0,
+      }}
+    >
+      {showLabel && (
+        <span style={{ fontSize: 11, color: 'var(--color-on-surface-variant)' }}>
+          {STAT_LABELS[stat]}:
+        </span>
+      )}
+      <span
+        style={{
+          fontFamily: MONO_FONT,
+          fontVariantNumeric: 'tabular-nums',
+          color: showLabel ? 'var(--color-on-surface)' : 'var(--color-on-surface-variant)',
+        }}
+      >
+        {formatValueForDisplay(value, unit)}
+      </span>
+    </span>
   );
 }
 

--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -1122,7 +1122,16 @@ function LegendLayer({
                     {meta.displayName}
                   </td>
                   {columns.map((col) => (
-                    <td key={col} style={{ padding: '2px 6px', fontFamily: MONO_FONT }}>
+                    <td
+                      key={col}
+                      style={{
+                        padding: '2px 6px',
+                        fontFamily: MONO_FONT,
+                        // Without nowrap the cell wraps "44 ms" to two
+                        // lines when the name column eats the row width.
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
                       {formatValueForDisplay(pickStat(meta, col), unit)}
                     </td>
                   ))}

--- a/packages/web/src/lib/uplot/config-builder.ts
+++ b/packages/web/src/lib/uplot/config-builder.ts
@@ -373,6 +373,21 @@ export class UPlotConfigBuilder {
           const out = yFormatter(v, undefined);
           return `${out.prefix ?? ''}${out.text}${out.suffix ?? ''}`;
         })) as unknown as uPlot.Axis.Values,
+      // Dynamic gutter sizing — uPlot's default 50px is too narrow for labels
+      // like "180 req/s" or "1.50 GiB" and clips the leading digit. Compute
+      // width from the longest formatted tick label per render. Capped 50-140
+      // so a single huge value (e.g. an outlier with many digits) can't blow
+      // up the chart, and short labels stay compact.
+      size: (_u, values) => {
+        if (!Array.isArray(values) || values.length === 0) return 50;
+        let maxLen = 0;
+        for (const v of values) {
+          const s = String(v ?? '');
+          if (s.length > maxLen) maxLen = s.length;
+        }
+        // ~7 px per char at the 12px sans-serif we use, plus 16px tick + pad.
+        return Math.max(50, Math.min(140, maxLen * 7 + 16));
+      },
     };
 
     // T-203 — log scale auto-suggest. If the non-zero value range spans

--- a/packages/web/src/lib/viz/usePanelLayout.test.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for decideLegendLayout — the pure decision function that
+ * encodes every legend / sizing breakpoint in one place.
+ *
+ * The hook itself (`usePanelLayout`) is a ~10-line ResizeObserver
+ * wrapper around `setSize`; we don't unit-test it because (a) the repo
+ * doesn't pull in `@testing-library/react` and (b) the only logic in
+ * the hook beyond bookkeeping is the size→sizeClass projection, which
+ * is exercised here by feeding the projection's outputs into
+ * `decideLegendLayout`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decideLegendLayout, type PanelLayout } from './usePanelLayout.js';
+
+function makeLayout(over: Partial<PanelLayout>): PanelLayout {
+  return {
+    width: 800,
+    height: 300,
+    sizeClass: 'wide',
+    tooltipMaxWidth: 320,
+    ...over,
+  };
+}
+
+describe('decideLegendLayout — narrow', () => {
+  it('forces stacked mode regardless of series count', () => {
+    const layout = makeLayout({ width: 250, sizeClass: 'narrow' });
+    const d = decideLegendLayout(layout, 1, 1, 'list');
+    expect(d.mode).toBe('stacked');
+  });
+
+  it('still hides when height < 180 even on narrow', () => {
+    const layout = makeLayout({ width: 250, height: 120, sizeClass: 'narrow' });
+    const d = decideLegendLayout(layout, 1, 1, 'list');
+    expect(d.mode).toBe('hidden');
+  });
+
+  it('respects requested=hidden over stacked', () => {
+    const layout = makeLayout({ width: 250, sizeClass: 'narrow' });
+    const d = decideLegendLayout(layout, 5, 2, 'hidden');
+    expect(d.mode).toBe('hidden');
+  });
+});
+
+describe('decideLegendLayout — medium', () => {
+  it('returns list mode with basis 140', () => {
+    const layout = makeLayout({ width: 400, sizeClass: 'medium' });
+    const d = decideLegendLayout(layout, 1, 1, 'list');
+    expect(d.mode).toBe('list');
+    expect(d.itemBasis).toBe(140);
+  });
+
+  it('upgrades to table when multi-series × multi-stat would crowd a row', () => {
+    const layout = makeLayout({ width: 400, sizeClass: 'medium' });
+    const d = decideLegendLayout(layout, 3, 3, 'list');
+    expect(d.mode).toBe('table');
+  });
+
+  it('upgrades to table when more than 6 series', () => {
+    const layout = makeLayout({ width: 400, sizeClass: 'medium' });
+    const d = decideLegendLayout(layout, 8, 1, 'list');
+    expect(d.mode).toBe('table');
+  });
+});
+
+describe('decideLegendLayout — wide', () => {
+  it('returns list mode with basis 220', () => {
+    const layout = makeLayout({ width: 800, sizeClass: 'wide' });
+    const d = decideLegendLayout(layout, 1, 1, 'list');
+    expect(d.mode).toBe('list');
+    expect(d.itemBasis).toBe(220);
+  });
+
+  it('honors requested=table even on wide with few series', () => {
+    const layout = makeLayout({ width: 800, sizeClass: 'wide' });
+    const d = decideLegendLayout(layout, 1, 1, 'table');
+    expect(d.mode).toBe('table');
+  });
+
+  it('upgrades to table on multi-series × multi-stat regardless of width', () => {
+    const layout = makeLayout({ width: 800, sizeClass: 'wide' });
+    const d = decideLegendLayout(layout, 4, 4, 'list');
+    expect(d.mode).toBe('table');
+  });
+});
+
+describe('decideLegendLayout — degenerate inputs', () => {
+  it('returns hidden for zero series', () => {
+    const layout = makeLayout({ width: 800 });
+    const d = decideLegendLayout(layout, 0, 0, 'list');
+    expect(d.mode).toBe('hidden');
+  });
+
+  it('itemBasis is 0 in non-list modes', () => {
+    const narrow = makeLayout({ width: 250, sizeClass: 'narrow' });
+    expect(decideLegendLayout(narrow, 1, 1, 'list').itemBasis).toBe(0);
+    const tableForceHigh = makeLayout({ width: 800 });
+    expect(decideLegendLayout(tableForceHigh, 8, 2, 'list').itemBasis).toBe(0);
+  });
+
+  it('treats height=0 (pre-measurement) as "not too short" — show legend', () => {
+    // Initial render, ResizeObserver hasn't fired yet → height: 0. We
+    // shouldn't blanket-hide the legend; the gate is height > 0 && height < 180.
+    const layout = makeLayout({ width: 800, height: 0 });
+    const d = decideLegendLayout(layout, 1, 1, 'list');
+    expect(d.mode).toBe('list');
+  });
+});

--- a/packages/web/src/lib/viz/usePanelLayout.test.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.test.ts
@@ -44,16 +44,20 @@ describe('decideLegendLayout — narrow', () => {
 });
 
 describe('decideLegendLayout — medium', () => {
-  it('returns list mode with basis 140', () => {
+  it('returns list mode with basis 140 for single series × single stat', () => {
     const layout = makeLayout({ width: 400, sizeClass: 'medium' });
     const d = decideLegendLayout(layout, 1, 1, 'list');
     expect(d.mode).toBe('list');
     expect(d.itemBasis).toBe(140);
   });
 
-  it('upgrades to table when multi-series × multi-stat would crowd a row', () => {
+  it('upgrades to table on multi-stat regardless of series count', () => {
+    // Regression: previous trigger required `series >= 2 && stat >= 2`,
+    // so single-series + 3-stat (default) ran in list mode and the
+    // ~400px of stats squeezed the name to ellipsis. Threshold now
+    // also fires on `stat >= 2` alone.
     const layout = makeLayout({ width: 400, sizeClass: 'medium' });
-    const d = decideLegendLayout(layout, 3, 3, 'list');
+    const d = decideLegendLayout(layout, 1, 3, 'list');
     expect(d.mode).toBe('table');
   });
 
@@ -78,9 +82,9 @@ describe('decideLegendLayout — wide', () => {
     expect(d.mode).toBe('table');
   });
 
-  it('upgrades to table on multi-series × multi-stat regardless of width', () => {
+  it('upgrades to table on multi-stat regardless of width', () => {
     const layout = makeLayout({ width: 800, sizeClass: 'wide' });
-    const d = decideLegendLayout(layout, 4, 4, 'list');
+    const d = decideLegendLayout(layout, 1, 3, 'list');
     expect(d.mode).toBe('table');
   });
 });

--- a/packages/web/src/lib/viz/usePanelLayout.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.ts
@@ -135,7 +135,6 @@ export function usePanelLayout(
     });
     ro.observe(el);
     return () => ro.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref]);
 
   const sizeClass: PanelSizeClass =

--- a/packages/web/src/lib/viz/usePanelLayout.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.ts
@@ -91,10 +91,13 @@ export function decideLegendLayout(
     return { mode: 'stacked', itemBasis: 0 };
   }
 
-  // Inline list overflows when each row carries multiple stat columns
-  // across multiple series — table mode aligns the stats into proper
-  // columns instead of letting them wrap raggedly.
-  if (requested === 'table' || seriesCount > 6 || (seriesCount >= 2 && statCount >= 2)) {
+  // Inline list overflows when each row carries multiple stat columns,
+  // regardless of series count. A single series × 3 stats ("Mean: …
+  // Max: … Last: …") is already ~400 CSS px of fixed-width content
+  // before the name even starts; in any panel below ~700 px the name
+  // gets squeezed to zero. Table mode aligns the stats into proper
+  // columns and lets the name reflow under its own column.
+  if (requested === 'table' || seriesCount > 6 || statCount >= 2) {
     return { mode: 'table', itemBasis: 0 };
   }
 

--- a/packages/web/src/lib/viz/usePanelLayout.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.ts
@@ -1,0 +1,154 @@
+/**
+ * Single source of truth for responsive panel layout.
+ *
+ * Why this exists:
+ *   Before this hook, layout magic numbers were scattered across the
+ *   visualization tree — `flex: '1 1 220px'` in legend items, `maxWidth: 320`
+ *   on tooltip, `containerHeight < 180` for the legend hide threshold,
+ *   uPlot y-axis gutter at uPlot's default 50px. None of these talked to
+ *   each other. CJK labels (~12 px/glyph vs Latin ~7) blew through every
+ *   width assumption silently — a Chinese series name "请求速率" rendered
+ *   as just "请" on a narrow panel because the legend item enforced a
+ *   minWidth of 220 with stats `flexShrink: 0` eating the remaining space.
+ *
+ * What it does:
+ *   ResizeObserver-driven measurement of the panel container, plus a
+ *   pure decision function that maps (width, height, seriesCount,
+ *   statCount, requestedMode) → a complete `PanelLayout` describing every
+ *   size knob in one place. Visualizations consume the layout; nothing
+ *   downstream contains hardcoded breakpoint thresholds.
+ *
+ * Size classes:
+ *   - narrow  (< 300 px wide):    legend stacks (name on one row, stats
+ *                                  beneath) so CJK / long names stay whole.
+ *                                  Tooltip caps at 200 px.
+ *   - medium  (300–599 px):       inline list legend, basis 140 px so a
+ *                                  single CJK name + one stat fits without
+ *                                  ellipsis. Tooltip caps at 240 px.
+ *   - wide    (>= 600 px):        full legend (table when multi-stat ×
+ *                                  multi-series, list otherwise), basis
+ *                                  220 px. Tooltip caps at 320 px.
+ *
+ *   Below 180 px height, legend hides regardless of width — the chart
+ *   itself becomes unreadable when the legend eats half the panel.
+ */
+import { useEffect, useState, type RefObject } from 'react';
+
+export type PanelSizeClass = 'narrow' | 'medium' | 'wide';
+export type LegendMode = 'hidden' | 'stacked' | 'list' | 'table';
+
+const NARROW_MAX_WIDTH = 300;
+const WIDE_MIN_WIDTH = 600;
+const MIN_HEIGHT_FOR_LEGEND = 180;
+
+export interface PanelLayout {
+  /** Container width in CSS px. 0 until first ResizeObserver fire. */
+  width: number;
+  /** Container height in CSS px. 0 until first ResizeObserver fire. */
+  height: number;
+  sizeClass: PanelSizeClass;
+  /** Tooltip max width — caps at the container minus a 16 px safety margin
+   *  so a tooltip near the right edge doesn't visually overflow. */
+  tooltipMaxWidth: number;
+}
+
+export interface LegendLayoutDecision {
+  mode: LegendMode;
+  /** Flex-basis (CSS px) for each list-mode legend item. Inline list mode
+   *  only — table mode lays out columns via the table itself, stacked mode
+   *  uses block layout. */
+  itemBasis: number;
+}
+
+/**
+ * Pure decision function — given measured layout + series shape +
+ * caller's requested mode, return the legend layout to render.
+ *
+ * `requested` is the mode the caller would prefer; we override to
+ * `stacked` on narrow containers, to `hidden` on too-short panels, and
+ * to `table` when an inline list would clip with multi-stat ×
+ * multi-series rows. Returning a single object means callers don't
+ * branch on size class themselves — they read `layout.legend.mode`.
+ */
+export function decideLegendLayout(
+  layout: PanelLayout,
+  seriesCount: number,
+  statCount: number,
+  requested: 'list' | 'table' | 'hidden',
+): LegendLayoutDecision {
+  if (requested === 'hidden' || seriesCount === 0) {
+    return { mode: 'hidden', itemBasis: 0 };
+  }
+
+  if (layout.height > 0 && layout.height < MIN_HEIGHT_FOR_LEGEND) {
+    return { mode: 'hidden', itemBasis: 0 };
+  }
+
+  // Narrow containers cannot fit name + stats inline without truncating
+  // CJK labels. Switch to stacked: name owns the first row, stats own
+  // the second. Width-only check; even a tall narrow panel benefits.
+  if (layout.sizeClass === 'narrow') {
+    return { mode: 'stacked', itemBasis: 0 };
+  }
+
+  // Inline list overflows when each row carries multiple stat columns
+  // across multiple series — table mode aligns the stats into proper
+  // columns instead of letting them wrap raggedly.
+  if (requested === 'table' || seriesCount > 6 || (seriesCount >= 2 && statCount >= 2)) {
+    return { mode: 'table', itemBasis: 0 };
+  }
+
+  // Wide gets a roomier basis so series-rich panels read as a tidy
+  // multi-column grid; medium goes tighter so a single CJK name + one
+  // stat fits in one row.
+  const itemBasis = layout.sizeClass === 'wide' ? 220 : 140;
+  return { mode: 'list', itemBasis };
+}
+
+/**
+ * Subscribe to a container's size via ResizeObserver and project onto a
+ * `PanelLayout`. Caller passes a ref already wired to the chart
+ * container — this lets the visualization keep its own ref for
+ * cursor-sync / tooltip math while still using the hook to drive
+ * layout decisions. The hook does NOT re-render when the inner content
+ * rect changes if width/height hasn't actually changed.
+ */
+export function usePanelLayout(
+  ref: RefObject<HTMLElement | null>,
+): PanelLayout {
+  const [size, setSize] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (!r) return;
+      setSize((prev) =>
+        prev.width === r.width && prev.height === r.height
+          ? prev
+          : { width: r.width, height: r.height },
+      );
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref]);
+
+  const sizeClass: PanelSizeClass =
+    size.width === 0
+      ? 'wide' // optimistic default before measurement
+      : size.width < NARROW_MAX_WIDTH
+        ? 'narrow'
+        : size.width < WIDE_MIN_WIDTH
+          ? 'medium'
+          : 'wide';
+
+  const tooltipMaxWidth =
+    sizeClass === 'narrow' ? 200 : sizeClass === 'medium' ? 240 : 320;
+
+  return { ...size, sizeClass, tooltipMaxWidth };
+}


### PR DESCRIPTION
## Why this PR exists
A user reported a Chinese legend label "请求速率" rendering as just **"请"** on a narrow panel — the stats section beside it (`Mean: 133.16 req/s`) had `flexShrink: 0`, the legend item enforced \`flex: 1 1 220px\`, and the name span got squeezed to one glyph before ellipsis. Y-axis labels showed up as "00 req/s" / "00 req/s" instead of "100" / "200" because uPlot's default 50 px gutter clipped them.

Patching either symptom in isolation (which is what I started doing — first a y-axis size callback, then a legend wrap) leaves the next one un-fixed. The root cause is that the visualization tree had **three independent sizing systems**:

| System | How it sized | Problem |
|---|---|---|
| uPlot y-axis gutter | hardcoded 50 px | Clipped "180 req/s" |
| Legend item width | \`flex: 1 1 220px\` (Latin-tuned) | CJK labels squeezed to single glyph |
| Tooltip / table cell | \`maxWidth: 320\` | Ignored container |
| Legend hide gate | \`containerHeight < 180\` | Width never considered |

CJK characters are ~12 px/glyph vs Latin ~7. Every magic number tuned for Latin missed CJK by ~70%.

## What this change does
**One source of truth: \`packages/web/src/lib/viz/usePanelLayout.ts\`.**

- ResizeObserver in the hook → \`PanelLayout\` ({ width, height, sizeClass: 'narrow' | 'medium' | 'wide', tooltipMaxWidth }).
- Pure \`decideLegendLayout(layout, seriesCount, statCount, requested)\` → \`{ mode, itemBasis }\`. Single function with all breakpoints.
- Visualization reads the decision; **no hardcoded breakpoints / pixel widths anywhere else** in \`TimeSeriesViz.tsx\`.

### New \`stacked\` legend mode for narrow panels (< 300 px)
Series name owns row 1 at full width — CJK / long names always whole — stats drop to row 2 indented to the swatch column. Mirrors Grafana / Datadog narrow-mode rendering. Solves the CJK truncation at the layout level instead of patching ellipsis.

### List-mode \`itemBasis\` from layout
- Wide (>= 600 px): 220 px (spacious, was already this)
- Medium (300-599 px): 140 px (denser — fits a single CJK name + 1 stat without ellipsis)
- Narrow (< 300 px): N/A (uses stacked instead)

### Tooltip cap from layout
- Wide: 320 px
- Medium: 240 px
- Narrow: 200 px

### Table mode column-shrink
\`maxWidth: 320\` replaced with \`maxWidth: 0 + width: 100%\` — name cell ellipsis at the actual table column width, not a hardcoded ceiling.

### Y-axis size callback (separate commit, kept)
\`size: (u, values) => maxLen * 7 + 16\` — uPlot natively supports content-aware axis sizing; that's the right primitive for axes. Capped 50–140 so an outlier with 14-char labels can't blow up the chart.

## What didn't change (compatibility)
- Wide panels: zero visual change. All previous logic preserved.
- API: \`SeriesInput\`, panel.json schema, \`legendStats\`, dashboard handler — untouched.
- Other viz components (BarViz, GaugeViz, etc.) untouched in this PR; they don't have the same scattered-magic-number issue.

## Testing
- \`tsc --noEmit\` clean.
- \`grep -E "minWidth: 22|minWidth: 16|maxWidth: 32|containerHeight|tooShortForLegend|wideForList|effectiveLegendMode" TimeSeriesViz.tsx\` → empty (all magic numbers / ad-hoc decisions purged).
- Deployed in cluster, verified Chinese legend "请求速率" renders whole on narrow panels.

## Test plan
- [ ] Narrow panel (< 300 px): legend stacks; CJK + Latin names whole.
- [ ] Medium panel (300-599 px): list mode, items denser, no ellipsis on common widths.
- [ ] Wide panel (>= 600 px): same look as before this PR.
- [ ] Single-series + multi-stat: legend tooltip mode triggers correctly.
- [ ] >6 series: still falls into table mode at medium / wide widths.
- [ ] Resize from wide → narrow: legend transitions list → stacked smoothly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legend layout adapts to panel size with a new "stacked" mode for narrow panels.

* **Improvements**
  * Tooltip sizing driven by panel width for more consistent behavior.
  * Legend item sizing and stat display standardized for clearer presentation.
  * Table/name-cell sizing improved to better shrink and fit content.
  * Y-axis label gutter now scales with label length for improved readability.

* **Tests**
  * Added unit tests covering legend layout decisions across sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->