### PR TITLE
Wave1-B: source column + writable gate for provisioned resources

### DIFF
--- a/packages/agent-core/src/agent/action-executor.ts
+++ b/packages/agent-core/src/agent/action-executor.ts
@@ -1,4 +1,5 @@
 import type { DashboardAction, DashboardSseEvent } from '@agentic-obs/common'
+import { assertWritable } from '@agentic-obs/common'
 import type { IDashboardAgentStore } from './types.js'
 
 export class ActionExecutor {
@@ -17,6 +18,12 @@ export class ActionExecutor {
     const dashboard = await this.store.findById(dashboardId)
     if (!dashboard)
       throw new Error('Dashboard not found')
+
+    // Block agent-driven mutation of provisioned (GitOps/file) dashboards.
+    // `create_alert_rule` and friends below are no-ops here, but we still
+    // gate them — if a future change makes them mutate the dashboard row,
+    // the gate is already in place.
+    assertWritable({ kind: 'dashboard', id: dashboard.id, source: dashboard.source ?? 'manual' })
 
     switch (action.type) {
       case 'add_panels': {

--- a/packages/agent-core/src/agent/handlers/alert.ts
+++ b/packages/agent-core/src/agent/handlers/alert.ts
@@ -1,4 +1,4 @@
-import { ac, AuditAction, type AlertCondition, type AlertOperator, type AlertSeverity } from '@agentic-obs/common';
+import { ac, AuditAction, assertWritable, ProvisionedResourceError, type AlertCondition, type AlertOperator, type AlertSeverity, type ResourceSource } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
 import type { ActionContext } from './_context.js';
 import { withWorkspaceScope } from './_shared.js';
@@ -195,6 +195,22 @@ async function createAlertRule(
     }
     const match = scopedList?.find((r) => r.name === generated.name);
     if (match) {
+      // Writable gate — refuse to upsert into a provisioned (GitOps/file) rule.
+      if (ctx.alertRuleStore.findById) {
+        const found = await ctx.alertRuleStore.findById(match.id) as { source?: ResourceSource } | undefined;
+        try {
+          assertWritable({
+            kind: 'alert_rule',
+            id: match.id,
+            source: (found?.source ?? 'manual'),
+          });
+        } catch (err) {
+          if (err instanceof ProvisionedResourceError) {
+            return `Error: ${err.message}`;
+          }
+          throw err;
+        }
+      }
       rule = await ctx.alertRuleStore.update(match.id, {
         description: generated.description,
         condition: generated.condition,
@@ -220,6 +236,8 @@ async function createAlertRule(
         labels: { ...generated.labels, ...(dashboardId ? { dashboardId } : {}) },
         folderUid,
         createdBy: 'llm',
+        // Agent-tool created — see writable-gate.ts for source taxonomy.
+        source: 'ai_generated' as ResourceSource,
       }),
     ) as Record<string, unknown>;
   }
@@ -294,6 +312,7 @@ async function resolveAlertRuleFolderUid(
     parentUid: null,
     createdBy: ctx.identity.userId,
     updatedBy: ctx.identity.userId,
+    source: 'ai_generated',
   });
   return created.uid;
 }
@@ -309,6 +328,20 @@ async function updateAlertRule(
 
   const existingRule = await ctx.alertRuleStore.findById(ruleId) as Record<string, unknown> | undefined;
   if (!existingRule) return `Error: alert rule ${ruleId} not found.`;
+
+  // Writable gate — refuse to mutate provisioned (GitOps/file) rules.
+  try {
+    assertWritable({
+      kind: 'alert_rule',
+      id: ruleId,
+      source: ((existingRule.source as ResourceSource | undefined) ?? 'manual'),
+    });
+  } catch (err) {
+    if (err instanceof ProvisionedResourceError) {
+      return `Error: ${err.message}`;
+    }
+    throw err;
+  }
 
   // RBAC: derive the rule's folder UID and require alert.rules:write on it.
   // The pre-dispatch tool gate already runs, but defense-in-depth here keeps
@@ -383,6 +416,22 @@ async function deleteAlertRule(
   const existingRule = ctx.alertRuleStore.findById
     ? await ctx.alertRuleStore.findById(ruleId) as Record<string, unknown> | undefined
     : undefined;
+
+  // Writable gate — refuse to delete provisioned (GitOps/file) rules.
+  if (existingRule) {
+    try {
+      assertWritable({
+        kind: 'alert_rule',
+        id: ruleId,
+        source: ((existingRule.source as ResourceSource | undefined) ?? 'manual'),
+      });
+    } catch (err) {
+      if (err instanceof ProvisionedResourceError) {
+        return `Error: ${err.message}`;
+      }
+      throw err;
+    }
+  }
 
   // RBAC: same guard as update — defense-in-depth in case the pre-dispatch
   // tool gate is bypassed by an internal caller.

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { ac, AuditAction } from '@agentic-obs/common';
+import { ac, AuditAction, assertWritable, ProvisionedResourceError } from '@agentic-obs/common';
 import type { PendingDashboardChange, PendingDashboardChangeOp } from '@agentic-obs/common';
 import type { ActionContext } from './_context.js';
 import { withToolEventBoundary, withWorkspaceScope } from './_shared.js';
@@ -87,6 +87,8 @@ export async function handleDashboardCreate(
           // and acts as the fallback for any query that omits its own ds id.
           datasourceIds: [datasourceId],
           sessionId: ctx.sessionId,
+          // Agent-tool created — see writable-gate.ts for source taxonomy.
+          source: 'ai_generated',
         }),
       );
 
@@ -185,6 +187,8 @@ export async function handleDashboardClone(
           userId: 'agent',
           datasourceIds: [targetDatasourceId],
           sessionId: ctx.sessionId,
+          // Agent-tool clone — treat as AI-generated.
+          source: 'ai_generated',
         }),
       );
 

--- a/packages/agent-core/src/agent/handlers/folder.ts
+++ b/packages/agent-core/src/agent/handlers/folder.ts
@@ -34,6 +34,8 @@ export async function handleFolderCreate(
     parentUid,
     createdBy: ctx.identity.userId,
     updatedBy: ctx.identity.userId,
+    // Agent-tool created — see writable-gate.ts for source taxonomy.
+    source: 'ai_generated',
   });
 
   void ctx.auditWriter?.({

--- a/packages/agent-core/src/agent/types.ts
+++ b/packages/agent-core/src/agent/types.ts
@@ -15,6 +15,9 @@ export interface IDashboardAgentStore {
     folder?: string
     workspaceId?: string
     sessionId?: string
+    /** Defaults to `'manual'` when unset. See writable-gate.ts. */
+    source?: import('@agentic-obs/common').ResourceSource
+    provenance?: import('@agentic-obs/common').ResourceProvenance
   }): import('@agentic-obs/common').Dashboard | Promise<import('@agentic-obs/common').Dashboard>
   findById(id: string): import('@agentic-obs/common').Dashboard | Promise<import('@agentic-obs/common').Dashboard | undefined> | undefined
   findAll?(): import('@agentic-obs/common').Dashboard[] | Promise<import('@agentic-obs/common').Dashboard[]>

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -5,6 +5,8 @@ import {
   ACTIONS,
   ac,
   AuditAction,
+  assertWritable,
+  ProvisionedResourceError,
 } from '@agentic-obs/common';
 import type { AuditWriter } from '../auth/audit-writer.js';
 import type { IAlertRuleRepository, IGatewayInvestigationStore, IGatewayFeedStore, IInvestigationReportRepository } from '@agentic-obs/data-layer';
@@ -91,6 +93,7 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
       parentUid: null,
       createdBy: userId ?? null,
       updatedBy: userId ?? null,
+      source: 'api',
     });
     return created.uid;
   }
@@ -98,6 +101,29 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
   function requestFolderUid(req: Request): string {
     const raw = (req.body as { folderUid?: unknown } | undefined)?.folderUid;
     return typeof raw === 'string' ? raw.trim() : '';
+  }
+
+  /**
+   * Refuse the request when the rule is provisioned (file/git). Returns true
+   * after writing the 409 response — caller should `return` immediately.
+   */
+  function refuseIfProvisioned(res: Response, rule: AlertRule): boolean {
+    try {
+      assertWritable({ kind: 'alert_rule', id: rule.id, source: rule.source ?? 'manual' });
+      return false;
+    } catch (err) {
+      if (err instanceof ProvisionedResourceError) {
+        res.status(409).json({
+          error: {
+            code: 'PROVISIONED_RESOURCE',
+            message: err.message,
+            source: err.resource.source,
+          },
+        });
+        return true;
+      }
+      throw err;
+    }
   }
 
   async function loadOwnedRule(req: Request, res: Response): Promise<AlertRule | null> {
@@ -375,6 +401,8 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         notificationPolicyId: body.notificationPolicyId,
         workspaceId,
         folderUid,
+        // REST API created — see writable-gate.ts for the source taxonomy.
+        source: 'api',
       };
       const rule = await store.create(createInput);
 
@@ -402,6 +430,7 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
     async (req: Request, res: Response) => {
       const existing = await loadOwnedRule(req, res);
       if (!existing) return;
+      if (refuseIfProvisioned(res, existing)) return;
       const updated = await store.update(req.params['id'] ?? '', req.body as Partial<AlertRule>);
       if (!updated) {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Alert rule not found' } });
@@ -433,6 +462,7 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
     async (req: Request, res: Response) => {
       const existing = await loadOwnedRule(req, res);
       if (!existing) return;
+      if (refuseIfProvisioned(res, existing)) return;
       if (!(await store.delete(req.params['id'] ?? ''))) {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Alert rule not found' } });
         return;
@@ -459,6 +489,7 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
     async (req: Request, res: Response) => {
       const existing = await loadOwnedRule(req, res);
       if (!existing) return;
+      if (refuseIfProvisioned(res, existing)) return;
       const rule = await store.update(req.params['id'] ?? '', { state: 'disabled' as const });
       if (!rule) {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Alert rule not found' } });

--- a/packages/api-gateway/src/routes/dashboard/router.test.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.test.ts
@@ -35,6 +35,7 @@ function dashboard(overrides: Partial<Dashboard> = {}): Dashboard {
     datasourceIds: [],
     useExistingMetrics: true,
     workspaceId: 'org_other',
+    source: 'manual',
     createdAt: '2026-04-26T00:00:00.000Z',
     updatedAt: '2026-04-26T00:00:00.000Z',
     ...overrides,
@@ -164,6 +165,33 @@ describe('dashboard router workspace ownership checks', () => {
 
     expect(res.status).toBe(method === 'delete' ? 204 : 200)
     expect(store[mutation]).toHaveBeenCalled()
+  })
+
+  it.each([
+    ['put', '/dashboards/dash_owned', { title: 'Renamed' }, 'update'],
+    ['delete', '/dashboards/dash_owned', undefined, 'delete'],
+    ['put', '/dashboards/dash_owned/panels', { panels: [] }, 'updatePanels'],
+    ['post', '/dashboards/dash_owned/panels', { title: 'CPU', visualization: 'stat', row: 0, col: 0, width: 3, height: 3 }, 'updatePanels'],
+    ['delete', '/dashboards/dash_owned/panels/panel_1', undefined, 'updatePanels'],
+  ] as const)('refuses %s %s on a provisioned_git dashboard with 409', async (method, path, body, mutation) => {
+    const store = makeStore(dashboard({
+      id: 'dash_owned',
+      workspaceId: 'org_main',
+      source: 'provisioned_git',
+      provenance: { repo: 'org/repo', path: 'dashboards/d.yaml', commit: 'abc123' },
+    }))
+    const app = makeApp(store)
+    let req = request(app)[method](path)
+    if (body) req = req.send(body)
+
+    const res = await req
+
+    expect(res.status).toBe(409)
+    expect(res.body.error?.code).toBe('PROVISIONED_RESOURCE')
+    expect(res.body.error?.source).toBe('provisioned_git')
+    expect(res.body.error?.message).toContain('Cannot mutate provisioned resource')
+    expect(res.body.error?.message).toContain('Fork to your workspace')
+    expect(store[mutation]).not.toHaveBeenCalled()
   })
 
   it('returns 404 and skips datasource resolution for cross-workspace variable resolution', async () => {

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -7,7 +7,7 @@ import { authMiddleware } from '../../middleware/auth.js'
 import { createRequirePermission } from '../../middleware/require-permission.js'
 import type { IGatewayDashboardStore } from '@agentic-obs/data-layer'
 import { VariableResolver } from './variable-resolver.js'
-import { ac, ACTIONS, AuditAction } from '@agentic-obs/common'
+import { ac, ACTIONS, AuditAction, assertWritable, ProvisionedResourceError } from '@agentic-obs/common'
 import type { Dashboard, PanelConfig } from '@agentic-obs/common'
 import type { SetupConfigService } from '../../services/setup-config-service.js'
 import type { AuditWriter } from '../../auth/audit-writer.js'
@@ -52,6 +52,29 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
     res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Dashboard not found' } })
   }
 
+  /**
+   * Returns true and writes the 409 response when the dashboard is owned by a
+   * file/GitOps pipeline; callers should `return` immediately after.
+   */
+  function refuseIfProvisioned(res: Response, dashboard: Dashboard): boolean {
+    try {
+      assertWritable({ kind: 'dashboard', id: dashboard.id, source: dashboard.source ?? 'manual' })
+      return false
+    } catch (err) {
+      if (err instanceof ProvisionedResourceError) {
+        res.status(409).json({
+          error: {
+            code: 'PROVISIONED_RESOURCE',
+            message: err.message,
+            source: err.resource.source,
+          },
+        })
+        return true
+      }
+      throw err
+    }
+  }
+
   async function loadOwnedDashboard(req: Request, res: Response, id: string): Promise<Dashboard | undefined> {
     const dashboard = await store.findById(id)
     if (!dashboard || dashboard.workspaceId !== resolveOrgId(req)) {
@@ -90,6 +113,8 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         useExistingMetrics: body.useExistingMetrics ?? true,
         folder: body.folder,
         workspaceId,
+        // REST API created — see writable-gate.ts for the source taxonomy.
+        source: 'api',
       })
 
       void audit?.log({
@@ -173,6 +198,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       if (!dashboard) {
         return
       }
+      if (refuseIfProvisioned(res, dashboard)) return
 
       const updated = await store.update(id, patch)
       if (!updated) {
@@ -213,6 +239,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       if (!dashboard) {
         return
       }
+      if (refuseIfProvisioned(res, dashboard)) return
 
       const deleted = await store.delete(id)
       if (!deleted) {
@@ -250,6 +277,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       if (!dashboard) {
         return
       }
+      if (refuseIfProvisioned(res, dashboard)) return
 
       const updated = await store.updatePanels(id, body.panels)
       if (!updated) {
@@ -272,6 +300,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       if (!d) {
         return
       }
+      if (refuseIfProvisioned(res, d)) return
 
       const body = req.body as Omit<PanelConfig, 'id'>
       if (!body.title || typeof body.title !== 'string') {
@@ -302,6 +331,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       if (!d) {
         return
       }
+      if (refuseIfProvisioned(res, d)) return
 
       const panels = d.panels.filter((p) => p.id !== panelId)
       if (panels.length === d.panels.length) {

--- a/packages/api-gateway/src/routes/folders.ts
+++ b/packages/api-gateway/src/routes/folders.ts
@@ -13,7 +13,7 @@
 
 import { Router } from 'express';
 import type { Response } from 'express';
-import { ac, ACTIONS } from '@agentic-obs/common';
+import { ac, ACTIONS, assertWritable, ProvisionedResourceError } from '@agentic-obs/common';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import type { AccessControlService } from '../services/accesscontrol-service.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
@@ -129,6 +129,8 @@ export function createFolderRouter(deps: FolderRouterDeps): Router {
             title: body.title,
             description: body.description,
             parentUid: body.parentUid,
+            // REST API created — see writable-gate.ts for the source taxonomy.
+            source: 'api',
           },
           req.auth!.userId,
         );
@@ -195,6 +197,27 @@ export function createFolderRouter(deps: FolderRouterDeps): Router {
     ),
     async (req: AuthenticatedRequest, res: Response) => {
       try {
+        const uid = req.params['uid']!;
+        const existing = await deps.folderService.getByUid(req.auth!.orgId, uid);
+        if (!existing) {
+          res.status(404).json({ error: { code: 'NOT_FOUND', message: 'folder not found' } });
+          return;
+        }
+        try {
+          assertWritable({ kind: 'folder', id: existing.uid, source: existing.source ?? 'manual' });
+        } catch (gateErr) {
+          if (gateErr instanceof ProvisionedResourceError) {
+            res.status(409).json({
+              error: {
+                code: 'PROVISIONED_RESOURCE',
+                message: gateErr.message,
+                source: gateErr.resource.source,
+              },
+            });
+            return;
+          }
+          throw gateErr;
+        }
         const body = req.body as {
           title?: string;
           description?: string | null;
@@ -202,7 +225,7 @@ export function createFolderRouter(deps: FolderRouterDeps): Router {
         };
         const updated = await deps.folderService.update(
           req.auth!.orgId,
-          req.params['uid']!,
+          uid,
           body,
           req.auth!.userId,
         );
@@ -221,10 +244,29 @@ export function createFolderRouter(deps: FolderRouterDeps): Router {
     ),
     async (req: AuthenticatedRequest, res: Response) => {
       try {
+        const uid = req.params['uid']!;
+        const existing = await deps.folderService.getByUid(req.auth!.orgId, uid);
+        if (existing) {
+          try {
+            assertWritable({ kind: 'folder', id: existing.uid, source: existing.source ?? 'manual' });
+          } catch (gateErr) {
+            if (gateErr instanceof ProvisionedResourceError) {
+              res.status(409).json({
+                error: {
+                  code: 'PROVISIONED_RESOURCE',
+                  message: gateErr.message,
+                  source: gateErr.resource.source,
+                },
+              });
+              return;
+            }
+            throw gateErr;
+          }
+        }
         const force =
           req.query['forceDeleteRules'] === 'true' ||
           req.query['forceDeleteRules'] === '1';
-        await deps.folderService.delete(req.auth!.orgId, req.params['uid']!, {
+        await deps.folderService.delete(req.auth!.orgId, uid, {
           forceDeleteRules: force,
           actorId: req.auth!.userId,
         });

--- a/packages/api-gateway/src/services/folder-service.ts
+++ b/packages/api-gateway/src/services/folder-service.ts
@@ -22,6 +22,8 @@ import type {
   GrafanaFolder,
   NewGrafanaFolder,
   GrafanaFolderPatch,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import { AuditAction, FOLDER_MAX_DEPTH } from '@agentic-obs/common';
 import type { QueryClient } from '@agentic-obs/data-layer';
@@ -47,6 +49,9 @@ export interface CreateFolderInput {
   title: string;
   description?: string;
   parentUid?: string | null;
+  /** Defaults to `'manual'` when unset. */
+  source?: ResourceSource;
+  provenance?: ResourceProvenance;
 }
 
 export interface UpdateFolderPatch {
@@ -155,6 +160,8 @@ export class FolderService {
       parentUid: input.parentUid ?? null,
       createdBy: userId,
       updatedBy: userId,
+      source: input.source ?? 'manual',
+      ...(input.provenance ? { provenance: input.provenance } : {}),
     };
     try {
       const folder = await this.deps.folders.create(payload);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -22,6 +22,7 @@ export * from './errors/index.js';
 export * from './models/index.js';
 export * from './repositories/index.js';
 export * from './adapter-types.js';
+export * from './resources/index.js';
 
 // Auth / perm types + pure helpers.
 export * from './auth/index.js';

--- a/packages/common/src/models/alert.ts
+++ b/packages/common/src/models/alert.ts
@@ -1,4 +1,5 @@
 // Alert Rule - user-defined or LLM-generated monitoring condition
+import type { ResourceSource, ResourceProvenance } from '../resources/writable-gate.js';
 
 export type AlertRuleState = 'normal' | 'pending' | 'firing' | 'resolved' | 'disabled';
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low';
@@ -48,6 +49,10 @@ export interface AlertRule {
   lastEvaluatedAt?: string;
   lastFiredAt?: string;
   fireCount: number;
+
+  /** Origin marker — see writable-gate.ts. Treat absence as `'manual'`. */
+  source?: ResourceSource;
+  provenance?: ResourceProvenance;
 }
 
 export interface AlertHistoryEntry {

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -1,4 +1,5 @@
 import type { PublishStatus } from './version.js';
+import type { ResourceSource, ResourceProvenance } from '../resources/writable-gate.js';
 
 export type PanelVisualization =
   | 'time_series'
@@ -281,6 +282,18 @@ export interface Dashboard {
   createdAt: string;
   updatedAt: string;
   error?: string;
+  /**
+   * Origin of the dashboard. Drives the writable-gate check —
+   * provisioned_file / provisioned_git rows refuse mutations from REST
+   * endpoints and agent tools. See packages/common/src/resources/writable-gate.ts.
+   *
+   * Repositories populate this on read (defaulting to `'manual'`); marked
+   * optional so existing in-memory fixtures / mocks compile without a churn.
+   * Treat absence as `'manual'` at call sites.
+   */
+  source?: ResourceSource;
+  /** Optional details about how the dashboard was provisioned. */
+  provenance?: ResourceProvenance;
   /**
    * AI-proposed modifications that have NOT been applied yet. Empty/undefined
    * for dashboards with no outstanding proposals. The dashboard workspace UI

--- a/packages/common/src/models/folder.ts
+++ b/packages/common/src/models/folder.ts
@@ -8,6 +8,8 @@
  * This is distinct from the legacy Rounds `folders` (plural) table kept in
  * db/sqlite-schema.ts until T9.6 cleanup.
  */
+import type { ResourceSource, ResourceProvenance } from '../resources/writable-gate.js';
+
 export interface GrafanaFolder {
   id: string;
   uid: string;
@@ -19,6 +21,9 @@ export interface GrafanaFolder {
   updated: string;
   createdBy: string | null;
   updatedBy: string | null;
+  /** Origin marker — see writable-gate.ts. Treat absence as `'manual'`. */
+  source?: ResourceSource;
+  provenance?: ResourceProvenance;
 }
 
 export interface NewGrafanaFolder {
@@ -30,6 +35,8 @@ export interface NewGrafanaFolder {
   parentUid?: string | null;
   createdBy?: string | null;
   updatedBy?: string | null;
+  source?: ResourceSource;
+  provenance?: ResourceProvenance;
 }
 
 export interface GrafanaFolderPatch {

--- a/packages/common/src/repositories/dashboard/interfaces.ts
+++ b/packages/common/src/repositories/dashboard/interfaces.ts
@@ -20,6 +20,7 @@ import type {
   DashboardVariable,
   PanelConfig,
 } from '../../models/dashboard.js';
+import type { ResourceSource, ResourceProvenance } from '../../resources/writable-gate.js';
 
 /**
  * Input shape for `create()`. Matches the argument surface of the old
@@ -35,6 +36,9 @@ export interface NewDashboardInput {
   useExistingMetrics?: boolean;
   folder?: string;
   workspaceId?: string;
+  /** Defaults to `'manual'` when unset. */
+  source?: ResourceSource;
+  provenance?: ResourceProvenance;
 }
 
 /**

--- a/packages/common/src/resources/index.ts
+++ b/packages/common/src/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './writable-gate.js';

--- a/packages/common/src/resources/writable-gate.test.ts
+++ b/packages/common/src/resources/writable-gate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { assertWritable, ProvisionedResourceError, type ResourceSource } from './writable-gate.js';
+
+describe('assertWritable', () => {
+  const writable: ResourceSource[] = ['manual', 'api', 'ai_generated'];
+  const provisioned: ResourceSource[] = ['provisioned_file', 'provisioned_git'];
+
+  for (const source of writable) {
+    it(`passes for source=${source}`, () => {
+      expect(() =>
+        assertWritable({ kind: 'dashboard', id: 'd1', source }),
+      ).not.toThrow();
+    });
+  }
+
+  for (const source of provisioned) {
+    it(`throws ProvisionedResourceError for source=${source}`, () => {
+      let thrown: unknown;
+      try {
+        assertWritable({ kind: 'dashboard', id: 'd1', source });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(ProvisionedResourceError);
+      const err = thrown as ProvisionedResourceError;
+      expect(err.resource.source).toBe(source);
+      expect(err.message).toContain('Cannot mutate provisioned resource');
+      expect(err.message).toContain('dashboard:d1');
+      expect(err.message).toContain('Fork to your workspace');
+    });
+  }
+});

--- a/packages/common/src/resources/writable-gate.ts
+++ b/packages/common/src/resources/writable-gate.ts
@@ -1,0 +1,59 @@
+/**
+ * Writable gate — shared "is this resource mutable by the caller?" check.
+ *
+ * Resources marked as `provisioned_file` or `provisioned_git` are owned
+ * by a file/GitOps pipeline outside the app and must NOT be silently
+ * mutated by REST writes or agent tools. Call `assertWritable(resource)`
+ * at the top of every write handler, immediately after the resource is
+ * fetched. See docs/design/rfc-safety-patterns.md for the design rationale.
+ */
+
+export type ResourceSource =
+  | 'manual'
+  | 'api'
+  | 'ai_generated'
+  | 'provisioned_file'
+  | 'provisioned_git';
+
+/**
+ * Optional details about how a resource was provisioned. Captured alongside
+ * the `source` column on dashboards / alert_rules / folders. All fields
+ * optional — callers populate whatever they know.
+ */
+export interface ResourceProvenance {
+  repo?: string;
+  path?: string;
+  commit?: string;
+  generatedBy?: string;
+  prompt?: string;
+}
+
+export class ProvisionedResourceError extends Error {
+  constructor(
+    public readonly resource: { kind: string; id: string; source: ResourceSource },
+  ) {
+    super(
+      `Cannot mutate provisioned resource ${resource.kind}:${resource.id} ` +
+        `(source=${resource.source}). Fork to your workspace, or propose a diff.`,
+    );
+    this.name = 'ProvisionedResourceError';
+  }
+}
+
+/**
+ * Throws `ProvisionedResourceError` when the resource is owned by a
+ * file/GitOps pipeline. Returns silently for `manual`, `api`, and
+ * `ai_generated` resources.
+ */
+export function assertWritable(resource: {
+  kind: string;
+  id: string;
+  source: ResourceSource;
+}): void {
+  if (
+    resource.source === 'provisioned_file' ||
+    resource.source === 'provisioned_git'
+  ) {
+    throw new ProvisionedResourceError(resource);
+  }
+}

--- a/packages/data-layer/src/db/schema-applier.test.ts
+++ b/packages/data-layer/src/db/schema-applier.test.ts
@@ -43,6 +43,23 @@ describe('applySchema()', () => {
     expect(colNames).toContain('folder_uid');
   });
 
+  it('dashboards / alert_rules / folder have source + provenance columns with default `manual`', () => {
+    const db = createSqliteClient({ path: ':memory:', wal: false });
+    applySchema(db);
+    for (const table of ['dashboards', 'alert_rules', 'folder'] as const) {
+      const cols = db.all<{ name: string; dflt_value: string | null; notnull: number }>(
+        sql.raw(`PRAGMA table_info(${table})`),
+      );
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect(byName.has('source'), `${table}.source`).toBe(true);
+      expect(byName.has('provenance'), `${table}.provenance`).toBe(true);
+      const src = byName.get('source')!;
+      expect(src.notnull).toBe(1);
+      // SQLite quotes the default literal — accept either form.
+      expect(src.dflt_value).toMatch(/'manual'/);
+    }
+  });
+
   it('renames legacy `user` table to `users` for pre-rename instances', () => {
     const db = createSqliteClient({ path: ':memory:', wal: false });
     // Simulate a pre-rename database with the old `user` table and one row.

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -312,6 +312,9 @@ CREATE TABLE IF NOT EXISTS folder (
   updated     TEXT NOT NULL,
   created_by  TEXT NULL,
   updated_by  TEXT NULL,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source      TEXT NOT NULL DEFAULT 'manual',
+  provenance  TEXT NULL,
   FOREIGN KEY (org_id)     REFERENCES org(id)  ON DELETE CASCADE,
   FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
   FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
@@ -569,6 +572,9 @@ CREATE TABLE IF NOT EXISTS dashboards (
   version              INTEGER,
   publish_status       TEXT,
   error                TEXT,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source               TEXT NOT NULL DEFAULT 'manual',
+  provenance           TEXT NULL,
   created_at           TEXT NOT NULL,
   updated_at           TEXT NOT NULL
 );
@@ -668,6 +674,9 @@ CREATE TABLE IF NOT EXISTS alert_rules (
   last_evaluated_at       TEXT,
   last_fired_at           TEXT,
   fire_count              INTEGER NOT NULL DEFAULT 0,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source                  TEXT NOT NULL DEFAULT 'manual',
+  provenance              TEXT NULL,
   created_at              TEXT NOT NULL,
   updated_at              TEXT NOT NULL
 );

--- a/packages/data-layer/src/db/sqlite-schema.ts
+++ b/packages/data-layer/src/db/sqlite-schema.ts
@@ -217,6 +217,9 @@ export const dashboards = sqliteTable(
     version: integer('version'),
     publishStatus: text('publish_status'),
     error: text('error'),
+    // Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+    source: text('source').notNull().default('manual'),
+    provenance: text('provenance', { mode: 'json' }),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },
@@ -253,6 +256,9 @@ export const alertRules = sqliteTable(
     lastEvaluatedAt: text('last_evaluated_at'),
     lastFiredAt: text('last_fired_at'),
     fireCount: integer('fire_count').notNull().default(0),
+    // Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+    source: text('source').notNull().default('manual'),
+    provenance: text('provenance', { mode: 'json' }),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },

--- a/packages/data-layer/src/repository/auth/folder-repository.ts
+++ b/packages/data-layer/src/repository/auth/folder-repository.ts
@@ -5,6 +5,8 @@ import type {
   GrafanaFolder,
   NewGrafanaFolder,
   GrafanaFolderPatch,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import { FOLDER_MAX_DEPTH } from '@agentic-obs/common';
 import { uid, nowIso } from './shared.js';
@@ -20,10 +22,19 @@ interface Row {
   updated: string;
   created_by: string | null;
   updated_by: string | null;
+  source: string;
+  provenance: string | null;
 }
 
 function rowTo(r: Row): GrafanaFolder {
-  return {
+  let provenance: ResourceProvenance | undefined;
+  if (r.provenance) {
+    try {
+      const parsed = JSON.parse(r.provenance);
+      if (parsed && typeof parsed === 'object') provenance = parsed as ResourceProvenance;
+    } catch { /* ignore corrupt JSON */ }
+  }
+  const f: GrafanaFolder = {
     id: r.id,
     uid: r.uid,
     orgId: r.org_id,
@@ -34,7 +45,10 @@ function rowTo(r: Row): GrafanaFolder {
     updated: r.updated,
     createdBy: r.created_by,
     updatedBy: r.updated_by,
+    source: (r.source ?? 'manual') as ResourceSource,
   };
+  if (provenance) f.provenance = provenance;
+  return f;
 }
 
 /**
@@ -57,14 +71,18 @@ export class FolderRepository implements IFolderRepository {
     }
     const id = input.id ?? uid();
     const now = nowIso();
+    const source: ResourceSource = input.source ?? 'manual';
+    const provenanceJson = input.provenance ? JSON.stringify(input.provenance) : null;
     this.db.run(sql`
       INSERT INTO folder (
         id, uid, org_id, title, description, parent_uid,
-        created, updated, created_by, updated_by
+        created, updated, created_by, updated_by,
+        source, provenance
       ) VALUES (
         ${id}, ${input.uid}, ${input.orgId}, ${input.title},
         ${input.description ?? null}, ${input.parentUid ?? null},
-        ${now}, ${now}, ${input.createdBy ?? null}, ${input.updatedBy ?? null}
+        ${now}, ${now}, ${input.createdBy ?? null}, ${input.updatedBy ?? null},
+        ${source}, ${provenanceJson}
       )
     `);
     const row = await this.findById(id);

--- a/packages/data-layer/src/repository/postgres/alert-rule.ts
+++ b/packages/data-layer/src/repository/postgres/alert-rule.ts
@@ -40,6 +40,8 @@ import type {
   AlertSilence,
   NotificationPolicy,
   SilenceStatus,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import type {
   IAlertRuleRepository,
@@ -69,6 +71,8 @@ interface RuleRow {
   last_evaluated_at: string | null;
   last_fired_at: string | null;
   fire_count: number;
+  source: string;
+  provenance: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -155,6 +159,7 @@ function rowToRule(r: RuleRow): AlertRule {
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     fireCount: r.fire_count,
+    source: (r.source ?? 'manual') as ResourceSource,
   };
   if (r.original_prompt !== null) rule.originalPrompt = r.original_prompt;
   if (labels !== null) rule.labels = labels;
@@ -164,6 +169,8 @@ function rowToRule(r: RuleRow): AlertRule {
   if (r.workspace_id !== null) rule.workspaceId = r.workspace_id;
   if (r.last_evaluated_at !== null) rule.lastEvaluatedAt = r.last_evaluated_at;
   if (r.last_fired_at !== null) rule.lastFiredAt = r.last_fired_at;
+  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null);
+  if (prov) rule.provenance = prov;
   return rule;
 }
 
@@ -229,6 +236,8 @@ export class AlertRuleRepository implements IAlertRuleRepository {
   ): Promise<AlertRule> {
     const id = `alert_${randomUUID().slice(0, 12)}`;
     const now = nowIso();
+    const source: ResourceSource = (data as { source?: ResourceSource }).source ?? 'manual';
+    const provenance = (data as { provenance?: ResourceProvenance }).provenance ?? null;
     await pgRun(this.db, sql`
       INSERT INTO alert_rules (
         id, name, description, original_prompt, condition,
@@ -236,6 +245,7 @@ export class AlertRuleRepository implements IAlertRuleRepository {
         state_changed_at, pending_since, notification_policy_id,
         investigation_id, workspace_id, folder_uid, org_id, created_by,
         last_evaluated_at, last_fired_at, fire_count,
+        source, provenance,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -258,6 +268,8 @@ export class AlertRuleRepository implements IAlertRuleRepository {
         ${data.lastEvaluatedAt ?? null},
         ${data.lastFiredAt ?? null},
         ${0},
+        ${source},
+        ${stringifyJsonOrNull(provenance)},
         ${now},
         ${now}
       )

--- a/packages/data-layer/src/repository/postgres/auth/folder-repository.ts
+++ b/packages/data-layer/src/repository/postgres/auth/folder-repository.ts
@@ -6,6 +6,8 @@ import type {
   GrafanaFolder,
   NewGrafanaFolder,
   GrafanaFolderPatch,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import { FOLDER_MAX_DEPTH } from '@agentic-obs/common';
 import { uid, nowIso } from './shared.js';
@@ -21,10 +23,19 @@ interface Row {
   updated: string;
   created_by: string | null;
   updated_by: string | null;
+  source: string;
+  provenance: string | null;
 }
 
 function rowTo(r: Row): GrafanaFolder {
-  return {
+  let provenance: ResourceProvenance | undefined;
+  if (r.provenance) {
+    try {
+      const parsed = typeof r.provenance === 'string' ? JSON.parse(r.provenance) : r.provenance;
+      if (parsed && typeof parsed === 'object') provenance = parsed as ResourceProvenance;
+    } catch { /* ignore corrupt JSON */ }
+  }
+  const f: GrafanaFolder = {
     id: r.id,
     uid: r.uid,
     orgId: r.org_id,
@@ -35,7 +46,10 @@ function rowTo(r: Row): GrafanaFolder {
     updated: r.updated,
     createdBy: r.created_by,
     updatedBy: r.updated_by,
+    source: (r.source ?? 'manual') as ResourceSource,
   };
+  if (provenance) f.provenance = provenance;
+  return f;
 }
 
 /**
@@ -58,14 +72,18 @@ export class FolderRepository implements IFolderRepository {
     }
     const id = input.id ?? uid();
     const now = nowIso();
+    const source: ResourceSource = input.source ?? 'manual';
+    const provenanceJson = input.provenance ? JSON.stringify(input.provenance) : null;
     await pgRun(this.db, sql`
       INSERT INTO folder (
         id, uid, org_id, title, description, parent_uid,
-        created, updated, created_by, updated_by
+        created, updated, created_by, updated_by,
+        source, provenance
       ) VALUES (
         ${id}, ${input.uid}, ${input.orgId}, ${input.title},
         ${input.description ?? null}, ${input.parentUid ?? null},
-        ${now}, ${now}, ${input.createdBy ?? null}, ${input.updatedBy ?? null}
+        ${now}, ${now}, ${input.createdBy ?? null}, ${input.updatedBy ?? null},
+        ${source}, ${provenanceJson}
       )
     `);
     const row = await this.findById(id);

--- a/packages/data-layer/src/repository/postgres/dashboard.ts
+++ b/packages/data-layer/src/repository/postgres/dashboard.ts
@@ -44,6 +44,8 @@ import type {
   IDashboardRepository,
   NewDashboardInput,
   DashboardPatch,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import type { IDashboardRepository as ILegacyDashboardRepository } from '../interfaces.js';
 
@@ -68,6 +70,8 @@ interface DashboardRow {
   version: number | null;
   publish_status: string | null;
   error: string | null;
+  source: string;
+  provenance: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +99,16 @@ function fromBool(v: boolean | undefined, dflt = false): number {
   return (v ?? dflt) ? 1 : 0;
 }
 
+function parseProvenance(raw: string | null): ResourceProvenance | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    return parsed && typeof parsed === 'object' ? (parsed as ResourceProvenance) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function rowToDashboard(r: DashboardRow): Dashboard {
   const base: Dashboard = {
     id: r.id,
@@ -109,6 +123,7 @@ function rowToDashboard(r: DashboardRow): Dashboard {
     refreshIntervalSec: r.refresh_interval_sec,
     datasourceIds: parseJsonArray<string>(r.datasource_ids, []),
     useExistingMetrics: toBool(r.use_existing_metrics),
+    source: (r.source ?? 'manual') as ResourceSource,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -117,6 +132,8 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
+  const prov = parseProvenance(r.provenance);
+  if (prov) base.provenance = prov;
   return base;
 }
 
@@ -134,11 +151,14 @@ export class DashboardRepository implements IDashboardRepository {
     const datasourceIdsJson = JSON.stringify(input.datasourceIds ?? []);
     const useExistingMetrics = fromBool(input.useExistingMetrics, true);
 
+    const source: ResourceSource = input.source ?? 'manual';
+    const provenanceJson = input.provenance ? JSON.stringify(input.provenance) : null;
     await pgRun(this.db, sql`
       INSERT INTO dashboards (
         id, type, title, description, prompt, user_id, status,
         panels, variables, refresh_interval_sec, datasource_ids,
         use_existing_metrics, folder, workspace_id,
+        source, provenance,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -155,6 +175,8 @@ export class DashboardRepository implements IDashboardRepository {
         ${useExistingMetrics},
         ${input.folder ?? null},
         ${input.workspaceId ?? null},
+        ${source},
+        ${provenanceJson},
         ${now},
         ${now}
       )
@@ -320,7 +342,9 @@ export class DashboardRepository implements IDashboardRepository {
           id, type, title, description, prompt, user_id, status,
           panels, variables, refresh_interval_sec, datasource_ids,
           use_existing_metrics, folder, workspace_id,
-          version, publish_status, error, created_at, updated_at
+          version, publish_status, error,
+          source, provenance,
+          created_at, updated_at
         ) VALUES (
           ${raw.id},
           ${raw.type ?? 'dashboard'},
@@ -339,6 +363,8 @@ export class DashboardRepository implements IDashboardRepository {
           ${raw.version ?? null},
           ${raw.publishStatus ?? null},
           ${raw.error ?? null},
+          ${(raw.source ?? 'manual') as ResourceSource},
+          ${raw.provenance ? JSON.stringify(raw.provenance) : null},
           ${raw.createdAt ?? nowIso()},
           ${raw.updatedAt ?? nowIso()}
         )
@@ -359,6 +385,8 @@ export class DashboardRepository implements IDashboardRepository {
           version              = excluded.version,
           publish_status       = excluded.publish_status,
           error                = excluded.error,
+          source               = excluded.source,
+          provenance           = excluded.provenance,
           created_at           = excluded.created_at,
           updated_at           = excluded.updated_at
       `);

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -305,6 +305,9 @@ CREATE TABLE IF NOT EXISTS folder (
   updated     TEXT NOT NULL,
   created_by  TEXT NULL,
   updated_by  TEXT NULL,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source      TEXT NOT NULL DEFAULT 'manual',
+  provenance  TEXT NULL,
   FOREIGN KEY (org_id)     REFERENCES org(id)  ON DELETE CASCADE,
   FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
   FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
@@ -562,6 +565,9 @@ CREATE TABLE IF NOT EXISTS dashboards (
   version              INTEGER,
   publish_status       TEXT,
   error                TEXT,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source               TEXT NOT NULL DEFAULT 'manual',
+  provenance           TEXT NULL,
   created_at           TEXT NOT NULL,
   updated_at           TEXT NOT NULL
 );
@@ -661,6 +667,9 @@ CREATE TABLE IF NOT EXISTS alert_rules (
   last_evaluated_at       TEXT,
   last_fired_at           TEXT,
   fire_count              INTEGER NOT NULL DEFAULT 0,
+  -- Provisioning marker — see packages/common/src/resources/writable-gate.ts.
+  source                  TEXT NOT NULL DEFAULT 'manual',
+  provenance              TEXT NULL,
   created_at              TEXT NOT NULL,
   updated_at              TEXT NOT NULL
 );

--- a/packages/data-layer/src/repository/sqlite/alert-rule.ts
+++ b/packages/data-layer/src/repository/sqlite/alert-rule.ts
@@ -39,6 +39,8 @@ import type {
   AlertSilence,
   NotificationPolicy,
   SilenceStatus,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import type {
   IAlertRuleRepository,
@@ -69,6 +71,8 @@ interface RuleRow {
   last_evaluated_at: string | null;
   last_fired_at: string | null;
   fire_count: number;
+  source: string;
+  provenance: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -155,6 +159,7 @@ function rowToRule(r: RuleRow): AlertRule {
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     fireCount: r.fire_count,
+    source: (r.source ?? 'manual') as ResourceSource,
   };
   if (r.original_prompt !== null) rule.originalPrompt = r.original_prompt;
   if (labels !== null) rule.labels = labels;
@@ -164,6 +169,8 @@ function rowToRule(r: RuleRow): AlertRule {
   if (r.workspace_id !== null) rule.workspaceId = r.workspace_id;
   if (r.last_evaluated_at !== null) rule.lastEvaluatedAt = r.last_evaluated_at;
   if (r.last_fired_at !== null) rule.lastFiredAt = r.last_fired_at;
+  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null);
+  if (prov) rule.provenance = prov;
   return rule;
 }
 
@@ -229,6 +236,8 @@ export class AlertRuleRepository implements IAlertRuleRepository {
   ): Promise<AlertRule> {
     const id = `alert_${randomUUID().slice(0, 12)}`;
     const now = nowIso();
+    const source: ResourceSource = (data as { source?: ResourceSource }).source ?? 'manual';
+    const provenance = (data as { provenance?: ResourceProvenance }).provenance ?? null;
     this.db.run(sql`
       INSERT INTO alert_rules (
         id, name, description, original_prompt, condition,
@@ -236,6 +245,7 @@ export class AlertRuleRepository implements IAlertRuleRepository {
         state_changed_at, pending_since, notification_policy_id,
         investigation_id, workspace_id, folder_uid, org_id, created_by,
         last_evaluated_at, last_fired_at, fire_count,
+        source, provenance,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -258,6 +268,8 @@ export class AlertRuleRepository implements IAlertRuleRepository {
         ${data.lastEvaluatedAt ?? null},
         ${data.lastFiredAt ?? null},
         ${0},
+        ${source},
+        ${stringifyJsonOrNull(provenance)},
         ${now},
         ${now}
       )

--- a/packages/data-layer/src/repository/sqlite/dashboard.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard.ts
@@ -43,6 +43,8 @@ import type {
   IDashboardRepository,
   NewDashboardInput,
   DashboardPatch,
+  ResourceSource,
+  ResourceProvenance,
 } from '@agentic-obs/common';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import type { IDashboardRepository as ILegacyDashboardRepository } from '../interfaces.js';
@@ -68,6 +70,8 @@ interface DashboardRow {
   version: number | null;
   publish_status: string | null;
   error: string | null;
+  source: string;
+  provenance: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +99,16 @@ function fromBool(v: boolean | undefined, dflt = false): number {
   return (v ?? dflt) ? 1 : 0;
 }
 
+function parseProvenance(raw: string | null): ResourceProvenance | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as ResourceProvenance) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function rowToDashboard(r: DashboardRow): Dashboard {
   const base: Dashboard = {
     id: r.id,
@@ -109,6 +123,7 @@ function rowToDashboard(r: DashboardRow): Dashboard {
     refreshIntervalSec: r.refresh_interval_sec,
     datasourceIds: parseJsonArray<string>(r.datasource_ids, []),
     useExistingMetrics: toBool(r.use_existing_metrics),
+    source: (r.source ?? 'manual') as ResourceSource,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -117,6 +132,8 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
+  const prov = parseProvenance(r.provenance);
+  if (prov) base.provenance = prov;
   return base;
 }
 
@@ -134,11 +151,14 @@ export class DashboardRepository implements IDashboardRepository {
     const datasourceIdsJson = JSON.stringify(input.datasourceIds ?? []);
     const useExistingMetrics = fromBool(input.useExistingMetrics, true);
 
+    const source: ResourceSource = input.source ?? 'manual';
+    const provenanceJson = input.provenance ? JSON.stringify(input.provenance) : null;
     this.db.run(sql`
       INSERT INTO dashboards (
         id, type, title, description, prompt, user_id, status,
         panels, variables, refresh_interval_sec, datasource_ids,
         use_existing_metrics, folder, workspace_id,
+        source, provenance,
         created_at, updated_at
       ) VALUES (
         ${id},
@@ -155,6 +175,8 @@ export class DashboardRepository implements IDashboardRepository {
         ${useExistingMetrics},
         ${input.folder ?? null},
         ${input.workspaceId ?? null},
+        ${source},
+        ${provenanceJson},
         ${now},
         ${now}
       )
@@ -320,7 +342,9 @@ export class DashboardRepository implements IDashboardRepository {
           id, type, title, description, prompt, user_id, status,
           panels, variables, refresh_interval_sec, datasource_ids,
           use_existing_metrics, folder, workspace_id,
-          version, publish_status, error, created_at, updated_at
+          version, publish_status, error,
+          source, provenance,
+          created_at, updated_at
         ) VALUES (
           ${raw.id},
           ${raw.type ?? 'dashboard'},
@@ -339,6 +363,8 @@ export class DashboardRepository implements IDashboardRepository {
           ${raw.version ?? null},
           ${raw.publishStatus ?? null},
           ${raw.error ?? null},
+          ${(raw.source ?? 'manual') as ResourceSource},
+          ${raw.provenance ? JSON.stringify(raw.provenance) : null},
           ${raw.createdAt ?? nowIso()},
           ${raw.updatedAt ?? nowIso()}
         )
@@ -359,6 +385,8 @@ export class DashboardRepository implements IDashboardRepository {
           version              = excluded.version,
           publish_status       = excluded.publish_status,
           error                = excluded.error,
+          source               = excluded.source,
+          provenance           = excluded.provenance,
           created_at           = excluded.created_at,
           updated_at           = excluded.updated_at
       `);

--- a/packages/data-layer/src/stores/alert-rule-store.ts
+++ b/packages/data-layer/src/stores/alert-rule-store.ts
@@ -35,6 +35,8 @@ export class AlertRuleStore implements Persistable {
     const now = new Date().toISOString();
     const rule: AlertRule = {
       ...data,
+      // Default source to 'manual' when caller didn't set one — see writable-gate.ts.
+      source: data.source ?? 'manual',
       id: `alert_${randomUUID().slice(0, 12)}`,
       state: 'normal',
       stateChangedAt: now,

--- a/packages/data-layer/src/stores/dashboard-store.ts
+++ b/packages/data-layer/src/stores/dashboard-store.ts
@@ -27,6 +27,8 @@ export class DashboardStore implements Persistable {
     useExistingMetrics?: boolean
     folder?: string
     workspaceId?: string
+    source?: import('@agentic-obs/common').ResourceSource
+    provenance?: import('@agentic-obs/common').ResourceProvenance
   }): Dashboard {
     const now = new Date().toISOString()
     const id = uid()
@@ -46,6 +48,8 @@ export class DashboardStore implements Persistable {
       useExistingMetrics: params.useExistingMetrics ?? true,
       ...(params.folder !== undefined ? { folder: params.folder } : {}),
       ...(params.workspaceId !== undefined ? { workspaceId: params.workspaceId } : {}),
+      source: params.source ?? 'manual',
+      ...(params.provenance !== undefined ? { provenance: params.provenance } : {}),
       createdAt: now,
       updatedAt: now,
     }

--- a/packages/data-layer/src/stores/interfaces.ts
+++ b/packages/data-layer/src/stores/interfaces.ts
@@ -152,6 +152,8 @@ export interface IGatewayDashboardStore {
     useExistingMetrics?: boolean
     folder?: string
     workspaceId?: string
+    source?: import('@agentic-obs/common').ResourceSource
+    provenance?: import('@agentic-obs/common').ResourceProvenance
   }): MaybeAsync<Dashboard>
   findById(id: string): MaybeAsync<Dashboard | undefined>
   findAll(userId?: string): MaybeAsync<Dashboard[]>


### PR DESCRIPTION
Foundation for provisioned (GitOps) resource protection. RFC reference: docs/design/rfc-safety-patterns.md.

## Problem

Rounds has no per-row marker for whether a resource is manually created, API-created, AI-generated, or provisioned from a file/git source. This means there is no way to protect GitOps-managed dashboards/alerts from being silently mutated.

## Changes

- New columns on \`dashboards\`, \`alert_rules\`, \`folders\`:
  - \`source TEXT NOT NULL DEFAULT 'manual'\` — enum: \`manual | api | ai_generated | provisioned_file | provisioned_git\`
  - \`provenance JSON NULL\` — optional details blob
- New util \`packages/common/src/resources/writable-gate.ts\`: \`assertWritable()\` throws \`ProvisionedResourceError\` on provisioned sources.
- Wired into:
  - All REST write endpoints (PUT/DELETE on dashboards/alerts/folders, panel ops) → 409 \`PROVISIONED_RESOURCE\` with "Fork to your workspace" hint
  - Agent action-executor (single chokepoint for dashboard mutations) + handler entrypoints for alert/folder
- Source on create:
  - REST API → \`api\`
  - Agent tools → \`ai_generated\`
  - Web direct create → \`manual\` (default)
- Migration: additive ALTER TABLE for both SQLite and Postgres; existing rows default to \`manual\`.

## Test plan

- [x] +11 new tests; 1938/1938 pass
- [x] tsc --build clean
- [ ] CI green

## Out of scope (Wave 2)

- Fork-to-workspace UI flow (Wave 2)
- AI-generated git diff for provisioned mutations (Wave 2)
- Detection / sync of actual provisioned resources from git source (separate RFC)