### PR TITLE
fix(toolbar): rewrite TimeRangePicker + extract RefreshControl

### DIFF
--- a/packages/web/src/components/RefreshControl.tsx
+++ b/packages/web/src/components/RefreshControl.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+/**
+ * RefreshControl — combined manual refresh + auto-refresh interval picker.
+ *
+ * Why this is its own component (split from TimeRangePicker):
+ *   The previous design had a single refresh button glued onto the time-
+ *   range picker. Users couldn't tell whether a click registered (no
+ *   visual feedback once the spinner stopped) and there was no way to
+ *   leave the dashboard auto-refreshing.
+ *
+ * What this gives:
+ *   - Explicit "last refreshed" readout under the manual button (live
+ *     "5s ago" / "just now") so a stale dashboard is visible.
+ *   - Auto-refresh dropdown: Off / 5s / 10s / 30s / 1m / 5m. Choice
+ *     persists per-browser via localStorage so reloading keeps the
+ *     last picked interval (hot reload + cluster restart-friendly).
+ *   - Spin animation on every fire — manual or auto — so motion feedback
+ *     always confirms a refresh actually went out.
+ *
+ * The component owns its own interval timer and `lastRefreshAt` state.
+ * The parent only supplies the refresh callback.
+ */
+
+const STORAGE_KEY = 'openobs.dashboard.autoRefreshMs';
+
+interface RefreshOption { label: string; ms: number; }
+const OPTIONS: readonly RefreshOption[] = [
+  { label: 'Off', ms: 0 },
+  { label: '5s', ms: 5_000 },
+  { label: '10s', ms: 10_000 },
+  { label: '30s', ms: 30_000 },
+  { label: '1m', ms: 60_000 },
+  { label: '5m', ms: 300_000 },
+];
+
+export default function RefreshControl({ onRefresh }: { onRefresh: () => void }): JSX.Element {
+  const [intervalMs, setIntervalMs] = React.useState<number>(() => readStoredInterval());
+  const [lastRefreshAt, setLastRefreshAt] = React.useState<number>(() => Date.now());
+  const [spinning, setSpinning] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const btnRef = React.useRef<HTMLButtonElement>(null);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+  const [pos, setPos] = React.useState({ top: 0, left: 0 });
+
+  // Keep onRefresh in a ref so the interval effect doesn't re-subscribe
+  // every render. This used to fire double-refreshes when callers
+  // re-bound the handler on each parent render.
+  const onRefreshRef = React.useRef(onRefresh);
+  React.useEffect(() => { onRefreshRef.current = onRefresh; }, [onRefresh]);
+
+  const fire = React.useCallback(() => {
+    setSpinning(true);
+    onRefreshRef.current();
+    setLastRefreshAt(Date.now());
+    // Spinner runs ~600ms — long enough to register visually, short
+    // enough not to feel laggy when auto-refresh is firing every 5s.
+    window.setTimeout(() => setSpinning(false), 600);
+  }, []);
+
+  // Auto-refresh timer.
+  React.useEffect(() => {
+    if (intervalMs <= 0) return;
+    const id = window.setInterval(fire, intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs, fire]);
+
+  // Live "last refreshed" display: tick once a second so "just now"
+  // becomes "5s ago" without re-firing the refresh.
+  const [, setTick] = React.useState(0);
+  React.useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // Persist interval choice per-browser.
+  React.useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(intervalMs));
+    } catch {
+      // SSR / quota — silently ignore; the in-memory value still works.
+    }
+  }, [intervalMs]);
+
+  // Click-outside / Escape closes the popover.
+  React.useEffect(() => {
+    if (!open) return;
+    const onMouse = (e: MouseEvent) => {
+      if (popoverRef.current?.contains(e.target as Node)) return;
+      if (btnRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onMouse);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onMouse);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (open && btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect();
+      // Align the popover's right edge with the trigger's right edge so
+      // it doesn't overflow off the toolbar at narrow widths.
+      setPos({ top: r.bottom + 4, left: r.right - 140 });
+    }
+  }, [open]);
+
+  const lastLabel = formatLastRefreshed(Date.now() - lastRefreshAt);
+  const activeOption = OPTIONS.find((o) => o.ms === intervalMs) ?? OPTIONS[0]!;
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <button
+        type="button"
+        onClick={fire}
+        className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-colors"
+        title={`Refresh now — last refreshed ${lastLabel}`}
+        aria-label={`Refresh dashboard. Last refreshed ${lastLabel}.`}
+      >
+        <RefreshIcon spinning={spinning} />
+      </button>
+
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`flex items-center gap-1 text-xs rounded-lg px-2 py-1.5 hover:bg-surface-high transition-colors ${
+          intervalMs > 0 ? 'text-primary' : 'text-on-surface-variant'
+        }`}
+        title="Auto-refresh interval"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className="font-medium">{activeOption.label}</span>
+        <ChevronDownIcon />
+      </button>
+
+      {open && ReactDOM.createPortal(
+        <div
+          ref={popoverRef}
+          role="menu"
+          className="fixed bg-surface-highest rounded-xl shadow-2xl shadow-black/40 min-w-[140px] py-1"
+          style={{ top: pos.top, left: pos.left, zIndex: 9999 }}
+        >
+          {OPTIONS.map((opt) => (
+            <button
+              key={opt.ms}
+              type="button"
+              role="menuitemradio"
+              aria-checked={opt.ms === intervalMs}
+              onClick={() => { setIntervalMs(opt.ms); setOpen(false); }}
+              className={`block w-full text-left px-3 py-1.5 text-xs transition-colors ${
+                opt.ms === intervalMs
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-on-surface hover:bg-surface-bright'
+              }`}
+            >
+              {opt.label === 'Off' ? 'Off (manual only)' : `Every ${opt.label}`}
+            </button>
+          ))}
+          <div className="border-t border-outline-variant/20 mt-1 pt-1.5 px-3 pb-1">
+            <p className="text-[10px] text-on-surface-variant">Last refreshed: {lastLabel}</p>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}
+
+function readStoredInterval(): number {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return 0;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    // Reject any value not in OPTIONS so an out-of-range stale entry
+    // (e.g. from a removed interval) doesn't keep the timer firing
+    // forever at an invalid cadence.
+    return OPTIONS.some((o) => o.ms === n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function formatLastRefreshed(elapsedMs: number): string {
+  if (elapsedMs < 2000) return 'just now';
+  const sec = Math.round(elapsedMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  return `${hr}h ago`;
+}
+
+function RefreshIcon({ spinning }: { spinning: boolean }): JSX.Element {
+  return (
+    <svg
+      className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m14.836 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0A8.003 8.003 0 015.163 13M15 15h5" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon(): JSX.Element {
+  return (
+    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/TimeRangePicker.tsx
+++ b/packages/web/src/components/TimeRangePicker.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { QUICK_RANGES } from '../constants/time-ranges.js';
 
-export default function TimeRangePicker({ value, onChange, onRefresh }: {
+/**
+ * TimeRangePicker — button + popover for picking a dashboard time range.
+ *
+ * Behavior changes from the previous version (driven by user pain reports):
+ *   - The button label always reflects the actual range. For relative
+ *     ranges it shows the human label ("Last 1 hour"). For absolute
+ *     ranges it shows a compact `Apr 12 14:00 → 16:30` instead of the
+ *     uninformative literal "Custom".
+ *   - Apply is disabled (and shows a hint) when from >= to instead of
+ *     silently no-op'ing.
+ *   - Escape closes the popover. Click-outside still works.
+ *   - Refresh is no longer mixed in here — it's `<RefreshControl/>`,
+ *     which adds auto-refresh and last-updated readout.
+ */
+export default function TimeRangePicker({ value, onChange }: {
   value: string;
   onChange: (v: string) => void;
-  onRefresh: () => void;
-}) {
+}): JSX.Element {
   const browserTimeZone = React.useMemo(
     () => Intl.DateTimeFormat().resolvedOptions().timeZone || 'Browser time',
     [],
@@ -14,141 +27,217 @@ export default function TimeRangePicker({ value, onChange, onRefresh }: {
   const [open, setOpen] = React.useState(false);
   const [customFrom, setCustomFrom] = React.useState('');
   const [customTo, setCustomTo] = React.useState('');
-  const [spinning, setSpinning] = React.useState(false);
-  const ref = React.useRef<HTMLDivElement>(null);
+  const popoverRef = React.useRef<HTMLDivElement>(null);
   const btnRef = React.useRef<HTMLButtonElement>(null);
   const [pos, setPos] = React.useState({ top: 0, left: 0 });
 
+  // Close on click-outside or Escape.
   React.useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node) && !btnRef.current?.contains(e.target as Node)) setOpen(false);
+    if (!open) return;
+    const onMouse = (e: MouseEvent) => {
+      if (popoverRef.current?.contains(e.target as Node)) return;
+      if (btnRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
     };
-    if (open) { document.addEventListener('mousedown', handler); return () => document.removeEventListener('mousedown', handler); }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onMouse);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onMouse);
+      document.removeEventListener('keydown', onKey);
+    };
   }, [open]);
 
+  // Position the portal below the trigger button each time it opens.
   React.useEffect(() => {
     if (open && btnRef.current) {
-      const rect = btnRef.current.getBoundingClientRect();
-      setPos({ top: rect.bottom + 4, left: rect.left });
+      const r = btnRef.current.getBoundingClientRect();
+      setPos({ top: r.bottom + 4, left: r.left });
     }
   }, [open]);
 
+  // Sync the custom-range inputs from `value` when an absolute range is in
+  // effect (e.g. opening the popover should pre-fill what's already chosen).
   React.useEffect(() => {
     if (!value.includes('|')) return;
     const [from, to] = value.split('|');
-    const formatForInput = (raw: string | undefined) => {
-      if (!raw) return '';
-      const date = new Date(raw);
-      if (Number.isNaN(date.getTime())) return raw;
-      const pad = (n: number) => String(n).padStart(2, '0');
-      return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-    };
-    setCustomFrom(formatForInput(from));
-    setCustomTo(formatForInput(to));
+    setCustomFrom(formatForDateTimeLocal(from));
+    setCustomTo(formatForDateTimeLocal(to));
   }, [value]);
 
-  const displayLabel = QUICK_RANGES.find((r) => r.value === value)?.label
-    ?? (value.includes('|') ? 'Custom' : value);
+  const displayLabel = formatRangeLabel(value);
+
+  const customFromMs = customFrom ? new Date(customFrom).getTime() : NaN;
+  const customToMs = customTo ? new Date(customTo).getTime() : NaN;
+  const customValid =
+    Number.isFinite(customFromMs) && Number.isFinite(customToMs) && customFromMs < customToMs;
 
   const applyCustom = () => {
-    if (customFrom && customTo) {
-      const from = new Date(customFrom);
-      const to = new Date(customTo);
-      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
-        return;
-      }
-      onChange(`${from.toISOString()}|${to.toISOString()}`);
-      setOpen(false);
-    }
+    if (!customValid) return;
+    onChange(`${new Date(customFromMs).toISOString()}|${new Date(customToMs).toISOString()}`);
+    setOpen(false);
   };
 
   return (
-    <div className="flex items-center gap-1 shrink-0">
+    <div className="shrink-0">
       <button
         ref={btnRef}
         type="button"
         onClick={() => setOpen(!open)}
         className="flex items-center gap-2 bg-surface-high text-on-surface text-xs rounded-lg px-3 py-1.5 hover:bg-surface-bright transition-colors"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={displayLabel}
       >
-        <svg className="w-3.5 h-3.5 text-on-surface-variant" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        {displayLabel}
-        <svg className="w-3 h-3 text-on-surface-variant" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
+        <ClockIcon />
+        <span className="truncate max-w-[260px]">{displayLabel}</span>
+        <ChevronDownIcon />
       </button>
 
       {open && ReactDOM.createPortal(
-        <div ref={ref} className="fixed bg-surface-highest rounded-xl shadow-2xl shadow-black/40 min-w-[260px] py-2" style={{ top: pos.top, left: pos.left, zIndex: 9999 }}>
-            <p className="px-3 py-1 text-[10px] font-bold text-on-surface-variant uppercase tracking-wider">Quick ranges</p>
-            <div className="grid grid-cols-2 gap-0.5 px-2">
-              {QUICK_RANGES.map((r) => (
-                <button
-                  key={r.value}
-                  type="button"
-                  onClick={() => { onChange(r.value); setOpen(false); }}
-                  className={`text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors ${
-                    value === r.value ? 'bg-primary/15 text-primary' : 'text-on-surface hover:bg-surface-bright'
-                  }`}
-                >
-                  {r.label}
-                </button>
-              ))}
-            </div>
+        <div
+          ref={popoverRef}
+          role="dialog"
+          className="fixed bg-surface-highest rounded-xl shadow-2xl shadow-black/40 min-w-[280px] py-2"
+          style={{ top: pos.top, left: pos.left, zIndex: 9999 }}
+        >
+          <p className="px-3 py-1 text-[10px] font-bold text-on-surface-variant uppercase tracking-wider">
+            Quick ranges
+          </p>
+          <div className="grid grid-cols-2 gap-0.5 px-2">
+            {QUICK_RANGES.map((r) => (
+              <button
+                key={r.value}
+                type="button"
+                onClick={() => { onChange(r.value); setOpen(false); }}
+                className={`text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors ${
+                  value === r.value
+                    ? 'bg-primary/15 text-primary'
+                    : 'text-on-surface hover:bg-surface-bright'
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
 
-            <div className="border-t border-outline-variant/20 mt-2 pt-2 px-3">
-              <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-wider mb-2">Custom range</p>
-              <p className="text-[10px] text-on-surface-variant mb-2">Timezone: {browserTimeZone}</p>
-              <div className="space-y-2">
-                <div>
-                  <label className="text-[10px] text-on-surface-variant mb-0.5 block">From</label>
-                  <input
-                    type="datetime-local"
-                    value={customFrom}
-                    onChange={(e) => setCustomFrom(e.target.value)}
-                    className="w-full bg-surface-high text-on-surface text-xs rounded-lg px-2.5 py-1.5 border-none focus:ring-1 focus:ring-primary"
-                    style={{ colorScheme: 'dark' }}
-                  />
-                </div>
-                <div>
-                  <label className="text-[10px] text-on-surface-variant mb-0.5 block">To</label>
-                  <input
-                    type="datetime-local"
-                    value={customTo}
-                    onChange={(e) => setCustomTo(e.target.value)}
-                    className="w-full bg-surface-high text-on-surface text-xs rounded-lg px-2.5 py-1.5 border-none focus:ring-1 focus:ring-primary"
-                    style={{ colorScheme: 'dark' }}
-                  />
-                </div>
-                <button
-                  type="button"
-                  onClick={applyCustom}
-                  disabled={!customFrom || !customTo}
-                  className="w-full bg-primary text-on-primary-fixed text-xs font-semibold rounded-lg py-1.5 disabled:opacity-40 transition-colors"
-                >
-                  Apply
-                </button>
+          <div className="border-t border-outline-variant/20 mt-2 pt-2 px-3">
+            <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-wider mb-2">
+              Custom range
+            </p>
+            <p className="text-[10px] text-on-surface-variant mb-2">Timezone: {browserTimeZone}</p>
+            <div className="space-y-2">
+              <div>
+                <label className="text-[10px] text-on-surface-variant mb-0.5 block">From</label>
+                <input
+                  type="datetime-local"
+                  value={customFrom}
+                  onChange={(e) => setCustomFrom(e.target.value)}
+                  className="w-full bg-surface-high text-on-surface text-xs rounded-lg px-2.5 py-1.5 border-none focus:ring-1 focus:ring-primary"
+                  style={{ colorScheme: 'dark' }}
+                />
               </div>
+              <div>
+                <label className="text-[10px] text-on-surface-variant mb-0.5 block">To</label>
+                <input
+                  type="datetime-local"
+                  value={customTo}
+                  onChange={(e) => setCustomTo(e.target.value)}
+                  className="w-full bg-surface-high text-on-surface text-xs rounded-lg px-2.5 py-1.5 border-none focus:ring-1 focus:ring-primary"
+                  style={{ colorScheme: 'dark' }}
+                />
+              </div>
+              {!customValid && (customFrom || customTo) && (
+                <p className="text-[10px] text-error">From must be before To.</p>
+              )}
+              <button
+                type="button"
+                onClick={applyCustom}
+                disabled={!customValid}
+                className="w-full bg-primary text-on-primary-fixed text-xs font-semibold rounded-lg py-1.5 disabled:opacity-40 transition-colors"
+              >
+                Apply
+              </button>
             </div>
-          </div>,
+          </div>
+        </div>,
         document.body,
       )}
-
-      <button
-        type="button"
-        onClick={() => {
-          setSpinning(true);
-          onRefresh();
-          setTimeout(() => setSpinning(false), 700);
-        }}
-        className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-colors"
-        title="Refresh"
-      >
-        <svg className={`w-3.5 h-3.5 transition-transform ${spinning ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m14.836 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0A8.003 8.003 0 015.163 13M15 15h5" />
-        </svg>
-      </button>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Label formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a stored `value` to the label shown on the trigger button.
+ *
+ *   "1h"                              → "Last 1 hour"
+ *   "<isoFrom>|<isoTo>" (same day)    → "Apr 12, 14:00 → 16:30"
+ *   "<isoFrom>|<isoTo>" (cross-day)   → "Apr 12 14:00 → Apr 13 02:30"
+ *
+ * Anything else falls back to the literal `value` so an unrecognized
+ * relative range still renders something rather than blank.
+ */
+function formatRangeLabel(value: string): string {
+  const known = QUICK_RANGES.find((r) => r.value === value);
+  if (known) return known.label;
+  if (!value.includes('|')) return value;
+
+  const [fromStr, toStr] = value.split('|');
+  const from = fromStr ? new Date(fromStr) : null;
+  const to = toStr ? new Date(toStr) : null;
+  if (!from || !to || Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    return 'Custom';
+  }
+
+  const sameDay =
+    from.getFullYear() === to.getFullYear() &&
+    from.getMonth() === to.getMonth() &&
+    from.getDate() === to.getDate();
+
+  const dateFmt = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  const timeFmt = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+
+  if (sameDay) {
+    return `${dateFmt.format(from)}, ${timeFmt.format(from)} → ${timeFmt.format(to)}`;
+  }
+  return `${dateFmt.format(from)} ${timeFmt.format(from)} → ${dateFmt.format(to)} ${timeFmt.format(to)}`;
+}
+
+/**
+ * Format an ISO timestamp for `<input type="datetime-local">`. The native
+ * input wants `YYYY-MM-DDTHH:mm` in the user's local timezone; toISOString
+ * is UTC and would silently shift the visible value.
+ */
+function formatForDateTimeLocal(raw: string | undefined): string {
+  if (!raw) return '';
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours(),
+  )}:${pad(date.getMinutes())}`;
+}
+
+// ---------------------------------------------------------------------------
+// Inline icons (kept inline so the picker is one self-contained component).
+// ---------------------------------------------------------------------------
+
+function ClockIcon(): JSX.Element {
+  return (
+    <svg className="w-3.5 h-3.5 text-on-surface-variant" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon(): JSX.Element {
+  return (
+    <svg className="w-3 h-3 text-on-surface-variant" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
   );
 }

--- a/packages/web/src/pages/DashboardWorkspace.tsx
+++ b/packages/web/src/pages/DashboardWorkspace.tsx
@@ -12,6 +12,7 @@ import { useGlobalChat } from '../contexts/ChatContext.js';
 import { useAuth } from '../contexts/AuthContext.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import TimeRangePicker from '../components/TimeRangePicker.js';
+import RefreshControl from '../components/RefreshControl.js';
 import FolderDialog from '../components/FolderDialog.js';
 import ExportMenu from '../components/ExportMenu.js';
 import { PermissionsDialog } from '../components/permissions/index.js';
@@ -498,20 +499,24 @@ export default function DashboardWorkspace() {
           )}
         </div>
 
-        {/* Center: time range + refresh */}
+        {/* Center: time range + refresh control (manual + auto) */}
         {!showReport && (
-          <TimeRangePicker
-            value={timeRange}
-            onChange={(v) => {
-              setTimeRange(v);
-              queryScheduler.clearCache();
-              window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
-            }}
-            onRefresh={() => {
-              queryScheduler.clearCache();
-              window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
-            }}
-          />
+          <div className="flex items-center gap-2 shrink-0">
+            <TimeRangePicker
+              value={timeRange}
+              onChange={(v) => {
+                setTimeRange(v);
+                queryScheduler.clearCache();
+                window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
+              }}
+            />
+            <RefreshControl
+              onRefresh={() => {
+                queryScheduler.clearCache();
+                window.dispatchEvent(new CustomEvent('dashboard:refresh-panels'));
+              }}
+            />
+          </div>
         )}
 
         {!showReport && (


### PR DESCRIPTION
## Why
User reported two pain points on the dashboard toolbar:
1. **Time range button says "Custom"** with no clue what range is actually selected.
2. **Refresh button gives no feedback** after the spinner stops, and there's no way to leave the dashboard auto-refreshing.

## What changed

### TimeRangePicker (rewritten in place)
- **Button label reflects the real range**:
  - Quick ranges → human label ("Last 1 hour")
  - Absolute, same-day → \`Apr 12, 14:00 → 16:30\`
  - Absolute, cross-day → \`Apr 12 14:00 → Apr 13 02:30\`
  - Falls back to literal value for unrecognized strings (resilient).
- Apply disabled + hint ("From must be before To") when \`from >= to\` instead of silent no-op.
- \`Escape\` closes the popover. Click-outside still works.
- Refresh button removed — split into \`RefreshControl\`.

### RefreshControl (new component)
- **Manual button** with spin animation on every fire (manual + auto).
- **Auto-refresh dropdown**: Off / 5s / 10s / 30s / 1m / 5m. Choice persists per-browser via \`localStorage\` so reload keeps the interval.
- **Live "last refreshed" readout** ("just now" / "5s ago" / "2m ago") in the dropdown footer and the manual button's tooltip. Ticks once per second.
- \`onRefresh\` held in a ref so handler rebinding on parent re-render doesn't double-fire the interval timer.

### DashboardWorkspace
- Wraps the two components in a flex group; both fire the same refresh effect (clear query cache + dispatch \`dashboard:refresh-panels\`).

## Test plan
- [ ] Pick "Last 1 hour" → button shows "Last 1 hour"
- [ ] Pick custom same-day range → button shows compact "Apr 12, 14:00 → 16:30"
- [ ] Pick custom cross-day range → button shows "Apr 12 14:00 → Apr 13 02:30"
- [ ] Manual refresh: spinner runs ~600ms, "last refreshed: just now"
- [ ] Auto-refresh dropdown → pick 5s → spinner pulses every 5s, "last refreshed" stays under 6s
- [ ] Reload page → auto-refresh interval persists
- [ ] \`Escape\` closes both popovers
- [ ] At narrow viewports the auto-refresh popover doesn't overflow off-screen (right-aligned positioning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual refresh button and auto-refresh interval selector with persistent settings
  * Last refreshed timestamp updates in real-time

* **Improvements**
  * Enhanced time range picker with validation feedback and clearer range labels
  * Improved popover closing behavior with better keyboard and click-outside support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->