### PR TITLE
R-1: reliability fixes (dashboard stuck-generating, investigation silent catches)

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
@@ -179,6 +179,86 @@ describe('dashboard handlers', () => {
       expect(observation).toMatch(/no active dashboard/);
       expect(ctx.actionExecutor.execute).not.toHaveBeenCalled();
     });
+
+    // ── T0.2 regression: status state machine never sticks at 'generating'
+    it('flips status to ready after a successful panel add', async () => {
+      const updateStatus = vi.fn().mockResolvedValue(undefined);
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+        store: {
+          findById: vi.fn().mockResolvedValue(undefined),
+          update: vi.fn(),
+          updatePanels: vi.fn(),
+          updateVariables: vi.fn(),
+          updateStatus,
+        } as never,
+      });
+
+      await handleDashboardAddPanels(ctx, {
+        panels: [{ title: 'p1', visualization: 'time_series', queries: [] }],
+      });
+
+      expect(updateStatus).toHaveBeenCalledWith('d1', 'ready', undefined);
+    });
+
+    it('flips status to failed when panel generation throws partway through', async () => {
+      const updateStatus = vi.fn().mockResolvedValue(undefined);
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+        store: {
+          findById: vi.fn().mockResolvedValue(undefined),
+          update: vi.fn(),
+          updatePanels: vi.fn(),
+          updateVariables: vi.fn(),
+          updateStatus,
+        } as never,
+        actionExecutor: {
+          execute: vi.fn().mockRejectedValue(new Error('boom: adapter blew up')),
+        } as never,
+      });
+
+      await expect(
+        handleDashboardAddPanels(ctx, {
+          panels: [{ title: 'p1', visualization: 'time_series', queries: [] }],
+        }),
+      ).rejects.toThrow(/boom/);
+
+      // No path leaves status at 'generating': failure must land at 'failed'.
+      const statusCalls = updateStatus.mock.calls.map((c) => c[1]);
+      expect(statusCalls).toContain('failed');
+      expect(statusCalls).not.toContain('ready');
+      // The error message rides along so the UI can render an actionable state.
+      const failedCall = updateStatus.mock.calls.find((c) => c[1] === 'failed');
+      expect(failedCall?.[2]).toMatch(/boom/);
+    });
+
+    it('emits SSE error event and warns when updateStatus itself fails', async () => {
+      const updateStatus = vi.fn().mockRejectedValue(new Error('db unavailable'));
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+        store: {
+          findById: vi.fn().mockResolvedValue(undefined),
+          update: vi.fn(),
+          updatePanels: vi.fn(),
+          updateVariables: vi.fn(),
+          updateStatus,
+        } as never,
+      });
+
+      await handleDashboardAddPanels(ctx, {
+        panels: [{ title: 'p1', visualization: 'time_series', queries: [] }],
+      });
+
+      // SSE error event surfaced so the web UI doesn't sit on stale 'generating'.
+      const errorEvent = ctx.sendEvent.mock.calls
+        .map(([e]) => e as { type: string; message?: string })
+        .find((e) => e.type === 'error');
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent!.message).toMatch(/db unavailable/);
+    });
   });
 
   describe('handleDashboardRemovePanels', () => {

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -1,9 +1,45 @@
 import { randomUUID } from 'node:crypto';
 import { ac, AuditAction, assertWritable, ProvisionedResourceError } from '@agentic-obs/common';
-import type { PendingDashboardChange, PendingDashboardChangeOp } from '@agentic-obs/common';
+import type { PendingDashboardChange, PendingDashboardChangeOp, DashboardStatus } from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/common/logging';
 import type { ActionContext } from './_context.js';
 import { withToolEventBoundary, withWorkspaceScope } from './_shared.js';
 import { applyLayout } from '../layout-engine.js';
+
+const log = createLogger('dashboard-handler');
+
+/**
+ * Best-effort `updateStatus` write. On failure we log a structured warning
+ * AND emit an SSE `error` event so the web UI doesn't sit on a stale
+ * 'generating' badge silently. We still don't fail the caller — the
+ * dashboard itself is fine; only the status row is out of sync.
+ */
+async function tryUpdateDashboardStatus(
+  ctx: ActionContext,
+  dashboardId: string,
+  status: DashboardStatus,
+  errorMessage?: string,
+): Promise<void> {
+  if (!ctx.store.updateStatus) return;
+  try {
+    await ctx.store.updateStatus(dashboardId, status, errorMessage);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(
+      {
+        dashboardId,
+        targetStatus: status,
+        errorClass: err instanceof Error ? err.constructor.name : typeof err,
+        error: msg,
+      },
+      'dashboard updateStatus failed',
+    );
+    ctx.sendEvent({
+      type: 'error',
+      message: `Failed to update dashboard status to "${status}": ${msg}`,
+    });
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pending-changes helper — Task 09
@@ -196,13 +232,7 @@ export async function handleDashboardClone(
       // copy over verbatim — they carry no per-connector state on their own.
       await ctx.store.updatePanels(created.id, clonedPanels);
       await ctx.store.updateVariables(created.id, source.variables ?? []);
-      if (ctx.store.updateStatus) {
-        try {
-          await ctx.store.updateStatus(created.id, 'ready');
-        } catch {
-          /* non-fatal — leaves badge at 'generating' until next status write */
-        }
-      }
+      await tryUpdateDashboardStatus(ctx, created.id, 'ready');
 
       ctx.setNavigateTo(`/dashboards/${created.id}`);
       // The freshly cloned dashboard becomes the active one (same as create).
@@ -290,6 +320,26 @@ export async function handleDashboardAddPanels(
 
   ctx.sendEvent({ type: 'tool_call', tool: 'dashboard_add_panels', args: { count: panels.length }, displayText: `Adding ${panels.length} panel(s)` });
 
+  try {
+    return await runAddPanels(ctx, dashboardId, panels);
+  } catch (err) {
+    // Critical: a throw partway through panel generation would otherwise
+    // leave the dashboard stuck at 'generating' forever (the list badge
+    // turns yellow and never resolves). Flip to 'failed' with the error
+    // message so the UI can render an actionable state, then rethrow so
+    // the orchestrator's tool_result(success: false) path still runs.
+    const msg = err instanceof Error ? err.message : String(err);
+    await tryUpdateDashboardStatus(ctx, dashboardId, 'failed', msg);
+    ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_panels', summary: msg, success: false });
+    throw err;
+  }
+}
+
+async function runAddPanels(
+  ctx: ActionContext,
+  dashboardId: string,
+  panels: Array<Record<string, unknown>>,
+): Promise<string> {
   type CommonPanel = import('@agentic-obs/common').PanelConfig;
   // Panel sizing is NOT the agent's concern — every panel gets a viz-based
   // default from the layout-engine's panelSize(); users can drag to resize
@@ -362,15 +412,9 @@ export async function handleDashboardAddPanels(
   // Flip the dashboard out of its initial 'generating' state once it has
   // real panels — the list page shows a yellow "GENERATING" badge until
   // status becomes 'ready', which looked wrong for a dashboard the user
-  // can already open and see populated. Best-effort; older store shapes
-  // may not implement updateStatus.
-  if (ctx.store.updateStatus) {
-    try {
-      await ctx.store.updateStatus(dashboardId, 'ready');
-    } catch {
-      /* non-fatal — badge will stay 'generating' until next status write */
-    }
-  }
+  // can already open and see populated. tryUpdateDashboardStatus logs +
+  // emits an SSE error if the status write itself fails.
+  await tryUpdateDashboardStatus(ctx, dashboardId, 'ready');
 
   const observationText = `Added ${panelConfigs.length} panel(s): ${panelConfigs.map((p) => p.title).join(', ')}`;
   ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_panels', summary: observationText, success: true });

--- a/packages/agent-core/src/agent/handlers/investigation.test.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Investigation } from '@agentic-obs/common';
+
+// Capture-fail T1.1 test asserts a structured warn log; intercept the logger
+// factory so we don't have to scrape pino's stream output.
+const warnSpy = vi.fn();
+vi.mock('@agentic-obs/common/logging', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agentic-obs/common/logging')>();
+  return {
+    ...actual,
+    createLogger: (name: string) => {
+      const real = actual.createLogger(name);
+      return new Proxy(real, {
+        get(target, prop) {
+          if (prop === 'warn') return warnSpy;
+          return (target as unknown as Record<string | symbol, unknown>)[prop];
+        },
+      });
+    },
+  };
+});
+
 import {
   handleInvestigationAddSection,
   handleInvestigationComplete,
   handleInvestigationCreate,
 } from './investigation.js';
 import { makeFakeActionContext } from './_test-helpers.js';
+import { AdapterRegistry } from '../../adapters/registry.js';
+import type { IMetricsAdapter } from '../../adapters/metrics-adapter.js';
 
 function investigationStore(workspaceId = 'test-org') {
   const investigation: Investigation = {
@@ -209,6 +231,88 @@ describe('investigation handlers', () => {
     expect(after.citations?.map((c) => c.ref).sort()).toEqual(['l1', 'm1']);
     expect(after.citations?.find((c) => c.ref === 'm1')?.kind).toBe('metric');
     expect(after.citations?.find((c) => c.ref === 'l1')?.kind).toBe('log');
+  });
+
+  // ── T1.1 regression: snapshot capture failure is observable ─────────────
+  it('warns + stamps captureError when snapshot capture fails, investigation still completes', async () => {
+    const created = {
+      id: 'inv_cap',
+      sessionId: 'ses_1',
+      userId: 'agent',
+      intent: 'why',
+      structuredIntent: {} as Investigation['structuredIntent'],
+      plan: { entity: '', objective: '', steps: [], stopConditions: [] },
+      status: 'investigating' as const,
+      hypotheses: [],
+      actions: [],
+      evidence: [],
+      symptoms: [],
+      workspaceId: 'test-org',
+      createdAt: '2026-04-26T00:00:00.000Z',
+      updatedAt: '2026-04-26T00:00:00.000Z',
+    };
+    const store = {
+      create: vi.fn(async () => created),
+      findById: vi.fn(async () => created),
+      findAll: vi.fn(),
+      updateStatus: vi.fn(),
+      updatePlan: vi.fn(),
+      updateResult: vi.fn(),
+    };
+    const reportStore = { save: vi.fn() };
+
+    // Throwing adapter — exercises the snapshot catch block.
+    const failingAdapter: IMetricsAdapter = {
+      instantQuery: vi.fn(async () => { throw new Error('prom unreachable'); }),
+      rangeQuery: vi.fn(async () => { throw new Error('prom unreachable'); }),
+    } as unknown as IMetricsAdapter;
+    const adapters = new AdapterRegistry();
+    adapters.register({
+      info: { id: 'prom-1', name: 'prom-1', type: 'prometheus', signalType: 'metrics', isDefault: true },
+      metrics: failingAdapter,
+    });
+
+    const ctx = makeFakeActionContext({
+      investigationStore: store,
+      investigationReportStore: reportStore,
+      adapters,
+    });
+
+    await handleInvestigationCreate(ctx, { question: 'why' });
+
+    warnSpy.mockClear();
+    await handleInvestigationAddSection(ctx, {
+      type: 'evidence',
+      content: 'CPU saturation',
+      panel: {
+        title: 'CPU',
+        visualization: 'time_series',
+        queries: [{ refId: 'A', expr: 'rate(cpu[5m])' }],
+      },
+    });
+
+    // Section persisted with a captureError provenance marker.
+    const sections = ctx.investigationSections.get('inv_cap')!;
+    expect(sections).toHaveLength(1);
+    const panel = sections[0]!.panel!;
+    expect(panel.snapshotData?.captureError).toMatch(/prom unreachable/);
+
+    // Warn log emitted with the structured context fields.
+    const snapshotWarn = warnSpy.mock.calls.find(
+      (c) => c[1] === 'investigation snapshot capture failed',
+    );
+    expect(snapshotWarn).toBeDefined();
+    const ctxFields = snapshotWarn![0] as Record<string, unknown>;
+    expect(ctxFields.investigationId).toBe('inv_cap');
+    expect(ctxFields.queryKind).toBe('range');
+    expect(ctxFields.adapterId).toBe('prom-1');
+    expect(ctxFields.panelTitle).toBe('CPU');
+    expect(ctxFields.errorClass).toBe('Error');
+
+    // Investigation still completes — capture failure is non-fatal.
+    const finishResult = await handleInvestigationComplete(ctx, { summary: 'done' });
+    expect(finishResult).toContain('report saved');
+    expect(reportStore.save).toHaveBeenCalledOnce();
   });
 
   it('persists provenance on the saved report at completion', async () => {

--- a/packages/agent-core/src/agent/handlers/investigation.test.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.test.ts
@@ -315,6 +315,57 @@ describe('investigation handlers', () => {
     expect(reportStore.save).toHaveBeenCalledOnce();
   });
 
+  // ── T1.2 regression: final status-update failure is observable ──────────
+  it('warns when updateStatus rejects at completion but still saves the report', async () => {
+    const inv: Investigation = {
+      id: 'inv_st',
+      sessionId: 'ses_1',
+      userId: 'agent',
+      intent: 'why',
+      structuredIntent: {} as Investigation['structuredIntent'],
+      plan: { entity: '', objective: '', steps: [], stopConditions: [] },
+      status: 'investigating',
+      hypotheses: [],
+      actions: [],
+      evidence: [],
+      symptoms: [],
+      workspaceId: 'test-org',
+      createdAt: '2026-04-26T00:00:00.000Z',
+      updatedAt: '2026-04-26T00:00:00.000Z',
+    };
+    const store = {
+      create: vi.fn(),
+      findById: vi.fn(async () => inv),
+      findAll: vi.fn(),
+      updateStatus: vi.fn().mockRejectedValue(new Error('db unreachable')),
+      updatePlan: vi.fn(),
+      updateResult: vi.fn(),
+    };
+    const reportStore = { save: vi.fn() };
+    const ctx = makeFakeActionContext({
+      investigationStore: store,
+      investigationReportStore: reportStore,
+      activeInvestigationId: 'inv_st',
+    });
+
+    warnSpy.mockClear();
+    const result = await handleInvestigationComplete(ctx, { summary: 'done' });
+
+    // Report saved regardless of status-update outcome.
+    expect(result).toContain('report saved');
+    expect(reportStore.save).toHaveBeenCalledOnce();
+
+    // Warn emitted with structured context.
+    const statusWarn = warnSpy.mock.calls.find(
+      (c) => typeof c[1] === 'string' && c[1].includes('investigation updateStatus failed'),
+    );
+    expect(statusWarn).toBeDefined();
+    const ctxFields = statusWarn![0] as Record<string, unknown>;
+    expect(ctxFields.investigationId).toBe('inv_st');
+    expect(ctxFields.targetStatus).toBe('completed');
+    expect(ctxFields.error).toMatch(/db unreachable/);
+  });
+
   it('persists provenance on the saved report at completion', async () => {
     const created = {
       id: 'inv_p2',

--- a/packages/agent-core/src/agent/handlers/investigation.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.ts
@@ -180,6 +180,7 @@ export async function handleInvestigationAddSection(
     const chosenSource = metricsSources.find((d) => d.isDefault) ?? metricsSources[0];
     const evidenceAdapter = chosenSource ? ctx.adapters.metrics(chosenSource.id) : undefined;
     if (evidenceAdapter && queries.length > 0) {
+      const adapterId = chosenSource?.id ?? 'unknown';
       try {
         const hasInstantQuery = queries.some((q) => q.instant);
         if (hasInstantQuery) {
@@ -206,8 +207,20 @@ export async function handleInvestigationAddSection(
                   values: first.values.map(([, v]) => Number(v)).filter(Number.isFinite),
                 };
               }
-            } catch {
-              // ignore — instant snapshot still wins
+            } catch (sparkErr) {
+              // Non-fatal: instant snapshot still wins. Operators get a trail
+              // so missing sparklines are explicable rather than mysterious.
+              log.warn(
+                {
+                  investigationId,
+                  panelTitle: panelConfig.title,
+                  queryKind: 'sparkline',
+                  adapterId,
+                  errorClass: sparkErr instanceof Error ? sparkErr.constructor.name : typeof sparkErr,
+                  error: sparkErr instanceof Error ? sparkErr.message : String(sparkErr),
+                },
+                'investigation sparkline capture failed',
+              );
             }
           }
           panelConfig.snapshotData = {
@@ -245,8 +258,30 @@ export async function handleInvestigationAddSection(
             capturedAt: new Date().toISOString(),
           };
         }
-      } catch {
-        // Snapshot capture failed — proceed without snapshot
+      } catch (capErr) {
+        // Snapshot capture failed — investigation still completes (the
+        // evidence is optional polish, not the report itself). Log so
+        // operators can correlate empty evidence panels with adapter
+        // failures, and stamp a `captureError` provenance marker on the
+        // panel so the UI can render "(capture failed)" instead of an
+        // empty chart.
+        const queryKind = queries.some((q) => q.instant) ? 'instant' : 'range';
+        const errMsg = capErr instanceof Error ? capErr.message : String(capErr);
+        log.warn(
+          {
+            investigationId,
+            panelTitle: panelConfig.title,
+            queryKind,
+            adapterId,
+            errorClass: capErr instanceof Error ? capErr.constructor.name : typeof capErr,
+            error: errMsg,
+          },
+          'investigation snapshot capture failed',
+        );
+        panelConfig.snapshotData = {
+          capturedAt: new Date().toISOString(),
+          captureError: errMsg,
+        };
       }
     }
 

--- a/packages/agent-core/src/agent/handlers/investigation.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.ts
@@ -390,12 +390,23 @@ export async function handleInvestigationComplete(
         ...(finalProvenance ? { provenance: finalProvenance } : {}),
       });
 
-      // Update investigation status if store supports it
+      // Update investigation status if store supports it. Non-fatal: the
+      // report is already saved, so callers shouldn't see a hard error
+      // just because the status row is briefly stale. Log loudly so the
+      // mismatch is discoverable instead of silent.
       if (ctx.investigationStore) {
         try {
           await ctx.investigationStore.updateStatus(investigationId, 'completed');
-        } catch {
-          // Status update failed — non-fatal
+        } catch (err) {
+          log.warn(
+            {
+              investigationId,
+              targetStatus: 'completed',
+              errorClass: err instanceof Error ? err.constructor.name : typeof err,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            'investigation updateStatus failed; report saved but status stale',
+          );
         }
       }
 

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -63,6 +63,10 @@ export interface PanelSnapshotData {
   sparkline?: { timestamps: number[]; values: number[] };
   /** ISO timestamp when the data was captured */
   capturedAt: string;
+  /** Set when snapshot capture failed (adapter/query error). The panel
+   *  rendered without snapshot data; this field tells the UI / operator
+   *  why the evidence is empty instead of silently appearing broken. */
+  captureError?: string;
 }
 
 /** Visual polish fields the agent may emit alongside core panel config.


### PR DESCRIPTION
From `internal-docs/design/code-review-remediation-tasks.md`: T0.2, T1.1, T1.2.

## T0.2 Dashboard status stuck in \`generating\` (P0)

**Before:** any throw or status-write failure in panel-add/clone left status at \`generating\` forever. Web badge spins indefinitely.

**After:** new \`tryUpdateDashboardStatus\` helper:
- success → \`ready\`
- throw → \`failed\` (with error message; existing \`updateStatus\` already supports the error arg)
- status-write failure → \`log.warn\` + SSE \`error\` event (no longer silent)

Touched: \`handleDashboardClone\`, \`handleDashboardAddPanels\` in \`packages/agent-core/src/agent/handlers/dashboard.ts\`. Body of add-panels wrapped in \`runAddPanels\` so a throw flips to \`failed\` before rethrow.

**Tests:** 3 new in \`dashboard.test.ts\` covering success/throw/status-write-fails.

## T1.1 Investigation snapshot capture silent catch (P1)

**Before:** 2 catch blocks in \`investigation.ts\` silently swallowed adapter failures during sparkline/instant/range capture. Operators couldn't tell why evidence was missing.

**After:** \`log.warn\` with \`{ investigationId, panelTitle, queryKind, adapterId, errorClass }\`. New \`PanelSnapshotData.captureError\` field in \`packages/common/src/models/dashboard.ts\` records the failure on the evidence panel so the UI can surface it later. Investigation still completes — non-fatal.

**Test:** \`warns + stamps captureError when snapshot capture fails, investigation still completes\`.

## T1.2 Investigation final status update silent catch (P1)

**Before:** \`handleInvestigationComplete\` silently swallowed \`updateStatus\` rejection. Report saved, status stale.

**After:** \`log.warn\` with \`{ investigationId, targetStatus, errorClass, error }\`. Behavior preserved — report still saves.

**Test:** \`warns when updateStatus rejects at completion but still saves the report\`.

## Test plan

- [x] 10/10 investigation tests pass
- [x] 28/28 dashboard handler tests pass
- [x] 224/225 agent-core tests pass (1 failure is pre-existing on main, verified)
- [ ] CI green