### PR TITLE
Preserve live chat state across navigation

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -53,10 +53,14 @@ function LayoutInner() {
       }
       return;
     }
+    if (chatId === currentSessionId) {
+      loadedUrlChatRef.current = chatId;
+      return;
+    }
     if (loadedUrlChatRef.current === chatId) return;
     loadedUrlChatRef.current = chatId;
     void loadSession(chatId);
-  }, [location.search, loadSession, showChat, startNewSession]);
+  }, [currentSessionId, location.search, loadSession, showChat, startNewSession]);
 
   useEffect(() => {
     if (!showChat || !currentSessionId) return;

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -136,12 +136,14 @@ export default function Home() {
   // a durable personal chat to reopen.
   useEffect(() => {
     if (chatIdFromUrl) {
-      void loadSession(chatIdFromUrl);
+      if (chatIdFromUrl !== currentSessionId) {
+        void loadSession(chatIdFromUrl);
+      }
     } else {
       globalChat.startNewSession();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatIdFromUrl]);
+  }, [chatIdFromUrl, currentSessionId]);
 
   const handleDeleteDashboard = useCallback(async (id: string) => {
     const res = await apiClient.delete(`/dashboards/${id}`);


### PR DESCRIPTION
## Summary
- Avoid reloading the current chat session when resource pages see the same chat id in the URL
- Avoid Home reloading the same active session after it syncs the current session id into the URL
- Keeps Home and post-navigation chat rendering backed by the same in-memory event state

## Tests
- npm --workspace @agentic-obs/web run typecheck