### PR TITLE
Rebrand: Rounds (by Syntropize) — 2-ring mark + full OpenObs → Rounds rename

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,7 +10,10 @@ export default defineConfig({
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
   ],
   themeConfig: {
-    logo: '/openobs-logo.svg',
+    logo: {
+      light: '/openobs-logo.svg',
+      dark: '/openobs-logo-dark.svg',
+    },
     siteTitle: 'OpenObs',
     nav: [
       { text: 'Get Started', link: '/getting-started' },

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,6 +1,13 @@
-<svg width="32" height="32" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="2" y="2" width="60" height="60" rx="16" fill="#ffffff"/>
-  <path d="M32 7L55 20.5v23L32 57 9 43.5v-23L32 7z" stroke="#020617" stroke-width="4" fill="none" stroke-linejoin="round"/>
-  <path d="M18.5 29.5h6.5l3-6 4 10.5 4-10.5 3 6h6.5" stroke="#020617" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M18.5 36.5h6.5l3 6 4-10.5 4 10.5 3-6h6.5" stroke="#020617" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="32" height="32" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <!-- 2-ring favicon — rings adapt to browser tab theme (dark on light bg,
+       light on dark bg); dot stays severity-critical red. -->
+  <style>
+    .ring { stroke: #1f2937; }
+    @media (prefers-color-scheme: dark) {
+      .ring { stroke: #e7e7ee; }
+    }
+  </style>
+  <path class="ring" d="M 18 7.75 A 28 28 0 1 1 7.75 46" stroke-width="7.8"/>
+  <path class="ring" d="M 45 32 A 13 13 0 1 1 32 19" stroke-width="7.8"/>
+  <circle cx="32" cy="32" r="5" fill="#EF4444"/>
 </svg>

--- a/docs/public/openobs-logo-dark.svg
+++ b/docs/public/openobs-logo-dark.svg
@@ -1,5 +1,6 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M32 4L56 18v28L32 60 8 46V18L32 4z" stroke="#4B4FBF" stroke-width="2" fill="none" stroke-linejoin="round"/>
-  <path d="M18 28h6l3-6 5 12 5-12 3 6h6" stroke="#1a1e2e" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M18 36h6l3 6 5-12 5 12 3-6h6" stroke="#0d9488" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <!-- 2-ring · dark theme variant (light strokes for dark backgrounds) -->
+  <path d="M 18 7.75 A 28 28 0 1 1 7.75 46" stroke="#e7e7ee" stroke-width="7.8"/>
+  <path d="M 45 32 A 13 13 0 1 1 32 19" stroke="#e7e7ee" stroke-width="7.8"/>
+  <circle cx="32" cy="32" r="5" fill="#EF4444"/>
 </svg>

--- a/docs/public/openobs-logo.svg
+++ b/docs/public/openobs-logo.svg
@@ -1,5 +1,6 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M32 4L56 18v28L32 60 8 46V18L32 4z" stroke="#A3A6FF" stroke-width="2" fill="none" stroke-linejoin="round"/>
-  <path d="M18 28h6l3-6 5 12 5-12 3 6h6" stroke="#E2E8F0" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M18 36h6l3 6 5-12 5 12 3-6h6" stroke="#62FAE3" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <!-- 2-ring · light theme variant (dark strokes for light backgrounds) -->
+  <path d="M 18 7.75 A 28 28 0 1 1 7.75 46" stroke="#1f2937" stroke-width="7.8"/>
+  <path d="M 45 32 A 13 13 0 1 1 32 19" stroke="#1f2937" stroke-width="7.8"/>
+  <circle cx="32" cy="32" r="5" fill="#EF4444"/>
 </svg>

--- a/packages/web/public/favicon.svg
+++ b/packages/web/public/favicon.svg
@@ -1,6 +1,13 @@
-<svg width="32" height="32" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="2" y="2" width="60" height="60" rx="16" fill="#ffffff"/>
-  <path d="M32 7L55 20.5v23L32 57 9 43.5v-23L32 7z" stroke="#020617" stroke-width="4" fill="none" stroke-linejoin="round"/>
-  <path d="M18.5 29.5h6.5l3-6 4 10.5 4-10.5 3 6h6.5" stroke="#020617" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M18.5 36.5h6.5l3 6 4-10.5 4 10.5 3-6h6.5" stroke="#020617" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="32" height="32" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <!-- 2-ring favicon — rings adapt to browser tab theme (dark on light bg,
+       light on dark bg); dot stays severity-critical red. -->
+  <style>
+    .ring { stroke: #1f2937; }
+    @media (prefers-color-scheme: dark) {
+      .ring { stroke: #e7e7ee; }
+    }
+  </style>
+  <path class="ring" d="M 18 7.75 A 28 28 0 1 1 7.75 46" stroke-width="7.8"/>
+  <path class="ring" d="M 45 32 A 13 13 0 1 1 32 19" stroke-width="7.8"/>
+  <circle cx="32" cy="32" r="5" fill="#EF4444"/>
 </svg>

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -141,8 +141,9 @@ export default function ChatPanel({ events, isGenerating, onSendMessage, onStop,
       <div className="flex items-center justify-between px-4 py-4 border-b border-outline-variant shrink-0">
         <div className="flex items-center gap-3 flex-1">
           <OpenObsLogo
-            className={`w-7 h-7 text-on-surface${isGenerating ? ' animate-spin-slow' : ''}`}
+            className="w-7 h-7 text-on-surface"
             size={28}
+            animated={isGenerating}
           />
           <div>
             <p className="text-xs font-semibold text-on-surface">OpenObs</p>

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -412,7 +412,7 @@ export default function Navigation() {
         {expanded ? (
           <div className="flex items-center gap-2.5 min-w-0">
             <div className="flex items-center justify-center w-10 h-10 text-on-surface shrink-0">
-              <OpenObsLogo className="w-6 h-6" />
+              <OpenObsLogo className="w-7 h-7" />
             </div>
             <span className="text-sm font-bold text-on-surface truncate">OpenObs</span>
           </div>
@@ -425,7 +425,7 @@ export default function Navigation() {
           >
             <div className="relative flex items-center justify-center w-10 h-10 text-on-surface shrink-0 group-hover:bg-surface-high/60 transition-colors">
               <span className="transition-opacity duration-150 group-hover:opacity-0">
-                <OpenObsLogo className="w-6 h-6" />
+                <OpenObsLogo className="w-7 h-7" />
               </span>
               <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 text-on-surface">
                 <SidebarToggleIcon expanded={false} />

--- a/packages/web/src/components/OpenObsLogo.tsx
+++ b/packages/web/src/components/OpenObsLogo.tsx
@@ -1,6 +1,28 @@
 import React from 'react';
 
-export function OpenObsLogo({ className = '', size = 28 }: { className?: string; size?: number }) {
+/**
+ * Triple Rounds brand mark — 2-ring variant.
+ *
+ * Outer + inner concentric 270° arcs + critical-red center dot. Rings inherit
+ * `currentColor` so the parent's text colour (typically `text-on-surface`)
+ * drives light/dark theming automatically; the dot stays severity-critical
+ * red (#EF4444).
+ *
+ * When `animated` is true, each ring rotates independently around the
+ * geometric centre (32, 32) — outer CW slow, inner CCW fast — and the
+ * centre dot pulses. Rotating the whole SVG via a parent CSS class would
+ * only spin both rings rigidly in the same direction, which is why the
+ * animation lives inside the SVG via SMIL `<animateTransform>`.
+ */
+export function OpenObsLogo({
+  className = '',
+  size = 28,
+  animated = false,
+}: {
+  className?: string;
+  size?: number;
+  animated?: boolean;
+}) {
   return (
     <svg
       width={size}
@@ -8,31 +30,51 @@ export function OpenObsLogo({ className = '', size = 28 }: { className?: string;
       viewBox="0 0 64 64"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      strokeLinecap="round"
       className={className}
     >
       <path
-        d="M32 4L56 18v28L32 60 8 46V18L32 4z"
+        d="M 18 7.75 A 28 28 0 1 1 7.75 46"
         stroke="currentColor"
-        strokeWidth="2"
-        fill="none"
-        strokeLinejoin="round"
-      />
+        strokeWidth="7.8"
+      >
+        {animated && (
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 32 32"
+            to="360 32 32"
+            dur="3.2s"
+            repeatCount="indefinite"
+          />
+        )}
+      </path>
       <path
-        d="M18 28h6l3-6 5 12 5-12 3 6h6"
+        d="M 45 32 A 13 13 0 1 1 32 19"
         stroke="currentColor"
-        strokeWidth="2"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M18 36h6l3 6 5-12 5 12 3-6h6"
-        stroke="currentColor"
-        strokeWidth="2"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+        strokeWidth="7.8"
+      >
+        {animated && (
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="360 32 32"
+            to="0 32 32"
+            dur="2.4s"
+            repeatCount="indefinite"
+          />
+        )}
+      </path>
+      <circle cx="32" cy="32" r="5" fill="#EF4444">
+        {animated && (
+          <animate
+            attributeName="opacity"
+            values="1;0.55;1"
+            dur="1.6s"
+            repeatCount="indefinite"
+          />
+        )}
+      </circle>
     </svg>
   );
 }


### PR DESCRIPTION
## What

Full rebrand from OpenObs to **Rounds** — a product of **Syntropize**.

Tagline: **AI does rounds on your production.**

## Why

The previous name "OpenObs" reads as observability/monitoring (Prometheus/Grafana category). Product scope is AI SRE end-to-end: investigate, dashboard, alert, remediate. The new name carries action ("does rounds" = systematic SRE check), the company name (Syntropize) gives room for future products under one entity.

## Commits in this PR (in order)

1. **`feat(brand)` 8c6bc7f** — 2-ring mark + red center dot (`#EF4444`), theme-adaptive favicon, sidebar size bump 24→28px, SMIL `<animateTransform>` for per-ring rotation when generating
2. **`rebrand(infra)` 136a29e** — `@syntropize/rounds` npm package, CLI binary `rounds`, Helm chart `helm/rounds`, Docker tag, GitHub workflows
3. **`rebrand(web/docs)` 8a233df** — `RoundsLogo` component, `rounds-logo*.svg` files, vitepress logo + footer + repo links
4. **`rebrand(strings)` 3ba3083** — sweep of all user-facing brand strings (130 files, ~378 lines): README, docs/**, LICENSE (Syntropize copyright), web UI (SetupWizard, Login, Home, ChatPanel, Settings), package code comments, e2e test narrative
5. **`rebrand(cleanup)` 2fa0b7f** — `demo/openobs-demo.yaml` → `demo/rounds-demo.yaml`

## What's NOT in this PR (intentional)

These are runtime identifiers that affect DB state / cookies / config and need a coordinated migration story or version bump. Listed for follow-up:

- **Token format prefixes**: `openobs_session` / `openobs_sa_` / `openobs_pat_`
- **Env vars**: `OPENOBS_DEMO`, `OPENOBS_ALLOW_PRIVATE_URLS`, `OPENOBS_LDAP_CONFIG_PATH`
- **HTTP headers**: `x-openobs-org-id`
- **localStorage keys**: `openobs:sidebar-expanded`, `openobs:sidebar-tab`
- **Config file path**: `/etc/openobs/ldap.toml`
- **Internal workspace package names**: `@agentic-obs/*` (changing these touches every import in the monorepo — defer to v0.1.0)

## Test plan

- [ ] `npm run typecheck` passes (already verified locally per commit)
- [ ] `npm run start` — sidebar shows "Rounds" wordmark + red-dot mark; ChatPanel shows "Rounds"
- [ ] Browser tab favicon — adapts to OS dark/light, shows 2-ring mark with red dot
- [ ] Docs site — vitepress hero, footer "Copyright Syntropize", AGPL license
- [ ] `rounds demo` from local checkout (`npx tsx bin/start.ts demo`) starts demo mode
- [ ] CLI binary name in `packages/cli/package.json bin.rounds` → `./bin/rounds.mjs`
- [ ] Helm template: `helm template rounds ./helm/rounds` renders with chart name `rounds`
- [ ] Release workflow stamps version into `helm/rounds/Chart.yaml` + `packages/cli/package.json`, publishes `@syntropize/rounds@<version>` to npm and `oci://ghcr.io/syntropize/charts/rounds:<version>`

## Note for the npm publish

Before tagging the next release, the npm `@syntropize` org must own the `@syntropize/rounds` package name. If `@syntropize` org claim is in flight, the release workflow's npm publish step will skip with a clear warning until it's set up.