### PR TITLE
docs(design): commit Rounds brand mark source SVG

### DIFF
--- a/design/logo/mark-2ring.svg
+++ b/design/logo/mark-2ring.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke-linecap="round">
+  <!-- 2-ring · thick · stroke=7.8. Outer r=28, inner r=13, dot r=5. -->
+  <path d="M 18 7.75 A 28 28 0 1 1 7.75 46" stroke="currentColor" stroke-width="7.8"/>
+  <path d="M 45 32 A 13 13 0 1 1 32 19" stroke="currentColor" stroke-width="7.8"/>
+  <circle cx="32" cy="32" r="5" fill="#EF4444"/>
+</svg>


### PR DESCRIPTION
## What

Commit \`design/logo/mark-2ring.svg\` — the canonical source for the 2-ring + red-dot Rounds brand mark that shipped in #176 / #178.

## Why

The mark is currently inlined in 4 places:
- \`packages/web/src/components/RoundsLogo.tsx\` (React component)
- \`docs/public/rounds-logo.svg\` (light variant)
- \`docs/public/rounds-logo-dark.svg\` (dark variant)
- 3 × \`favicon.svg\` (prefers-color-scheme adaptive, accent dot)

There's no single design source. Future tweaks (color, stroke width, geometry) would have to edit all inlined copies in sync. Committing the source makes the next iteration trivial: edit one SVG, regenerate the rest.

## Parameters

- Outer arc: r=28, 270° sweep starting at 240°
- Inner arc: r=13, 270° sweep starting at 0°
- Center dot: r=5, fill \`#EF4444\` (severity-critical red)
- Stroke: 7.8, \`stroke-linecap="round"\`, \`currentColor\` (rings inherit theme color)

## Test plan

- [ ] File visible at \`design/logo/mark-2ring.svg\` after merge
- [ ] No CI changes (single SVG addition)