### PR TITLE
RFC-1: Folder UX honesty — show mixed-resource counts

### DIFF
--- a/docs/design/ai-native-resource-organization.md
+++ b/docs/design/ai-native-resource-organization.md
@@ -1,0 +1,426 @@
+# AI-Native Resource Organization
+
+## Problem
+
+Rounds currently exposes Grafana-style folders directly on the Dashboards page.
+That is useful for compatibility and permissions, but it creates the wrong
+product mental model:
+
+- A folder may contain dashboards, alert rules, silences, and other resources,
+  but the Dashboards page renders it like a dashboard-only directory.
+- Alert-only folders look empty: "0 dashboards" even when they contain alert
+  rules.
+- Users coming from Grafana expect a personal folder for scratch dashboards,
+  but AI-generated work should not force users to manually organize every
+  temporary exploration.
+- AI workflows create related resources together: dashboard, alert rules,
+  investigation notes, service context, and approvals. A plain file browser
+  hides those relationships.
+
+The product should keep Grafana-compatible folders as a storage and permission
+primitive, while making the primary experience centered on work, ownership,
+services, and AI-created resource relationships.
+
+## Grafana Baseline
+
+Grafana folders are not dashboard-only. They are an organization and permission
+boundary for multiple resource types. Folder permissions apply to resources in
+the folder, including dashboards and alert rules.
+
+Compatibility requirements to preserve where they matter:
+
+- Users browse folders and dashboards from the Dashboards section.
+- Dashboards without a folder appear at the top level.
+- Folders can be used to manage permissions for teams and roles.
+- Alert rules can be scoped by folder for access control.
+- Users often create personal folders named after themselves for scratch work.
+- Power users rely on search, recent dashboards, starring, sharing links,
+  copying dashboards, importing/exporting JSON, and moving dashboards between
+  folders.
+
+Rounds should preserve the useful compatibility layer without copying the
+entire folder-first UX.
+
+References:
+
+- Grafana folder access control: https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/folder-access-control/
+- Grafana dashboard management: https://grafana.com/docs/grafana/latest/visualizations/dashboards/manage-dashboards/
+
+## Product Principles
+
+1. Folders are an RBAC and compatibility primitive, not the main user mental
+   model.
+2. Users should find work by service, owner, environment, recency, and health.
+3. AI-created resources should be grouped automatically.
+4. Personal scratch work should be first-class and private by default.
+5. Team/shared resources should be promoted intentionally.
+6. Grafana-style browsing remains available for migration, admin, and power use.
+
+## Status & Scope
+
+This document captures the long-term direction. Only RFC-1 (Folder UX honesty)
+is committed for the current cycle. RFC-2 through RFC-6 are kept as future
+direction but are out of scope until validated.
+
+## RFC-1: Folder UX honesty (committed)
+
+Goal: make the existing Dashboards page honest about what folders contain.
+This is the only change needed to fix the reported user-visible bug
+(alert-only folders rendering "0 dashboards").
+
+### Folder Row
+
+Current:
+
+```text
+Alerts
+0 dashboards
+```
+
+Better:
+
+```text
+Alerts
+0 dashboards · 3 alert rules
+```
+
+If the folder is alert-only and the current tab is Dashboards:
+
+```text
+Alerts
+No dashboards · contains 3 alert rules
+```
+
+### Folder Detail Empty State
+
+If a folder has no dashboards but has alert rules:
+
+```text
+This folder has no dashboards.
+It contains 3 alert rules.
+
+[View alert rules] [Create dashboard here]
+```
+
+### Folder Header
+
+When inside a folder:
+
+```text
+Dashboards / Platform / Ingress Gateway
+2 dashboards · 5 alert rules · 1 subfolder
+```
+
+### Search Results
+
+Search should group mixed resource types:
+
+```text
+Folders
+  Platform / Ingress Gateway
+
+Dashboards
+  HTTP Latency Monitoring
+
+Alert rules
+  P99 latency above threshold
+
+Panels
+  Request duration p99
+```
+
+### API: Folder Counts
+
+Add counts to folder responses or a batch endpoint:
+
+```http
+GET /api/folders?includeCounts=true
+```
+
+Response:
+
+```json
+{
+  "uid": "alerts",
+  "title": "Alerts",
+  "counts": {
+    "dashboards": 0,
+    "alertRules": 3,
+    "subfolders": 0
+  }
+}
+```
+
+Batch alternative:
+
+```http
+POST /api/folders/counts
+{ "uids": ["alerts", "platform"] }
+```
+
+### Tasks
+
+- Add folder counts for dashboards, alert rules, and subfolders.
+- Render mixed-resource counts in folder rows.
+- Add alert-only folder empty state with "View alert rules".
+- Keep Dashboards page focused on dashboards, but stop implying folders are
+  dashboard-only.
+
+## Deferred RFCs
+
+The following RFCs sketch a longer-term direction. They are kept here so the
+design conversation is not lost, but none are committed. Each has a gate that
+must be cleared before promotion to a committed RFC.
+
+### RFC-2: My Workspace (deferred)
+
+Deferred until: RFC-1 ships and we have data on personal vs shared resource
+usage.
+
+A personal scratchpad that replaces the Grafana habit of manually creating a
+folder named after yourself.
+
+Default behavior:
+
+- Every user gets a private workspace automatically.
+- AI defaults temporary, ambiguous, or exploratory resources into My workspace.
+- Items can be promoted to a team/service/shared location.
+- Temporary items have lifecycle metadata.
+
+Example:
+
+```text
+My workspace
+  Drafts
+    p99 latency debug        last opened 2h ago
+    checkout error spike     last opened 2h ago
+  Pinned
+    my on-call view
+  Archived
+    old redis migration checks
+```
+
+Save flow destinations:
+
+```text
+Save to
+  My workspace
+  Service: ingress-gateway
+  Team: Platform
+  Shared library
+```
+
+Lifecycle fields:
+
+- Draft / Pinned / Shared / Promoted / Archived
+- `last_opened_at`
+- manual `archived` state
+
+Rounds will not auto-archive or auto-expire user resources. Lifecycle fields
+are display-only and user-driven.
+
+Saved explorations (lightweight query workspaces) are listed here as a candidate
+resource type but are under-specified — see Open Risks. RFC-2 must either
+define their CRUD/permission/storage model or scope them to ephemeral query
+windows.
+
+Promotion changes visibility and folder/RBAC placement. Promoting asks for
+target service/team/folder, owner, description, whether to create matching
+alert rules, and whether to notify a team.
+
+Shared dashboards are never the default place for experiments. Users duplicate
+to My workspace, iterate, and promote back.
+
+### RFC-3: Library (deferred)
+
+Deferred until: RFC-1 + RFC-2 ship.
+
+Library is the mixed-resource browser and admin surface — the Grafana-compatible
+power-user view.
+
+Capabilities:
+
+- Browse folders with mixed resource counts.
+- Move resources between folders.
+- Bulk archive/delete/move.
+- Manage folder permissions.
+- Import/export dashboard JSON and alert definitions.
+- View provisioned vs user-created resources.
+- See orphaned resources and resources without owner/service metadata.
+
+Provisioning rules:
+
+- Provisioned resources are read-only by default.
+- Users can fork provisioned resources to My workspace.
+- AI proposes PR-ready changes rather than mutating provisioned resources.
+- Library shows source metadata: repo, path, commit, provisioner.
+
+Permission changes show impact:
+
+```text
+This affects:
+  8 dashboards
+  12 alert rules
+  3 silences
+```
+
+### RFC-4: Services (deferred)
+
+Deferred until: a service-identity spike confirms ≥70% of resources can be
+auto-attributed to a service from k8s labels / CODEOWNERS / manual tags.
+
+Make service-centric organization the default operational model.
+
+Each service page aggregates:
+
+- Golden signal dashboard
+- Related dashboards
+- Alert rules
+- Firing or noisy alerts
+- Recent investigations
+- Recent deploys / changes
+- Owners and teams
+- Environments and namespaces
+
+Example:
+
+```text
+Ingress Gateway
+  Health: warning
+  Dashboards: 2
+  Alert rules: 5
+  Investigations: 3 recent
+  Owner: Platform
+  Environments: prod, staging
+```
+
+AI infers variables (service, namespace, workload, cluster, environment,
+region, metric labels) so a dashboard opened from `ingress-gateway / prod`
+scopes itself to that service and environment. Inferred variables must be
+shown in the dashboard header on first open and confirmed by the user — see
+Open Risks.
+
+### RFC-5: Sharing, Versions, and Operational Views (deferred)
+
+Deferred until: RFC-2 ships.
+
+Sharing should be explicit, temporary when appropriate, and safe for personal
+work.
+
+Share options:
+
+- Share with user / team
+- Create expiring link
+- Create incident snapshot (dashboard link, time range, variables, related
+  alerts, AI summary)
+- Promote to shared library
+
+Dashboards have a version timeline with author, time, AI-generated change
+summary, panel/query/variable/layout diff, restore, and duplicate-version-to-
+My-workspace. Shared dashboards support a review flow before applying AI-
+generated large changes.
+
+Playlists / Views model rotating dashboards for wallboards and on-call rooms.
+AI can generate a view from a service, team, or active incident.
+
+### RFC-6: AI Resource Stewardship (deferred)
+
+Deferred. Likely folds into a single Home "AI suggestions" inbox rather than 6
+surfaces.
+
+Gap detection surfaces through a single Home "AI suggestions" inbox with
+snooze/dismiss, not as 6 independent channels.
+
+## Information Architecture (deferred direction)
+
+The long-term navigation shape that RFC-2 through RFC-6 build toward:
+
+```text
+Home
+Services
+Dashboards
+Alerts
+Investigations
+My workspace
+Library
+Settings
+```
+
+Home is the operational command center: what is unhealthy, what changed, what
+needs approval, recent AI-created resources, open investigations, pinned
+services, personal drafts. Home answers "what should I do now?", not "where
+did I file something?"
+
+## Data Model
+
+Existing folder fields stay:
+
+```text
+dashboard.folder_uid
+alert_rule.folder_uid
+folder.uid
+```
+
+For deferred RFCs, formalize:
+
+```text
+resource_visibility
+  personal | team | shared | provisioned
+
+resource_owner
+  user_id
+  team_id
+  service_id
+
+resource_lifecycle
+  draft | active | temporary | archived
+  last_opened_at
+```
+
+Relations are encoded as explicit foreign keys on the resource
+(e.g. `dashboard.service_id`, `alert_rule.dashboard_panel_ref`) and via the
+existing provenance table for chat-session → resource creation lineage. A
+generic `resource_relation` table is rejected as over-abstraction.
+
+## Open Risks (from review)
+
+- **Service identity is not solved.** RFC-4's Service view assumes resources
+  can be auto-attributed to a service. Until a spike validates this, the
+  Service view will mis-attribute or under-attribute resources and will be
+  worse than the folder view.
+- **My workspace vs folder duality.** RFC-2 must decide whether My workspace
+  is a real folder (`uid: user:<id>`) or a virtual collection. Implementing
+  both creates two stores of truth. Pick one in the RFC-2 design doc.
+- **Promote flow crosses RBAC boundaries.** Promoting personal drafts into
+  shared collections must integrate with the GuardedAction confirmation model
+  and audit log — not a silent metadata edit.
+- **Variable inference is high-stakes.** Wrong namespace = wrong data.
+  RFC-4 must show inferred variables in the dashboard header on first open
+  and require user confirmation, not silent injection.
+- **Saved Explorations are under-specified.** Treated as a third resource type
+  here without CRUD / permission / storage design. RFC-2 must either define
+  them properly or scope them down to ephemeral query windows.
+
+## Open Questions
+
+- Should My workspace be implemented as a real folder, a virtual collection,
+  or both?
+- Should personal dashboards be visible to org admins by default?
+- What is the default retention for temporary resources?
+- Do we want a separate Explore page, or should chat + scratch panels replace
+  it?
+- Should service ownership come from Kubernetes labels, manually assigned
+  teams, GitHub CODEOWNERS, or all of the above?
+- How should provisioned/GitOps resources behave when AI wants to modify them?
+
+## Recommendation
+
+Ship RFC-1 now. It is the only piece needed to fix the reported user-visible
+bug (alert-only folders showing "0 dashboards") and it does not commit the
+product to any larger IA change.
+
+Treat RFC-2 through RFC-6 as direction, not commitment. Each requires its
+own validation gate (see "Deferred until" lines) before promotion to a
+committed RFC.
+
+Folders stay as the RBAC and compatibility backbone in all scenarios.

--- a/packages/api-gateway/src/services/folder-service.test.ts
+++ b/packages/api-gateway/src/services/folder-service.test.ts
@@ -329,6 +329,40 @@ describe('FolderService.getParents / getChildren / getCounts', () => {
   });
 });
 
+describe('FolderService.list counts', () => {
+  let db: SqliteClient;
+  beforeEach(async () => {
+    db = createTestDb();
+    await bootstrap(db);
+  });
+
+  it('returns mixed-resource counts per folder (RFC-1)', async () => {
+    const svc = makeService(db);
+    const alertsOnly = await seedFolder(svc, 'Alerts Only');
+    const empty = await seedFolder(svc, 'Empty');
+    // Two alert rules in `alertsOnly`, zero dashboards.
+    for (const id of ['ar1', 'ar2']) {
+      db.run(sql`
+        INSERT INTO alert_rules (
+          id, name, description, condition, evaluation_interval_sec,
+          severity, state, state_changed_at, created_by,
+          fire_count, created_at, updated_at, org_id, folder_uid
+        ) VALUES (
+          ${id}, ${id}, '', 'true', 60, 'warning', 'normal',
+          '2026-04-17T00:00:00Z', 'u', 0,
+          '2026-04-17T00:00:00Z', '2026-04-17T00:00:00Z',
+          'org_main', ${alertsOnly}
+        )
+      `);
+    }
+    const items = await svc.list('org_main', { parentUid: null });
+    const a = items.find((f) => f.uid === alertsOnly)!;
+    const e = items.find((f) => f.uid === empty)!;
+    expect(a.counts).toEqual({ dashboards: 0, alertRules: 2, subfolders: 0 });
+    expect(e.counts).toEqual({ dashboards: 0, alertRules: 0, subfolders: 0 });
+  });
+});
+
 describe('slugifyUid', () => {
   it('lowercases and replaces non-alnum runs with _', () => {
     expect(slugifyUid('Hello World!')).toBe('hello_world');

--- a/packages/api-gateway/src/services/folder-service.ts
+++ b/packages/api-gateway/src/services/folder-service.ts
@@ -166,7 +166,10 @@ export class FolderService {
     return this.deps.folders.findByUid(orgId, uid);
   }
 
-  async list(orgId: string, opts: ListFoldersOpts = {}): Promise<GrafanaFolder[]> {
+  async list(
+    orgId: string,
+    opts: ListFoldersOpts = {},
+  ): Promise<(GrafanaFolder & { counts: FolderCounts })[]> {
     const { items } = await this.deps.folders.list({
       orgId,
       // `undefined` = "all folders". `null` = "roots only". A concrete string =
@@ -175,11 +178,62 @@ export class FolderService {
       limit: opts.limit ?? 200,
       offset: opts.offset ?? 0,
     });
-    if (opts.query) {
-      const q = opts.query.toLowerCase();
-      return items.filter((f) => f.title.toLowerCase().includes(q));
-    }
-    return items;
+    const filtered = opts.query
+      ? items.filter((f) => f.title.toLowerCase().includes(opts.query!.toLowerCase()))
+      : items;
+    const countsByUid = await this.getFolderCounts(
+      orgId,
+      filtered.map((f) => f.uid),
+    );
+    return filtered.map((f) => ({
+      ...f,
+      counts: countsByUid.get(f.uid) ?? { dashboards: 0, alertRules: 0, subfolders: 0 },
+    }));
+  }
+
+  /**
+   * Batch counts for many folders. Three GROUP BY queries — one per resource
+   * type — joined in memory. Returns a map keyed by folder uid; folders with
+   * zero of every resource may be missing from the map (callers should default
+   * to zeros).
+   */
+  async getFolderCounts(
+    orgId: string,
+    folderUids: string[],
+  ): Promise<Map<string, FolderCounts>> {
+    const out = new Map<string, FolderCounts>();
+    if (folderUids.length === 0) return out;
+    const placeholders = sql.join(
+      folderUids.map((u) => sql`${u}`),
+      sql`, `,
+    );
+    const ensure = (uid: string): FolderCounts => {
+      let c = out.get(uid);
+      if (!c) {
+        c = { dashboards: 0, alertRules: 0, subfolders: 0 };
+        out.set(uid, c);
+      }
+      return c;
+    };
+    const dashRows = await this.deps.db.all<{ folder_uid: string; n: number }>(sql`
+      SELECT folder_uid, COUNT(*) AS n FROM dashboards
+      WHERE org_id = ${orgId} AND folder_uid IN (${placeholders})
+      GROUP BY folder_uid
+    `);
+    for (const r of dashRows) ensure(r.folder_uid).dashboards = Number(r.n);
+    const ruleRows = await this.deps.db.all<{ folder_uid: string; n: number }>(sql`
+      SELECT folder_uid, COUNT(*) AS n FROM alert_rules
+      WHERE org_id = ${orgId} AND folder_uid IN (${placeholders})
+      GROUP BY folder_uid
+    `);
+    for (const r of ruleRows) ensure(r.folder_uid).alertRules = Number(r.n);
+    const subRows = await this.deps.db.all<{ parent_uid: string; n: number }>(sql`
+      SELECT parent_uid, COUNT(*) AS n FROM folder
+      WHERE org_id = ${orgId} AND parent_uid IN (${placeholders})
+      GROUP BY parent_uid
+    `);
+    for (const r of subRows) ensure(r.parent_uid).subfolders = Number(r.n);
+    return out;
   }
 
   async update(

--- a/packages/web/src/pages/Dashboards.tsx
+++ b/packages/web/src/pages/Dashboards.tsx
@@ -21,6 +21,12 @@ interface Dashboard {
   folder?: string;
 }
 
+interface FolderCounts {
+  dashboards: number;
+  alertRules: number;
+  subfolders: number;
+}
+
 interface Folder {
   id: string;
   name: string;
@@ -29,6 +35,7 @@ interface Folder {
   title?: string;
   parentUid?: string | null;
   createdAt: string;
+  counts?: FolderCounts;
 }
 
 type SortKey = 'date' | 'name';
@@ -523,8 +530,25 @@ export default function Dashboards() {
             )}
 
             {visibleFolders.map((folder) => {
-              const childCount = folders.filter((child) => child.parentId === folder.id).length;
-              const dashboardCount = dashboards.filter((dashboard) => dashboard.folder === folder.id).length;
+              const localChildCount = folders.filter((child) => child.parentId === folder.id).length;
+              const localDashboardCount = dashboards.filter((dashboard) => dashboard.folder === folder.id).length;
+              // Prefer server-supplied counts (which include alert rules and
+              // are authoritative across pagination). Fall back to whatever we
+              // can compute locally if the backend hasn't shipped counts yet.
+              const dashboardCount = folder.counts?.dashboards ?? localDashboardCount;
+              const alertRuleCount = folder.counts?.alertRules ?? 0;
+              const childCount = folder.counts?.subfolders ?? localChildCount;
+              let summary: string;
+              if (dashboardCount > 0 && alertRuleCount > 0) {
+                summary = `${dashboardCount} dashboards · ${alertRuleCount} alert rules`;
+              } else if (dashboardCount > 0) {
+                summary = `${dashboardCount} dashboards`;
+              } else if (alertRuleCount > 0) {
+                summary = `No dashboards · contains ${alertRuleCount} alert rules`;
+              } else {
+                summary = 'Empty';
+              }
+              if (childCount > 0) summary += ` · ${childCount} subfolders`;
               return (
                 <div
                   key={folder.id}
@@ -545,7 +569,7 @@ export default function Dashboards() {
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium text-on-surface">{folder.name}</div>
                     <div className="text-xs text-on-surface-variant">
-                      {dashboardCount} dashboards{childCount > 0 ? ` · ${childCount} folders` : ''}
+                      {summary}
                     </div>
                   </div>
                   <button
@@ -604,9 +628,34 @@ export default function Dashboards() {
             ))}
 
             {visibleFolders.length === 0 && visibleDashboards.length === 0 && !showNewFolder && (
-              <div className="px-4 py-10 text-center text-sm text-on-surface-variant">
-                This folder is empty.
-              </div>
+              currentFolder && (currentFolder.counts?.dashboards ?? 0) === 0 && (currentFolder.counts?.alertRules ?? 0) > 0 ? (
+                <div className="px-4 py-10 text-center text-sm text-on-surface-variant">
+                  <p className="mb-1 text-on-surface">This folder has no dashboards.</p>
+                  <p className="mb-4">It contains {currentFolder.counts?.alertRules} alert rules.</p>
+                  <div className="flex justify-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/alerts?folder=${encodeURIComponent(currentFolder.id)}`)}
+                      className="bg-surface-container border border-outline-variant text-on-surface-variant hover:text-on-surface hover:border-outline px-4 py-2 text-xs font-semibold transition-colors"
+                    >
+                      View alert rules
+                    </button>
+                    {canCreateDashboard && (
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/?folder=${encodeURIComponent(currentFolder.id)}`)}
+                        className="bg-primary text-on-primary-fixed px-4 py-2 text-xs font-semibold transition-transform active:scale-95"
+                      >
+                        Create dashboard here
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="px-4 py-10 text-center text-sm text-on-surface-variant">
+                  This folder is empty.
+                </div>
+              )
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

Fixes the misleading "0 dashboards" label on alert-only folders. Implements **RFC-1** of `docs/design/ai-native-resource-organization.md`; defers RFC-2 through RFC-6.

- **Backend** (`packages/api-gateway`): `GET /api/folders` now always includes `counts: { dashboards, alertRules, subfolders }` per folder (3 batched GROUP BY queries — no perf flag needed).
- **Frontend** (`packages/web/src/pages/Dashboards.tsx`): folder rows render `"No dashboards · contains 3 alert rules"` instead of `"0 dashboards"`. Entering an alert-only folder shows a dedicated empty state with **View alert rules** + **Create dashboard here** actions.
- **Doc**: refactored `ai-native-resource-organization.md` (927 → 426 lines) — committed RFC-1, deferred RFC-2..6 with explicit "deferred until" gates, dropped generic `resource_relation` table, removed auto-expire, collapsed AI gap detection to a single inbox concept, added "Open Risks (from review)".

## Out of scope (intentional)

- "View alert rules" button emits `/alerts?folder={id}`. Wiring the filter into the Alerts page is part of RFC-1 follow-up — the page currently doesn't read the param. Adding the filter is a small follow-up; flagging it explicitly so it's not lost.
- All of RFC-2..6 (My workspace, Services, Library, etc.) — deferred per design doc.

## Test plan

- [x] `npx vitest run packages/api-gateway` — 773/773 pass (agent-verified)
- [x] `tsc --noEmit` in `packages/api-gateway` and `packages/web` — clean (agent-verified)
- [ ] CI green
- [ ] Manual: open Dashboards page, navigate into an alert-only folder, verify row label + empty state + "View alert rules" navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder rows now display accurate counts of all resource types (dashboards, alert rules, subfolders).
  * Improved empty state messaging for folders containing only alert rules.

* **Documentation**
  * Added AI-Native Resource Organization design document outlining folder UX improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->