### PR TITLE
Fix chat activity replay ordering

### DIFF
--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -244,11 +244,10 @@ function pickAgentTypeFromContext(
   return 'orchestrator';
 }
 
-// Event kinds that represent transient signalling (terminator, navigation
-// side-effect, duplicated message content) and should NOT be persisted to the
-// event trace — they'd clutter replay or double-render messages already saved
-// in chat_messages.
-const SKIP_PERSIST_KINDS = new Set(['reply', 'done', 'navigate']);
+// Event kinds that represent transient signalling (terminator / navigation
+// side-effect) and should NOT be persisted to the event trace. `reply` events
+// are persisted so history replay keeps the same interleaving users saw live.
+const SKIP_PERSIST_KINDS = new Set(['done', 'navigate']);
 
 export interface ChatSessionResult {
   sessionId: string;

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { motion } from 'framer-motion';
 import { slideIn } from '../animations.js';
 import type { ChatEvent } from '../hooks/useDashboardChat.js';
-import { groupEvents } from './chat/event-processing.js';
-import type { Block } from './chat/event-processing.js';
+import { groupEvents, liveAgentBlockId } from './chat/event-processing.js';
 import { UserMessage, AssistantMessage, ErrorMessage } from './chat/MessageComponents.js';
 import AgentActivityBlock from './chat/AgentActivityBlock.js';
 import AskUserPrompt from './chat/AskUserPrompt.js';
@@ -40,12 +39,7 @@ export default function ChatPanel({ events, isGenerating, onSendMessage, onStop,
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
   const blocks = useMemo(() => groupEvents(events), [events]);
-  const lastAgentBlockId = useMemo(() => {
-    for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      if (blocks[i]!.type === 'agent') return (blocks[i] as Extract<Block, { type: 'agent' }>).id;
-    }
-    return null;
-  }, [blocks]);
+  const liveBlockId = useMemo(() => liveAgentBlockId(blocks, isGenerating), [blocks, isGenerating]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -276,7 +270,7 @@ export default function ChatPanel({ events, isGenerating, onSendMessage, onStop,
               <AgentActivityBlock
                 key={block.id}
                 events={block.events}
-                isLive={isGenerating && block.id === lastAgentBlockId}
+                isLive={block.id === liveBlockId}
               />
             );
           }

--- a/packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx
+++ b/packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx
@@ -11,7 +11,12 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import AgentActivityBlock, { ToolCallCardView } from '../AgentActivityBlock.js';
-import { buildToolCalls, type ToolCallCard } from '../event-processing.js';
+import {
+  buildToolCalls,
+  groupEvents,
+  liveAgentBlockId,
+  type ToolCallCard,
+} from '../event-processing.js';
 import type { ChatEvent } from '../../../hooks/useDashboardChat.js';
 
 function makeToolCallEvent(idx: number, params?: Record<string, unknown>): ChatEvent {
@@ -160,5 +165,48 @@ describe('AgentActivityBlock aria-expanded', () => {
     const events: ChatEvent[] = [makeToolCallEvent(0), makeResultEvent(0)];
     const html = renderToStaticMarkup(<AgentActivityBlock events={events} isLive={false} />);
     expect(html).toContain('aria-expanded="false"');
+  });
+});
+
+describe('liveAgentBlockId', () => {
+  it('does not mark the previous agent block live after a new user message', () => {
+    const events: ChatEvent[] = [
+      makeToolCallEvent(0),
+      makeResultEvent(0),
+      {
+        id: 'user-1',
+        kind: 'message',
+        message: {
+          id: 'user-1',
+          role: 'user',
+          content: 'next request',
+          timestamp: '2026-05-12T01:00:00.000Z',
+        },
+      },
+    ];
+
+    const blocks = groupEvents(events);
+    expect(liveAgentBlockId(blocks, true)).toBeNull();
+  });
+
+  it('marks only the trailing agent block live once new agent activity starts', () => {
+    const events: ChatEvent[] = [
+      makeToolCallEvent(0),
+      makeResultEvent(0),
+      {
+        id: 'user-1',
+        kind: 'message',
+        message: {
+          id: 'user-1',
+          role: 'user',
+          content: 'next request',
+          timestamp: '2026-05-12T01:00:00.000Z',
+        },
+      },
+      { id: 'think-1', kind: 'thinking', content: 'Thinking...' },
+    ];
+
+    const blocks = groupEvents(events);
+    expect(liveAgentBlockId(blocks, true)).toBe('think-1');
   });
 });

--- a/packages/web/src/components/chat/event-processing.ts
+++ b/packages/web/src/components/chat/event-processing.ts
@@ -40,6 +40,12 @@ export function groupEvents(events: ChatEvent[]): Block[] {
   return blocks;
 }
 
+export function liveAgentBlockId(blocks: Block[], isGenerating: boolean): string | null {
+  if (!isGenerating) return null;
+  const last = blocks[blocks.length - 1];
+  return last?.type === 'agent' ? last.id : null;
+}
+
 // Step processing
 
 // Phase-grouped step builder.

--- a/packages/web/src/hooks/useChat.test.ts
+++ b/packages/web/src/hooks/useChat.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rebuildChatEventsFromSession,
+  type PersistedChatSessionEvent,
+} from './useChat.js';
+import type { ChatMessage } from './useDashboardChat.js';
+
+describe('rebuildChatEventsFromSession', () => {
+  it('replays persisted assistant replies in live-stream order', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'delete ingress gateway dashboard',
+        timestamp: '2026-05-12T01:00:00.000Z',
+      },
+      {
+        id: 'assistant-final',
+        role: 'assistant',
+        content: 'Done.',
+        timestamp: '2026-05-12T01:00:05.000Z',
+      },
+    ];
+    const persistedEvents: PersistedChatSessionEvent[] = [
+      {
+        id: 'reply-1',
+        seq: 0,
+        kind: 'reply',
+        payload: { type: 'reply', content: 'I found two matching dashboards.' },
+        timestamp: '2026-05-12T01:00:01.000Z',
+      },
+      {
+        id: 'tool-1',
+        seq: 1,
+        kind: 'tool_call',
+        payload: {
+          type: 'tool_call',
+          tool: 'dashboard_list',
+          displayText: 'Listing dashboards',
+        },
+        timestamp: '2026-05-12T01:00:02.000Z',
+      },
+      {
+        id: 'tool-result-1',
+        seq: 2,
+        kind: 'tool_result',
+        payload: {
+          type: 'tool_result',
+          tool: 'dashboard_list',
+          summary: '2 dashboards',
+          success: true,
+        },
+        timestamp: '2026-05-12T01:00:03.000Z',
+      },
+      {
+        id: 'reply-2',
+        seq: 3,
+        kind: 'reply',
+        payload: { type: 'reply', content: 'Which one should I delete?' },
+        timestamp: '2026-05-12T01:00:04.000Z',
+      },
+    ];
+
+    const rebuilt = rebuildChatEventsFromSession(messages, persistedEvents);
+
+    expect(rebuilt.map((evt) => evt.kind)).toEqual([
+      'message',
+      'message',
+      'tool_call',
+      'tool_result',
+      'message',
+    ]);
+    expect(rebuilt.map((evt) => evt.message?.content ?? evt.content)).toEqual([
+      'delete ingress gateway dashboard',
+      'I found two matching dashboards.',
+      'Listing dashboards',
+      '2 dashboards',
+      'Which one should I delete?',
+    ]);
+    expect(rebuilt.some((evt) => evt.message?.id === 'assistant-final')).toBe(false);
+  });
+
+  it('keeps legacy assistant messages when no reply trace was persisted', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'hello',
+        timestamp: '2026-05-12T01:00:00.000Z',
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'hi',
+        timestamp: '2026-05-12T01:00:01.000Z',
+      },
+    ];
+
+    const rebuilt = rebuildChatEventsFromSession(messages, []);
+
+    expect(rebuilt.map((evt) => evt.message?.content)).toEqual(['hello', 'hi']);
+  });
+});

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -52,27 +52,50 @@ export interface UseChatResult {
  * by the chat panel. Mirrors the live parsing in handleSSEEvent so replayed
  * history renders identically to the live stream.
  */
-function payloadToChatEvent(
+export function payloadToChatEvent(
   id: string,
   kind: string,
   payload: Record<string, unknown>,
+  timestamp?: string,
 ): ChatEvent | null {
   switch (kind) {
+    case 'reply': {
+      const content = (payload.content as string) ?? '';
+      if (!content) return null;
+      return {
+        id,
+        kind: 'message',
+        message: {
+          id,
+          role: 'assistant',
+          content,
+          timestamp: timestamp ?? new Date().toISOString(),
+        },
+      };
+    }
     case 'thinking':
       return {
         id,
         kind: 'thinking',
         content: (payload.content as string) ?? 'Thinking...',
       };
-    case 'tool_call':
+    case 'tool_call': {
+      const params =
+        payload.args && typeof payload.args === 'object' && !Array.isArray(payload.args)
+          ? (payload.args as Record<string, unknown>)
+          : undefined;
       return {
         id,
         kind: 'tool_call',
         tool: payload.tool as string | undefined,
         content:
           (payload.displayText as string) ?? (payload.content as string) ?? '',
+        ...(params ? { params } : {}),
+        ...(typeof payload.evidenceId === 'string' ? { evidenceId: payload.evidenceId } : {}),
       };
-    case 'tool_result':
+    }
+    case 'tool_result': {
+      const output = typeof payload.output === 'string' ? payload.output : undefined;
       return {
         id,
         kind: 'tool_result',
@@ -80,7 +103,12 @@ function payloadToChatEvent(
         content:
           (payload.summary as string) ?? (payload.content as string) ?? '',
         success: payload.success !== false,
+        ...(output ? { output } : {}),
+        ...(typeof payload.evidenceId === 'string' ? { evidenceId: payload.evidenceId } : {}),
+        ...(typeof payload.cost === 'number' ? { cost: payload.cost } : {}),
+        ...(typeof payload.durationMs === 'number' ? { durationMs: payload.durationMs } : {}),
       };
+    }
     case 'panel_added':
       return {
         id,
@@ -162,6 +190,54 @@ function payloadToChatEvent(
       // verification_report / approval_required aren't currently rendered.
       return null;
   }
+}
+
+export interface PersistedChatSessionEvent {
+  id: string;
+  seq: number;
+  kind: string;
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+
+export function rebuildChatEventsFromSession(
+  messages: ChatMessage[],
+  persistedEvents: PersistedChatSessionEvent[] = [],
+): ChatEvent[] {
+  const hasPersistedReplies = persistedEvents.some((evt) => evt.kind === 'reply');
+
+  type Entry =
+    | { kind: 'msg'; ts: string; message: ChatMessage }
+    | { kind: 'evt'; ts: string; seq: number; evt: ChatEvent };
+
+  const entries: Entry[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && hasPersistedReplies) continue;
+    entries.push({ kind: 'msg', ts: msg.timestamp, message: msg });
+  }
+  for (const raw of persistedEvents) {
+    const evt = payloadToChatEvent(raw.id, raw.kind, raw.payload, raw.timestamp);
+    if (evt) {
+      entries.push({
+        kind: 'evt',
+        ts: raw.timestamp,
+        seq: raw.seq,
+        evt,
+      });
+    }
+  }
+  entries.sort((a, b) => {
+    if (a.ts !== b.ts) return a.ts < b.ts ? -1 : 1;
+    const aSeq = a.kind === 'evt' ? a.seq : -Infinity;
+    const bSeq = b.kind === 'evt' ? b.seq : -Infinity;
+    return aSeq - bSeq;
+  });
+
+  return entries.map((entry) =>
+    entry.kind === 'msg'
+      ? { id: entry.message.id, kind: 'message', message: entry.message }
+      : entry.evt,
+  );
 }
 
 function withChatQuery(path: string, sessionId: string): string {
@@ -484,13 +560,7 @@ export function useChat(): UseChatResult {
       const res = await apiClient.get<{
         sessionId: string;
         messages: ChatMessage[];
-        events?: Array<{
-          id: string;
-          seq: number;
-          kind: string;
-          payload: Record<string, unknown>;
-          timestamp: string;
-        }>;
+        events?: PersistedChatSessionEvent[];
       }>(`/chat/sessions/${sessionId}/messages`);
 
       if (token !== loadTokenRef.current) {
@@ -533,46 +603,7 @@ export function useChat(): UseChatResult {
       const loaded = res.data.messages;
       setMessages(loaded);
 
-      // Rebuild the full event trace so the chat panel looks identical to the
-      // live run: messages interleaved with the agent-activity events they
-      // produced (tool_call / tool_result / panel_added / thinking / etc.).
-      // Strategy: turn each message + each persisted step event into a
-      // timestamped entry, sort chronologically, then convert to ChatEvents.
-      type Entry =
-        | { kind: 'msg'; ts: string; message: ChatMessage }
-        | { kind: 'evt'; ts: string; seq: number; id: string; evt: ChatEvent };
-
-      const entries: Entry[] = [];
-      for (const msg of loaded) {
-        entries.push({ kind: 'msg', ts: msg.timestamp, message: msg });
-      }
-      for (const raw of res.data.events ?? []) {
-        const evt = payloadToChatEvent(raw.id, raw.kind, raw.payload);
-        if (evt)
-          entries.push({
-            kind: 'evt',
-            ts: raw.timestamp,
-            seq: raw.seq,
-            id: raw.id,
-            evt,
-          });
-      }
-      entries.sort((a, b) => {
-        if (a.ts !== b.ts) return a.ts < b.ts ? -1 : 1;
-        // Same timestamp: events use seq for ordering; messages come before
-        // any same-timestamp events to match the live-stream order (user
-        // message appended, then agent activity begins).
-        const aSeq = a.kind === 'evt' ? a.seq : -Infinity;
-        const bSeq = b.kind === 'evt' ? b.seq : -Infinity;
-        return aSeq - bSeq;
-      });
-
-      const rebuilt: ChatEvent[] = entries.map((e) =>
-        e.kind === 'msg'
-          ? { id: e.message.id, kind: 'message', message: e.message }
-          : e.evt,
-      );
-      setEvents(rebuilt);
+      setEvents(rebuildChatEventsFromSession(loaded, res.data.events ?? []));
     } catch (err) {
       if (token !== loadTokenRef.current) {
         // Same race guard for thrown errors — a stale failure must not

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -6,8 +6,7 @@ import { fadeIn } from '../animations.js';
 import ConfirmDialog from '../components/ConfirmDialog.js';
 import { relativeTime } from '../utils/time.js';
 import { useGlobalChat } from '../contexts/ChatContext.js';
-import { groupEvents } from '../components/chat/event-processing.js';
-import type { Block } from '../components/chat/event-processing.js';
+import { groupEvents, liveAgentBlockId } from '../components/chat/event-processing.js';
 import {
   UserMessage,
   AssistantMessage,
@@ -126,13 +125,7 @@ export default function Home() {
   const hasMessages = events.length > 0;
 
   const blocks = useMemo(() => groupEvents(events), [events]);
-  const lastAgentBlockId = useMemo(() => {
-    for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      if (blocks[i]!.type === 'agent')
-        return (blocks[i] as Extract<Block, { type: 'agent' }>).id;
-    }
-    return null;
-  }, [blocks]);
+  const liveBlockId = useMemo(() => liveAgentBlockId(blocks, isGenerating), [blocks, isGenerating]);
 
   const chatIdFromUrl = useMemo(
     () => new URLSearchParams(location.search).get('chat'),
@@ -462,7 +455,7 @@ export default function Home() {
                 <AgentActivityBlock
                   key={block.id}
                   events={block.events}
-                  isLive={isGenerating && block.id === lastAgentBlockId}
+                  isLive={block.id === liveBlockId}
                 />
               );
             }


### PR DESCRIPTION
## Summary
- Persist assistant reply SSE events so loaded sessions replay the same message/tool interleaving as the live Home chat
- Rebuild session events from reply traces without duplicating the final assistant message
- Only mark the trailing agent block as live so submitting a new message does not auto-expand previous step blocks

## Tests
- npx vitest run packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx packages/web/src/hooks/useChat.test.ts
- npm --workspace @agentic-obs/web run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent activity blocks now correctly identify and display the active block during generation.
  * Chat event persistence expanded to include reply events, improving session recovery and replay accuracy.

* **Bug Fixes**
  * Fixed agent activity tracking logic for more reliable "live" block identification during chat generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->