### PR TITLE
R-2: agent factory extraction + audit writer bridge

### DIFF
--- a/packages/agent-core/src/agent/background-runner.ts
+++ b/packages/agent-core/src/agent/background-runner.ts
@@ -12,7 +12,8 @@
  */
 
 import type { Identity } from '@agentic-obs/common';
-import type { OrchestratorAgent, OrchestratorDeps } from './orchestrator-agent.js';
+import type { OrchestratorDeps } from './orchestrator-agent.js';
+import type { AgentRunner } from './factory.js';
 import type { AgentType } from './agent-types.js';
 
 /**
@@ -70,7 +71,7 @@ export interface BackgroundRunnerDeps {
     overrides: Pick<OrchestratorDeps, 'identity'> & {
       agentType?: AgentType;
     },
-  ) => OrchestratorAgent | Promise<OrchestratorAgent>;
+  ) => AgentRunner | Promise<AgentRunner>;
 }
 
 /**

--- a/packages/agent-core/src/agent/factory.test.ts
+++ b/packages/agent-core/src/agent/factory.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { AuditAction } from '@agentic-obs/common';
-import type { Identity } from '@agentic-obs/common';
+import type { Identity, NewAuditLogEntry } from '@agentic-obs/common';
 import { AdapterRegistry } from '../adapters/index.js';
 import { ActionExecutor } from './action-executor.js';
 import { buildActionContext } from './orchestrator-action-context.js';
@@ -104,7 +104,7 @@ describe('audit-writer bridge', () => {
 // ---------------------------------------------------------------------------
 
 function makeContextDeps(overrides: {
-  auditEntryWriter?: (entry: unknown) => Promise<void>;
+  auditEntryWriter?: (entry: NewAuditLogEntry) => Promise<void>;
 }): Parameters<typeof buildActionContext>[0] {
   const created: Record<string, unknown> = {
     id: 'dash-1',

--- a/packages/agent-core/src/agent/factory.test.ts
+++ b/packages/agent-core/src/agent/factory.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Factory tests — focus on the audit-writer bridge (T1.5 / Wave-1 leftover).
+ *
+ * The factory's job is "construct the agent runner and wire deps". The
+ * one piece of behavior here that isn't already covered by orchestrator
+ * tests is the new bridge: when the api-gateway hands the factory an
+ * `AuditWriter` (with `.log(entry)`), every handler's
+ * `ctx.auditWriter?.(entry)` must reach that writer.
+ *
+ * We don't drive a full ReAct loop here — that requires a real LLM
+ * gateway. We construct the action context the same way the orchestrator
+ * does and call a handler directly, asserting the audit row lands.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { AuditAction } from '@agentic-obs/common';
+import type { Identity } from '@agentic-obs/common';
+import { AdapterRegistry } from '../adapters/index.js';
+import { ActionExecutor } from './action-executor.js';
+import { buildActionContext } from './orchestrator-action-context.js';
+import { createAgentRunner } from './factory.js';
+import { handleDashboardCreate } from './handlers/dashboard.js';
+import type { IAuditWriter } from './types-permissions.js';
+
+function makeIdentity(): Identity {
+  return {
+    userId: 'u1',
+    orgId: 'org1',
+    orgRole: 'Admin',
+    isServerAdmin: false,
+    authenticatedBy: 'session',
+  };
+}
+
+function makeFakeAuditWriter() {
+  const entries: unknown[] = [];
+  const writer: IAuditWriter = {
+    log: vi.fn(async (entry) => {
+      entries.push(entry);
+    }),
+  };
+  return { writer, entries };
+}
+
+describe('createAgentRunner', () => {
+  it('returns a runner with a sessionId', () => {
+    const { writer } = makeFakeAuditWriter();
+    const runner = createAgentRunner(makeRunnerDeps({ auditWriter: writer }));
+    expect(typeof runner.sessionId).toBe('string');
+    expect(runner.sessionId.length).toBeGreaterThan(0);
+  });
+
+  it('preserves an explicit sessionId', () => {
+    const { writer } = makeFakeAuditWriter();
+    const runner = createAgentRunner(
+      makeRunnerDeps({ auditWriter: writer }),
+      'session-fixed',
+    );
+    expect(runner.sessionId).toBe('session-fixed');
+  });
+});
+
+describe('audit-writer bridge', () => {
+  it('bridges IAuditWriter.log into ActionContext.auditWriter', async () => {
+    const { writer, entries } = makeFakeAuditWriter();
+
+    // Build context the same way the factory-built runner does: route the
+    // structured writer through the bridge.
+    const ctx = buildActionContext(
+      makeContextDeps({
+        auditEntryWriter: (entry) => writer.log(entry),
+      }),
+      makeContextRuntime(),
+    );
+
+    expect(ctx.auditWriter).toBeDefined();
+
+    // Invoke the dashboard.create handler and assert the audit row reached
+    // the underlying AuditWriter.
+    const result = await handleDashboardCreate(ctx, {
+      title: 'Latency overview',
+      datasourceId: 'ds-prod',
+    });
+
+    expect(result).toContain('Created dashboard');
+    // The handler fires-and-forgets; give the microtask queue a tick.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(writer.log).toHaveBeenCalled();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0] as { action: string; targetType: string };
+    expect(entry.action).toBe(AuditAction.DashboardCreate);
+    expect(entry.targetType).toBe('dashboard');
+  });
+
+  it('leaves ActionContext.auditWriter undefined when no writer is wired', () => {
+    const ctx = buildActionContext(makeContextDeps({}), makeContextRuntime());
+    expect(ctx.auditWriter).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeContextDeps(overrides: {
+  auditEntryWriter?: (entry: unknown) => Promise<void>;
+}): Parameters<typeof buildActionContext>[0] {
+  const created: Record<string, unknown> = {
+    id: 'dash-1',
+    title: 'Latency overview',
+    workspaceId: 'org1',
+  };
+  return {
+    gateway: {} as never,
+    model: 'test-model',
+    store: {
+      create: vi.fn(async (input: Record<string, unknown>) => ({
+        ...input,
+        ...created,
+      })),
+    } as never,
+    conversationStore: {} as never,
+    investigationReportStore: {} as never,
+    alertRuleStore: {} as never,
+    adapters: new AdapterRegistry(),
+    sendEvent: () => undefined,
+    identity: makeIdentity(),
+    accessControl: {
+      filterByPermission: async (list: unknown[]) => list,
+      checkPermission: async () => ({ ok: true }),
+    } as never,
+    ...(overrides.auditEntryWriter
+      ? { auditEntryWriter: overrides.auditEntryWriter as never }
+      : {}),
+  };
+}
+
+function makeContextRuntime(): Parameters<typeof buildActionContext>[1] {
+  return {
+    sessionId: 'sess-1',
+    actionExecutor: new ActionExecutor({} as never, () => undefined),
+    emitAgentEvent: () => undefined,
+    makeAgentEvent: (type) => ({ type, agentType: 'orchestrator', timestamp: 'now' }) as never,
+    pushConversationAction: () => undefined,
+    setNavigateTo: () => undefined,
+    investigationSections: new Map(),
+    investigationProvenance: new Map(),
+    activeInvestigationIdRef: { current: null },
+    activeDashboardIdRef: { current: null },
+    freshlyCreatedDashboards: new Set<string>(),
+    dashboardBuildEvidence: {
+      webSearchCount: 0,
+      metricDiscoveryCount: 0,
+      validatedQueries: new Set<string>(),
+    },
+  };
+}
+
+function makeRunnerDeps(overrides: {
+  auditWriter?: IAuditWriter;
+}): Parameters<typeof createAgentRunner>[0] {
+  return {
+    gateway: {} as never,
+    model: 'test-model',
+    store: {} as never,
+    conversationStore: {
+      getMessages: async () => [],
+      addMessage: async (_k: string, m: unknown) => m as never,
+      clearMessages: async () => undefined,
+      deleteConversation: async () => undefined,
+    } as never,
+    investigationReportStore: {} as never,
+    alertRuleStore: {} as never,
+    adapters: new AdapterRegistry(),
+    sendEvent: () => undefined,
+    identity: makeIdentity(),
+    accessControl: {
+      filterByPermission: async (list: unknown[]) => list,
+      checkPermission: async () => ({ ok: true }),
+    } as never,
+    ...(overrides.auditWriter ? { auditWriter: overrides.auditWriter } : {}),
+  };
+}

--- a/packages/agent-core/src/agent/factory.ts
+++ b/packages/agent-core/src/agent/factory.ts
@@ -1,0 +1,70 @@
+/**
+ * Agent factory — single entry point for constructing a fully-wired
+ * `OrchestratorAgent` runner.
+ *
+ * Why this exists:
+ *   - `api-gateway` previously imported the orchestrator class directly and
+ *     wired internals (tool registry, audit reporter, action runner) per
+ *     call site. That leaked agent lifecycle into the gateway package.
+ *   - PR #185 added `ActionContext.auditWriter` as an optional slim
+ *     fire-and-forget function, but no caller was bridging
+ *     `AuditWriter.log` into that slot — so resource-mutation handlers
+ *     (dashboard_create, alert_rule_write, …) silently wrote no audit
+ *     rows. This factory is the natural place to install that bridge.
+ *
+ * Callers in api-gateway pass deps in and get an `AgentRunner` out;
+ * they never construct `OrchestratorAgent` themselves.
+ */
+
+import type { IAuditWriter } from './types-permissions.js';
+import { OrchestratorAgent, type OrchestratorDeps } from './orchestrator-agent.js';
+
+/**
+ * Minimal runner shape consumers depend on. Returned by `createAgentRunner`
+ * so api-gateway never sees the `OrchestratorAgent` class.
+ */
+export interface AgentRunner {
+  readonly sessionId: string;
+  handleMessage(
+    message: string,
+    dashboardId?: string,
+    signal?: AbortSignal,
+  ): Promise<string>;
+  consumeConversationActions(): ReturnType<OrchestratorAgent['consumeConversationActions']>;
+  consumeNavigate(): string | undefined;
+}
+
+/**
+ * Deps for constructing an agent runner. Mirrors `OrchestratorDeps` —
+ * the factory passes them through verbatim. The only thing it adds is
+ * the audit-writer bridge.
+ */
+export type CreateAgentRunnerDeps = OrchestratorDeps;
+
+/**
+ * Construct a fully-wired agent runner.
+ *
+ * Audit bridge (one line, the whole point of T1.5 wave 1 leftover): when
+ * a structured `IAuditWriter` is in deps, install a slim
+ * `auditEntryWriter` that adapts `.log(entry)` into the
+ * `(entry) => Promise<void>` shape handlers consume via
+ * `ctx.auditWriter?.(entry)`. Without this, agent-tool mutations emit
+ * no audit rows.
+ */
+export function createAgentRunner(
+  deps: CreateAgentRunnerDeps,
+  sessionId?: string,
+): AgentRunner {
+  const bridged: OrchestratorDeps = bridgeAuditWriter(deps);
+  return new OrchestratorAgent(bridged, sessionId);
+}
+
+function bridgeAuditWriter(deps: OrchestratorDeps): OrchestratorDeps {
+  // Caller-supplied bridge wins (lets tests inject directly).
+  if (deps.auditEntryWriter || !deps.auditWriter) return deps;
+  const writer: IAuditWriter = deps.auditWriter;
+  return {
+    ...deps,
+    auditEntryWriter: (entry) => writer.log(entry),
+  };
+}

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -3,6 +3,11 @@
 export { OrchestratorAgent } from './orchestrator-agent.js'
 export type { OrchestratorDeps } from './orchestrator-agent.js'
 
+// Single entry point for api-gateway. Wires the audit-writer bridge so
+// agent-tool mutations actually persist audit rows.
+export { createAgentRunner } from './factory.js'
+export type { AgentRunner, CreateAgentRunnerDeps } from './factory.js'
+
 export { ActionExecutor } from './action-executor.js'
 
 export { ReActLoop } from './react-loop.js'

--- a/packages/agent-core/src/agent/orchestrator-action-context.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-context.ts
@@ -4,6 +4,7 @@ import type {
   Identity,
   IFolderRepository,
   InvestigationReportSection,
+  NewAuditLogEntry,
   Provenance,
 } from '@agentic-obs/common';
 import type { LLMGateway } from '@agentic-obs/llm-gateway';
@@ -51,6 +52,13 @@ export interface OrchestratorActionContextDeps {
   sendEvent: (event: DashboardSseEvent) => void;
   identity: Identity;
   accessControl: IAccessControlService;
+  /**
+   * Slim fire-and-forget audit writer threaded into every handler ctx
+   * (see ActionContext.auditWriter). The agent factory bridges
+   * `AuditWriter.log` into this slot so resource-mutation handlers
+   * (dashboard_create, alert_rule_write, …) actually persist audit rows.
+   */
+  auditEntryWriter?: (entry: NewAuditLogEntry) => Promise<void>;
 }
 
 export interface OrchestratorActionRuntime {
@@ -103,6 +111,7 @@ export function buildActionContext(
     sessionId: runtime.sessionId,
     identity: deps.identity,
     accessControl: deps.accessControl,
+    auditWriter: deps.auditEntryWriter,
     actionExecutor: runtime.actionExecutor,
     emitAgentEvent: runtime.emitAgentEvent,
     makeAgentEvent: runtime.makeAgentEvent,

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -7,6 +7,7 @@ import type {
   Identity,
   IFolderRepository,
   InvestigationReportSection,
+  NewAuditLogEntry,
   Provenance,
 } from '@agentic-obs/common'
 import type {
@@ -95,6 +96,13 @@ export interface OrchestratorDeps {
    * `agent.tool_denied` per §D9.
    */
   auditWriter?: IAuditWriter
+  /**
+   * Slim fire-and-forget audit writer for resource-mutation handlers
+   * (`dashboard_create`, `alert_rule_write`, …). The agent factory bridges
+   * `AuditWriter.log` into this slot so handler audit rows actually persist
+   * — without it, `ctx.auditWriter?.(entry)` is a no-op.
+   */
+  auditEntryWriter?: (entry: NewAuditLogEntry) => Promise<void>
   /**
    * Which specialized agent this run uses. Defaults to `orchestrator`. Pick a
    * narrower type to tighten the allowedTools ceiling (Layer 1).

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -3,6 +3,9 @@
 export * from './adapters/index.js';
 
 export {
+  createAgentRunner,
+  type AgentRunner,
+  type CreateAgentRunnerDeps,
   OrchestratorAgent,
   type OrchestratorDeps,
   // Compat alias — api-gateway still imports under the old name

--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -19,7 +19,8 @@
 import { randomUUID } from 'node:crypto';
 import type { Identity, IFolderRepository } from '@agentic-obs/common';
 import {
-  DashboardOrchestratorAgent as OrchestratorAgent,
+  createAgentRunner,
+  type AgentRunner,
   type AgentType,
   type IConversationStore as IAgentConversationStore,
   type IInvestigationStore,
@@ -65,7 +66,7 @@ export interface BackgroundOrchestratorFactoryDeps {
 export type MakeBackgroundOrchestrator = (overrides: {
   identity: Identity;
   agentType?: AgentType;
-}) => Promise<OrchestratorAgent>;
+}) => Promise<AgentRunner>;
 
 /**
  * Build the closure passed as `BackgroundRunnerDeps.makeOrchestrator`.
@@ -95,7 +96,7 @@ export function buildBackgroundOrchestratorFactory(
       [],
     );
 
-    return new OrchestratorAgent({
+    return createAgentRunner({
       gateway,
       model: llm.model,
       store: deps.persistence.repos.dashboards,

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -10,7 +10,7 @@ import type {
 } from '@agentic-obs/common';
 import { createLlmGateway, createDbAuditSink } from '../routes/llm-factory.js';
 import {
-  DashboardOrchestratorAgent as OrchestratorAgent,
+  createAgentRunner,
   shouldCompact,
   compactMessages,
 } from '@agentic-obs/agent-core';
@@ -490,7 +490,7 @@ export class ChatService {
       },
     } as IAgentConversationStore;
 
-    const orchestrator = new OrchestratorAgent(
+    const orchestrator = createAgentRunner(
       {
         gateway,
         model,


### PR DESCRIPTION
From \`internal-docs/design/code-review-remediation-tasks.md\` T1.5, plus Wave 1 (#185) leftover: the \`ActionContext.auditWriter\` slot added in #185 had no bridge to api-gateway's \`AuditWriter\` — agent-tool mutations were producing zero audit entries.

## Changes

### Factory boundary

- New \`packages/agent-core/src/agent/factory.ts\` — exports \`createAgentRunner(deps, sessionId?): AgentRunner\`
- \`OrchestratorDeps\` extended with optional \`auditEntryWriter\` callback
- \`OrchestratorActionContextDeps\` propagates \`auditEntryWriter\` into \`ActionContext.auditWriter\`
- \`background-runner.makeOrchestrator\` typed against \`AgentRunner\` interface, not the concrete class
- Barrel exports for \`createAgentRunner\`, \`AgentRunner\`, \`CreateAgentRunnerDeps\`

### api-gateway becomes a consumer

- \`chat-service.ts\`: \`new OrchestratorAgent(...)\` → \`createAgentRunner(...)\`
- \`agent-factory.ts\`: same swap; returns \`AgentRunner\`
- **Zero direct imports** of orchestrator internals from api-gateway (\`grep\` verified — all imports go through the package barrel)

### Audit bridge

One-line in \`factory.ts:65\`:
\`\`\`ts
auditEntryWriter: (entry) => writer.log(entry),
\`\`\`
surfaced as \`ctx.auditWriter\` in \`orchestrator-action-context.ts:90\`. Wave 1's audit calls in \`handleDashboardCreate\`, \`handleAlertRuleWrite\`, etc., now actually emit entries.

## Test plan

- [x] New \`factory.test.ts\` 4/4 pass — explicitly asserts that running \`handleDashboardCreate\` through factory-built runner causes \`writer.log\` to be called with \`action: 'dashboard.create'\`
- [x] \`chat-service.test.ts\` 2/2 pass (no regression from factory swap)
- [x] \`packages/agent-core\` 223/224 pass (1 failure pre-existing on main)
- [ ] CI green

## Acceptance

- \`grep -rn "OrchestratorAgent\\|orchestrator-agent\\|react-loop" packages/api-gateway/src/\` returns zero import statements ✓
- Audit entries from agent tools land in the audit log ✓