### PR TITLE
fix(test): permission-gate.test.ts missing dashboardBuildEvidence after #171

### DIFF
--- a/packages/agent-core/src/agent/permission-gate.test.ts
+++ b/packages/agent-core/src/agent/permission-gate.test.ts
@@ -27,6 +27,11 @@ function makeCtx(allowAll = true): ActionContext {
     investigationSections: new Map(),
     activeInvestigationId: null,
     activeDashboardId: null,
+    dashboardBuildEvidence: {
+      webSearchCount: 0,
+      metricDiscoveryCount: 0,
+      validatedQueries: new Set<string>(),
+    },
   } as ActionContext;
 }
 


### PR DESCRIPTION
## Bug
PR [#171](https://github.com/openobs/openobs/pull/171) added a required \`dashboardBuildEvidence\` field to \`ActionContext\` but didn't update \`permission-gate.test.ts\`'s manually-constructed ctx object. \`tsc\` fails the build (caught when rebuilding the cluster image off latest \`main\`):

\`\`\`
packages/agent-core/src/agent/permission-gate.test.ts(9,10): error TS2352:
  Conversion of type ... to type 'ActionContext' may be a mistake because
  neither type sufficiently overlaps with the other.
  Property 'dashboardBuildEvidence' is missing in type ... but required
  in type 'ActionContext'.
\`\`\`

## Fix
Add the same shape used in \`packages/agent-core/src/agent/handlers/_test-helpers.ts\` — zero counts + empty \`validatedQueries\` Set. Doesn't affect any assertion in permission-gate.test.ts; just satisfies the type constraint.

## Why this slipped through
\`permission-gate.test.ts\` ends its ctx literal with \`as ActionContext\` (cast). Casts pass typecheck if the source's literal type is **assignable** to the target — when the new required field was added, the cast became invalid because the source object has an extra "missing field" relative to the target's required keys, but tsc emits the error as a ts(2352) "conversion ... may be a mistake" rather than a clean missing-property message. Easy to miss in a large diff review.

## Test plan
- [x] \`npx tsc --noEmit -p packages/agent-core/tsconfig.json\` clean
- [x] \`docker build\` succeeds (was failing before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include additional context for test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->