### PR TITLE
Wave1-A: AuditAction enum extension + resource mutation wiring

### DIFF
--- a/packages/agent-core/src/agent/handlers/_context.ts
+++ b/packages/agent-core/src/agent/handlers/_context.ts
@@ -12,6 +12,7 @@ import type {
   Identity,
   IFolderRepository,
   InvestigationReportSection,
+  NewAuditLogEntry,
   Provenance,
 } from '@agentic-obs/common';
 import type { LLMGateway } from '@agentic-obs/llm-gateway';
@@ -94,6 +95,14 @@ export interface ActionContext {
    */
   identity: Identity;
   accessControl: IAccessControlService;
+  /**
+   * Optional fire-and-forget audit log writer. When wired, resource-mutating
+   * handlers (alert_rule_write, investigation_create, etc.) emit audit rows
+   * via this slim function. Optional so tests / in-memory wirings can omit;
+   * production callers in api-gateway pass through `AuditWriter.log`.
+   * Failures are the caller's responsibility — handlers must not await this.
+   */
+  auditWriter?: (entry: NewAuditLogEntry) => Promise<void>;
 
   actionExecutor: ActionExecutor;
 

--- a/packages/agent-core/src/agent/handlers/alert.ts
+++ b/packages/agent-core/src/agent/handlers/alert.ts
@@ -1,4 +1,4 @@
-import { ac, type AlertCondition, type AlertOperator, type AlertSeverity } from '@agentic-obs/common';
+import { ac, AuditAction, type AlertCondition, type AlertOperator, type AlertSeverity } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
 import type { ActionContext } from './_context.js';
 import { withWorkspaceScope } from './_shared.js';
@@ -226,6 +226,17 @@ async function createAlertRule(
 
   const rc = rule.condition as Record<string, unknown>;
   const verb = isUpdate ? 'Updated' : 'Created';
+  void ctx.auditWriter?.({
+    action: isUpdate ? AuditAction.AlertRuleUpdate : AuditAction.AlertRuleCreate,
+    actorType: 'user',
+    actorId: ctx.identity.userId,
+    orgId: ctx.identity.orgId,
+    targetType: 'alert_rule',
+    targetId: String(rule.id ?? ''),
+    targetName: String(rule.name ?? generated.name),
+    outcome: 'success',
+    metadata: { severity: rule.severity, folderUid, via: 'agent_tool' },
+  });
   ctx.pushConversationAction({
     type: 'create_alert_rule',
     ruleId: String(rule.id ?? ''),
@@ -326,6 +337,18 @@ async function updateAlertRule(
 
   const updatedRule = await ctx.alertRuleStore.update(ruleId, updatePatch) as Record<string, unknown> | undefined;
 
+  void ctx.auditWriter?.({
+    action: AuditAction.AlertRuleUpdate,
+    actorType: 'user',
+    actorId: ctx.identity.userId,
+    orgId: ctx.identity.orgId,
+    targetType: 'alert_rule',
+    targetId: ruleId,
+    targetName: String(updatedRule?.name ?? existingRule.name ?? ''),
+    outcome: 'success',
+    metadata: { patch: updatePatch, via: 'agent_tool' },
+  });
+
   ctx.pushConversationAction({
     type: 'modify_alert_rule',
     ruleId,
@@ -369,6 +392,18 @@ async function deleteAlertRule(
   }
 
   await ctx.alertRuleStore.delete(ruleId);
+
+  void ctx.auditWriter?.({
+    action: AuditAction.AlertRuleDelete,
+    actorType: 'user',
+    actorId: ctx.identity.userId,
+    orgId: ctx.identity.orgId,
+    targetType: 'alert_rule',
+    targetId: ruleId,
+    targetName: String(existingRule?.name ?? ''),
+    outcome: 'success',
+    metadata: { via: 'agent_tool' },
+  });
 
   ctx.pushConversationAction({ type: 'delete_alert_rule', ruleId });
 

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { ac } from '@agentic-obs/common';
+import { ac, AuditAction } from '@agentic-obs/common';
 import type { PendingDashboardChange, PendingDashboardChangeOp } from '@agentic-obs/common';
 import type { ActionContext } from './_context.js';
 import { withToolEventBoundary, withWorkspaceScope } from './_shared.js';
@@ -94,6 +94,17 @@ export async function handleDashboardCreate(
       ctx.setNavigateTo(`/dashboards/${dashboard.id}`);
 
       createdId = dashboard.id;
+      void ctx.auditWriter?.({
+        action: AuditAction.DashboardCreate,
+        actorType: 'user',
+        actorId: ctx.identity.userId,
+        orgId: ctx.identity.orgId,
+        targetType: 'dashboard',
+        targetId: dashboard.id,
+        targetName: dashboard.title,
+        outcome: 'success',
+        metadata: { datasourceId, via: 'agent_tool' },
+      });
       // Mark this dashboard as the active one for the session — subsequent
       // dashboard_add_panels / modify_panel / etc. calls in this ReAct loop
       // pick it up implicitly instead of taking a (truncatable) id param.
@@ -193,6 +204,18 @@ export async function handleDashboardClone(
       // The freshly cloned dashboard becomes the active one (same as create).
       ctx.activeDashboardId = created.id;
       ctx.freshlyCreatedDashboards.add(created.id);
+
+      void ctx.auditWriter?.({
+        action: AuditAction.DashboardFork,
+        actorType: 'user',
+        actorId: ctx.identity.userId,
+        orgId: ctx.identity.orgId,
+        targetType: 'dashboard',
+        targetId: created.id,
+        targetName: created.title,
+        outcome: 'success',
+        metadata: { sourceDashboardId, targetDatasourceId, via: 'agent_tool' },
+      });
 
       const observation = `Cloned "${source.title}" (${clonedPanels.length} panel${clonedPanels.length === 1 ? '' : 's'}) to connector ${targetDatasourceId}. New dashboard id: ${created.id}.`;
       ctx.emitAgentEvent(

--- a/packages/agent-core/src/agent/handlers/folder.ts
+++ b/packages/agent-core/src/agent/handlers/folder.ts
@@ -1,4 +1,4 @@
-import { ac } from '@agentic-obs/common';
+import { ac, AuditAction } from '@agentic-obs/common';
 import type { GrafanaFolder } from '@agentic-obs/common';
 import type { ActionContext } from './_context.js';
 
@@ -34,6 +34,18 @@ export async function handleFolderCreate(
     parentUid,
     createdBy: ctx.identity.userId,
     updatedBy: ctx.identity.userId,
+  });
+
+  void ctx.auditWriter?.({
+    action: AuditAction.FolderCreate,
+    actorType: 'user',
+    actorId: ctx.identity.userId,
+    orgId: ctx.identity.orgId,
+    targetType: 'folder',
+    targetId: folder.uid,
+    targetName: folder.title,
+    outcome: 'success',
+    metadata: { parentUid: folder.parentUid, via: 'agent_tool' },
   });
 
   const observation = `Folder "${folder.title}" created (uid=${folder.uid})${folder.parentUid ? ` under ${folder.parentUid}` : ' at root'}.`;

--- a/packages/agent-core/src/agent/handlers/investigation.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { ac } from '@agentic-obs/common';
+import { ac, AuditAction } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
 import type {
   Citation,
@@ -64,6 +64,17 @@ export async function handleInvestigationCreate(
       );
 
       createdId = investigation.id;
+      void ctx.auditWriter?.({
+        action: AuditAction.InvestigationCreate,
+        actorType: 'user',
+        actorId: ctx.identity.userId,
+        orgId: ctx.identity.orgId,
+        targetType: 'investigation',
+        targetId: investigation.id,
+        targetName: question,
+        outcome: 'success',
+        metadata: { sessionId: ctx.sessionId, via: 'agent_tool' },
+      });
       // Mark this investigation as the active one for the session.
       // `add_section` and `complete` read from here; the LLM no longer
       // has to copy the id back through tool params (which it sometimes

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -212,6 +212,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     store: repos.dashboards,
     accessControl,
     setupConfig,
+    audit: authSub.audit,
   }));
   app.use('/api/chat', createChatRouter({
     dashboardStore: repos.dashboards,
@@ -238,6 +239,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     setupConfig,
     folderRepository: sharedFolderRepo,
     ac: accessControl,
+    audit: authSub.audit,
     ...(deps.runner ? { runner: deps.runner } : {}),
   }));
   // /api/folders is mounted in rbac-routes.ts (T7.1).

--- a/packages/api-gateway/src/app/rbac-routes.ts
+++ b/packages/api-gateway/src/app/rbac-routes.ts
@@ -265,6 +265,7 @@ export async function mountRbacRoutes(
   const folderService = new FolderService({
     folders: sharedFolderRepo,
     db,
+    audit: authSub.audit,
   });
   const resourcePermissionService = new ResourcePermissionService({
     roles: rbacRoleRepo,

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -4,7 +4,9 @@ import type { AlertRule, AlertSilence, NotificationPolicy, IFolderRepository } f
 import {
   ACTIONS,
   ac,
+  AuditAction,
 } from '@agentic-obs/common';
+import type { AuditWriter } from '../auth/audit-writer.js';
 import type { IAlertRuleRepository, IGatewayInvestigationStore, IGatewayFeedStore, IInvestigationReportRepository } from '@agentic-obs/data-layer';
 import { defaultAlertRuleStore } from '@agentic-obs/data-layer';
 import { runBackgroundAgent, type BackgroundRunnerDeps } from '@agentic-obs/agent-core';
@@ -56,12 +58,18 @@ export interface AlertRulesRouterDeps {
    * (the legacy half-finished behavior).
    */
   runner?: BackgroundRunnerDeps;
+  /**
+   * Audit writer — records alert_rule.create/update/delete and
+   * investigation.create events for manual investigate flows.
+   */
+  audit?: AuditWriter;
 }
 
 export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
   const store = deps.alertRuleStore ?? defaultAlertRuleStore;
   const router = Router();
   const alertRuleService = new AlertRuleService(store, deps.setupConfig);
+  const audit = deps.audit;
   const requirePermission = createRequirePermission(deps.ac);
 
   async function resolveAlertRuleFolderUid(
@@ -370,6 +378,18 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
       };
       const rule = await store.create(createInput);
 
+      void audit?.log({
+        action: AuditAction.AlertRuleCreate,
+        actorType: 'user',
+        actorId: (req as AuthenticatedRequest).auth?.userId ?? null,
+        orgId: workspaceId,
+        targetType: 'alert_rule',
+        targetId: rule.id,
+        targetName: rule.name,
+        outcome: 'success',
+        metadata: { folderUid: rule.folderUid, severity: rule.severity },
+      });
+
       res.status(201).json(rule);
     },
   );
@@ -387,6 +407,20 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Alert rule not found' } });
         return;
       }
+      void audit?.log({
+        action: AuditAction.AlertRuleUpdate,
+        actorType: 'user',
+        actorId: (req as AuthenticatedRequest).auth?.userId ?? null,
+        orgId: resolveOrgId(req),
+        targetType: 'alert_rule',
+        targetId: updated.id,
+        targetName: updated.name,
+        outcome: 'success',
+        metadata: {
+          before: { severity: existing.severity, state: existing.state, condition: existing.condition },
+          after: { severity: updated.severity, state: updated.state, condition: updated.condition },
+        },
+      });
       res.json(updated);
     },
   );
@@ -403,6 +437,16 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Alert rule not found' } });
         return;
       }
+      void audit?.log({
+        action: AuditAction.AlertRuleDelete,
+        actorType: 'user',
+        actorId: (req as AuthenticatedRequest).auth?.userId ?? null,
+        orgId: resolveOrgId(req),
+        targetType: 'alert_rule',
+        targetId: existing.id,
+        targetName: existing.name,
+        outcome: 'success',
+      });
       res.status(204).end();
     },
   );
@@ -515,6 +559,18 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         });
 
         await store.update(rule.id, { investigationId: investigation.id });
+
+        void audit?.log({
+          action: AuditAction.InvestigationCreate,
+          actorType: 'user',
+          actorId: identity.userId,
+          orgId: workspaceId,
+          targetType: 'investigation',
+          targetId: investigation.id,
+          targetName: question,
+          outcome: 'success',
+          metadata: { alertRuleId: rule.id, manual: true },
+        });
 
         // Spawn the orchestrator in the background under the clicker's
         // identity. We respond immediately so the UI can subscribe to the

--- a/packages/api-gateway/src/routes/dashboard/router-audit.test.ts
+++ b/packages/api-gateway/src/routes/dashboard/router-audit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Audit wiring tests for the dashboard router (Wave 1 / PR-A).
+ *
+ * Verifies that PUT /dashboards/:id emits a dashboard.update audit row
+ * (or dashboard.move when the folder changes) via the AuditWriter passed
+ * through router deps.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { AuditAction, type Dashboard, type PanelConfig } from '@agentic-obs/common'
+import type { IGatewayDashboardStore } from '@agentic-obs/data-layer'
+import type { AccessControlSurface } from '../../services/accesscontrol-holder.js'
+import type { SetupConfigService } from '../../services/setup-config-service.js'
+import type { AuditWriter } from '../../auth/audit-writer.js'
+import { createDashboardRouter } from './router.js'
+
+vi.mock('../../middleware/auth.js', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.auth = {
+      userId: 'user_1',
+      orgId: 'org_main',
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    }
+    next()
+  },
+}))
+
+function dashboard(overrides: Partial<Dashboard> = {}): Dashboard {
+  return {
+    id: 'dash_owned',
+    type: 'dashboard',
+    title: 'Latency',
+    description: '',
+    prompt: 'show me latency',
+    userId: 'user_1',
+    status: 'ready',
+    panels: [] as PanelConfig[],
+    variables: [],
+    refreshIntervalSec: 30,
+    datasourceIds: [],
+    useExistingMetrics: true,
+    workspaceId: 'org_main',
+    folder: 'observability',
+    createdAt: '2026-04-26T00:00:00.000Z',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeStore(dash: Dashboard): IGatewayDashboardStore {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(async () => dash),
+    findAll: vi.fn(async () => [dash]),
+    update: vi.fn(async (_id, patch) => ({ ...dash, ...patch })),
+    updateStatus: vi.fn(),
+    updatePanels: vi.fn(),
+    updateVariables: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function makeApp(store: IGatewayDashboardStore, audit: AuditWriter) {
+  const accessControl: AccessControlSurface = {
+    evaluate: vi.fn(async () => true),
+    getUserPermissions: vi.fn(async () => []),
+    ensurePermissions: vi.fn(async () => []),
+    filterByPermission: vi.fn(async (_identity, items) => [...items]),
+  }
+
+  const app = express()
+  app.use(express.json())
+  app.use('/dashboards', createDashboardRouter({
+    store,
+    accessControl,
+    setupConfig: { listConnectors: vi.fn() } as unknown as SetupConfigService,
+    audit,
+  }))
+  return app
+}
+
+describe('dashboard router audit wiring', () => {
+  it('emits DashboardUpdate audit row on title change', async () => {
+    const log = vi.fn(async () => {})
+    const audit = { log } as unknown as AuditWriter
+    const store = makeStore(dashboard())
+    const app = makeApp(store, audit)
+
+    const res = await request(app)
+      .put('/dashboards/dash_owned')
+      .send({ title: 'New Title' })
+
+    expect(res.status).toBe(200)
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith(expect.objectContaining({
+      action: AuditAction.DashboardUpdate,
+      actorType: 'user',
+      actorId: 'user_1',
+      orgId: 'org_main',
+      targetType: 'dashboard',
+      targetId: 'dash_owned',
+      targetName: 'New Title',
+      outcome: 'success',
+      metadata: expect.objectContaining({
+        before: expect.objectContaining({ title: 'Latency', folder: 'observability' }),
+        after: expect.objectContaining({ title: 'New Title', folder: 'observability' }),
+      }),
+    }))
+  })
+
+  it('emits DashboardMove audit row when folder changes', async () => {
+    const log = vi.fn(async () => {})
+    const audit = { log } as unknown as AuditWriter
+    const store = makeStore(dashboard())
+    const app = makeApp(store, audit)
+
+    const res = await request(app)
+      .put('/dashboards/dash_owned')
+      .send({ folder: 'security' })
+
+    expect(res.status).toBe(200)
+    expect(log).toHaveBeenCalledWith(expect.objectContaining({
+      action: AuditAction.DashboardMove,
+      targetId: 'dash_owned',
+      metadata: expect.objectContaining({
+        before: expect.objectContaining({ folder: 'observability' }),
+        after: expect.objectContaining({ folder: 'security' }),
+      }),
+    }))
+  })
+})

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -7,9 +7,10 @@ import { authMiddleware } from '../../middleware/auth.js'
 import { createRequirePermission } from '../../middleware/require-permission.js'
 import type { IGatewayDashboardStore } from '@agentic-obs/data-layer'
 import { VariableResolver } from './variable-resolver.js'
-import { ac, ACTIONS } from '@agentic-obs/common'
+import { ac, ACTIONS, AuditAction } from '@agentic-obs/common'
 import type { Dashboard, PanelConfig } from '@agentic-obs/common'
 import type { SetupConfigService } from '../../services/setup-config-service.js'
+import type { AuditWriter } from '../../auth/audit-writer.js'
 import { getOrgId } from '../../middleware/workspace-context.js'
 
 /**
@@ -30,12 +31,19 @@ export interface DashboardRouterDeps {
   accessControl: AccessControlSurface
   /** W2 / T2.4 — LLM + datasource config source. */
   setupConfig: SetupConfigService
+  /**
+   * Audit writer — records resource mutation events (dashboard.create/update/
+   * delete/move). Optional so legacy tests can construct the router without
+   * one; production wires the same writer used by auth routes.
+   */
+  audit?: AuditWriter
 }
 
 export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter {
   const store = deps.store
   const accessControl = deps.accessControl
   const setupConfig = deps.setupConfig
+  const audit = deps.audit
 
   const router = Router()
   const requirePermission = createRequirePermission(accessControl)
@@ -82,6 +90,18 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         useExistingMetrics: body.useExistingMetrics ?? true,
         folder: body.folder,
         workspaceId,
+      })
+
+      void audit?.log({
+        action: AuditAction.DashboardCreate,
+        actorType: 'user',
+        actorId: userId,
+        orgId: workspaceId,
+        targetType: 'dashboard',
+        targetId: dashboard.id,
+        targetName: dashboard.title,
+        outcome: 'success',
+        metadata: { folder: dashboard.folder ?? null },
       })
 
       res.status(201).json(dashboard)
@@ -160,6 +180,24 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         return
       }
 
+      const actorId = (req as AuthenticatedRequest).auth?.userId ?? null
+      const orgId = resolveOrgId(req)
+      const folderChanged = patch.folder !== undefined && patch.folder !== dashboard.folder
+      void audit?.log({
+        action: folderChanged ? AuditAction.DashboardMove : AuditAction.DashboardUpdate,
+        actorType: 'user',
+        actorId,
+        orgId,
+        targetType: 'dashboard',
+        targetId: id,
+        targetName: updated.title,
+        outcome: 'success',
+        metadata: {
+          before: { title: dashboard.title, folder: dashboard.folder ?? null },
+          after: { title: updated.title, folder: updated.folder ?? null },
+        },
+      })
+
       res.json(updated)
     }
     catch (err) {
@@ -181,6 +219,16 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         dashboardNotFound(res)
         return
       }
+      void audit?.log({
+        action: AuditAction.DashboardDelete,
+        actorType: 'user',
+        actorId: (req as AuthenticatedRequest).auth?.userId ?? null,
+        orgId: resolveOrgId(req),
+        targetType: 'dashboard',
+        targetId: id,
+        targetName: dashboard.title,
+        outcome: 'success',
+      })
       res.status(204).send()
     }
     catch (err) {

--- a/packages/api-gateway/src/routes/folders.ts
+++ b/packages/api-gateway/src/routes/folders.ts
@@ -226,6 +226,7 @@ export function createFolderRouter(deps: FolderRouterDeps): Router {
           req.query['forceDeleteRules'] === '1';
         await deps.folderService.delete(req.auth!.orgId, req.params['uid']!, {
           forceDeleteRules: force,
+          actorId: req.auth!.userId,
         });
         res.status(200).json({ message: 'Folder deleted' });
       } catch (err) {

--- a/packages/api-gateway/src/services/folder-service-audit.test.ts
+++ b/packages/api-gateway/src/services/folder-service-audit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Audit wiring tests for FolderService — verifies that resource mutation
+ * audit entries are emitted with the right shape (Wave 1 / PR-A).
+ *
+ * Companion to folder-service.test.ts (which covers business logic);
+ * lives in a separate file so the audit assertions don't bloat existing
+ * scenarios.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDb,
+  seedDefaultOrg,
+  seedServerAdmin,
+  FolderRepository,
+  AuditLogRepository,
+} from '@agentic-obs/data-layer';
+import type { SqliteClient } from '@agentic-obs/data-layer';
+import { AuditAction } from '@agentic-obs/common';
+import { FolderService } from './folder-service.js';
+import { AuditWriter } from '../auth/audit-writer.js';
+
+let adminId = '';
+
+async function bootstrap(db: SqliteClient): Promise<void> {
+  await seedDefaultOrg(db);
+  const seeded = await seedServerAdmin(db);
+  adminId = seeded.user.id;
+}
+
+describe('FolderService audit wiring', () => {
+  let db: SqliteClient;
+  let auditRepo: AuditLogRepository;
+  let writer: AuditWriter;
+  let svc: FolderService;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    await bootstrap(db);
+    auditRepo = new AuditLogRepository(db);
+    writer = new AuditWriter(auditRepo);
+    svc = new FolderService({
+      folders: new FolderRepository(db),
+      db,
+      audit: writer,
+    });
+  });
+
+  it('emits folder.create audit row with target metadata', async () => {
+    const folder = await svc.create(
+      'org_main',
+      { title: 'Test Folder' },
+      adminId,
+    );
+    // The writer fires void — wait a microtask so the row lands.
+    await new Promise((r) => setImmediate(r));
+
+    const { items, total } = await auditRepo.query();
+    expect(total).toBe(1);
+    const row = items[0]!;
+    expect(row.action).toBe(AuditAction.FolderCreate);
+    expect(row.actorType).toBe('user');
+    expect(row.actorId).toBe(adminId);
+    expect(row.orgId).toBe('org_main');
+    expect(row.targetType).toBe('folder');
+    expect(row.targetId).toBe(folder.uid);
+    expect(row.targetName).toBe('Test Folder');
+    expect(row.outcome).toBe('success');
+  });
+});

--- a/packages/api-gateway/src/services/folder-service.ts
+++ b/packages/api-gateway/src/services/folder-service.ts
@@ -23,8 +23,9 @@ import type {
   NewGrafanaFolder,
   GrafanaFolderPatch,
 } from '@agentic-obs/common';
-import { FOLDER_MAX_DEPTH } from '@agentic-obs/common';
+import { AuditAction, FOLDER_MAX_DEPTH } from '@agentic-obs/common';
 import type { QueryClient } from '@agentic-obs/data-layer';
+import type { AuditWriter } from '../auth/audit-writer.js';
 
 export class FolderServiceError extends Error {
   constructor(
@@ -75,6 +76,11 @@ export interface FolderServiceDeps {
    * the cascade delete that walks multiple tables in one transaction.
    */
   db: QueryClient;
+  /**
+   * Audit writer — records folder.create/update/delete events. Optional so
+   * tests can construct the service without one.
+   */
+  audit?: AuditWriter;
 }
 
 /** Slugify a title into a URL-safe UID. Mirrors Grafana's folder UID rule. */
@@ -151,7 +157,19 @@ export class FolderService {
       updatedBy: userId,
     };
     try {
-      return await this.deps.folders.create(payload);
+      const folder = await this.deps.folders.create(payload);
+      void this.deps.audit?.log({
+        action: AuditAction.FolderCreate,
+        actorType: 'user',
+        actorId: userId,
+        orgId,
+        targetType: 'folder',
+        targetId: folder.uid,
+        targetName: folder.title,
+        outcome: 'success',
+        metadata: { parentUid: folder.parentUid },
+      });
+      return folder;
     } catch (err) {
       // Repo throws plain Error; map to 400 for operator-friendly feedback.
       throw new FolderServiceError(
@@ -241,6 +259,20 @@ export class FolderService {
       if (!updated) {
         throw new FolderServiceError('not_found', `folder not found: ${uid}`, 404);
       }
+      void this.deps.audit?.log({
+        action: AuditAction.FolderUpdate,
+        actorType: 'user',
+        actorId: userId,
+        orgId,
+        targetType: 'folder',
+        targetId: updated.uid,
+        targetName: updated.title,
+        outcome: 'success',
+        metadata: {
+          before: { title: existing.title, parentUid: existing.parentUid },
+          after: { title: updated.title, parentUid: updated.parentUid },
+        },
+      });
       return updated;
     } catch (err) {
       if (err instanceof FolderServiceError) throw err;
@@ -255,7 +287,7 @@ export class FolderService {
   async delete(
     orgId: string,
     uid: string,
-    opts: { forceDeleteRules: boolean },
+    opts: { forceDeleteRules: boolean; actorId?: string },
   ): Promise<void> {
     const existing = await this.deps.folders.findByUid(orgId, uid);
     if (!existing) {
@@ -307,6 +339,17 @@ export class FolderService {
           sql`DELETE FROM folder WHERE org_id = ${orgId} AND uid = ${u}`,
         );
       }
+    });
+    void this.deps.audit?.log({
+      action: AuditAction.FolderDelete,
+      actorType: 'user',
+      actorId: opts.actorId ?? null,
+      orgId,
+      targetType: 'folder',
+      targetId: existing.uid,
+      targetName: existing.title,
+      outcome: 'success',
+      metadata: { cascadedUids: uidList, forceDeleteRules: opts.forceDeleteRules },
     });
   }
 

--- a/packages/common/src/audit/actions.ts
+++ b/packages/common/src/audit/actions.ts
@@ -88,6 +88,25 @@ export const AuditAction = {
   NotificationChannelUpdated: 'notification_channel.updated',
   NotificationChannelDeleted: 'notification_channel.deleted',
   InstanceBootstrapped: 'instance.bootstrapped',
+
+  // Resource mutations (Wave 1 — enables downstream RFCs for My Workspace
+  // promote, provisioned protection, service attribution confirm).
+  // See docs/design/rfc-safety-patterns.md.
+  DashboardCreate: 'dashboard.create',
+  DashboardUpdate: 'dashboard.update',
+  DashboardDelete: 'dashboard.delete',
+  DashboardMove: 'dashboard.move',
+  DashboardFork: 'dashboard.fork',
+  DashboardPromote: 'dashboard.promote',
+  FolderCreate: 'folder.create',
+  FolderUpdate: 'folder.update',
+  FolderDelete: 'folder.delete',
+  AlertRuleCreate: 'alert_rule.create',
+  AlertRuleUpdate: 'alert_rule.update',
+  AlertRuleDelete: 'alert_rule.delete',
+  InvestigationCreate: 'investigation.create',
+  InvestigationUpdate: 'investigation.update',
+  ServiceAttributionConfirm: 'service.attribution_confirm',
 } as const;
 
 export type AuditActionValue = (typeof AuditAction)[keyof typeof AuditAction];


### PR DESCRIPTION
Foundation for RFC-2 (My Workspace promote audit), RFC-4 (service attribution confirm audit), provisioned-resource protection, and general SRE compliance.

## Problem

`AuditAction` enum had 40+ auth/RBAC entries but **zero entries for resource mutations**. Editing a dashboard, moving a folder, creating an alert rule — none audited.

## Changes

- 15 new `AuditAction` entries: `dashboard.create/update/delete/move/fork/promote`, `folder.create/update/delete`, `alert_rule.create/update/delete`, `investigation.create/update`, `service.attribution_confirm`.
- REST handlers in api-gateway: dashboard router, alert-rules router, folder-service all emit audit entries.
- Agent-tool handlers in agent-core: dashboard_create, dashboard_clone (→Fork), folder_create, alert_rule_write {create,update,delete}, investigation_create.
- `ActionContext.auditWriter` slim function slot avoids a package cycle.
- 3 new tests; 163/163 affected tests pass.

## Out of scope (Wave 2)

- `dashboard.promote` action wired but handler doesn't exist yet (Wave 2)
- `service.attribution_confirm` entry added, handler is Wave 2
- Bridge from api-gateway `AuditWriter.log` into agent-core `ActionContext.auditWriter` is a thin glue PR

## Test plan
- [x] tsc clean
- [x] 163/163 affected tests pass
- [ ] CI green