### PR TITLE
R-4: API key fallback fail-closed + markSeen observability test

### DIFF
--- a/packages/api-gateway/src/middleware/auth.test.ts
+++ b/packages/api-gateway/src/middleware/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   ApiKeyRepository,
   OrgUserRepository,
@@ -9,6 +9,7 @@ import {
 import { SessionService } from '../auth/session-service.js';
 import {
   createAuthMiddleware,
+  log as authLog,
   readCookie,
   type AuthenticatedRequest,
 } from './auth.js';
@@ -111,6 +112,55 @@ describe('createAuthMiddleware', () => {
     expect(req.auth?.userId).toBe(user.id);
     expect(req.auth?.orgRole).toBe('Editor');
     expect(req.auth?.authenticatedBy).toBe('session');
+  });
+
+  it('still authenticates when markSeen rejects and logs a structured warn', async () => {
+    const user = await users.create({
+      email: 'a@x.com',
+      login: 'alice',
+      name: 'A',
+      orgId: 'org_main',
+    });
+    await orgUsers.create({ orgId: 'org_main', userId: user.id, role: 'Editor' });
+    const { token, row } = await sessions.create(user.id, 'ua', '1.2.3.4');
+
+    // Force markSeen to reject.
+    const markErr = new Error('db unavailable');
+    const markSeenSpy = vi
+      .spyOn(sessions, 'markSeen')
+      .mockRejectedValue(markErr);
+    const warnSpy = vi.spyOn(authLog, 'warn').mockImplementation(() => {});
+
+    try {
+      const req = {
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      } as unknown as AuthenticatedRequest;
+      const res = mockRes();
+      let called = false;
+      await mw(req, res, () => {
+        called = true;
+      });
+
+      // Auth still succeeded.
+      expect(called).toBe(true);
+      expect(req.auth?.userId).toBe(user.id);
+      expect(res._status).toBe(200);
+
+      // markSeen rejection is fire-and-forget — wait one tick for the catch.
+      await new Promise((r) => setImmediate(r));
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [fields, msg] = warnSpy.mock.calls[0]!;
+      expect(fields).toMatchObject({
+        sessionId: row.id,
+        metric: 'session.markSeen.failed',
+        err: 'db unavailable',
+      });
+      expect(msg).toContain('markSeen failed');
+    } finally {
+      warnSpy.mockRestore();
+      markSeenSpy.mockRestore();
+    }
   });
 
   it('returns 401 for an unknown session cookie', async () => {

--- a/packages/api-gateway/src/middleware/auth.test.ts
+++ b/packages/api-gateway/src/middleware/auth.test.ts
@@ -180,6 +180,18 @@ describe('createAuthMiddleware', () => {
     expect(res._status).toBe(401);
   });
 
+  it('refuses to boot without apiKeyService outside test mode', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      expect(() =>
+        createAuthMiddleware({ sessions, users, orgUsers, apiKeys }),
+      ).toThrow(/apiKeyService is required outside test mode/);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
   it('rejects an expired API key', async () => {
     const key = 'openobs_' + 'b'.repeat(32);
     const hashed = createHash('sha256').update(key, 'utf8').digest('hex');

--- a/packages/api-gateway/src/middleware/auth.ts
+++ b/packages/api-gateway/src/middleware/auth.ts
@@ -43,8 +43,13 @@ export interface AuthMiddlewareDeps {
    * ApiKeyService path (T6.3). When provided, the bearer-token branch goes
    * through `validateAndLookup` — which honours SA vs PAT, applies
    * rate-limited `apikey.used` audit, and enforces `is_disabled` on the
-   * principal. When absent, the middleware falls back to the raw-repo path
-   * used by pre-T6 test harnesses.
+   * principal.
+   *
+   * In production this MUST be provided — `createAuthMiddleware` fails
+   * closed at construction time if it is absent. The raw-repo fallback
+   * below is permitted only under `NODE_ENV === 'test'` (pre-T6 test
+   * harnesses), and applies weaker semantics than `ApiKeyService` so it
+   * must never be reachable outside tests.
    */
   apiKeyService?: ApiKeyService;
 }
@@ -120,6 +125,17 @@ export function authMiddleware(
 }
 
 export function createAuthMiddleware(deps: AuthMiddlewareDeps) {
+  // Fail closed at boot in any non-test environment if the preferred
+  // ApiKeyService path is missing. The raw-repo fallback below has weaker
+  // semantics than `ApiKeyService` (no SA/PAT distinction, no audit, no
+  // principal-disabled enforcement on PATs) and exists only for pre-T6
+  // test harnesses that have not yet been migrated.
+  if (!deps.apiKeyService && process.env.NODE_ENV !== 'test') {
+    throw new Error(
+      'createAuthMiddleware: apiKeyService is required outside test mode — ' +
+        'refusing to boot with the weaker pre-T6 raw-repo fallback path',
+    );
+  }
   return async function authMiddleware(
     req: AuthenticatedRequest,
     res: Response,

--- a/packages/api-gateway/src/middleware/auth.ts
+++ b/packages/api-gateway/src/middleware/auth.ts
@@ -28,7 +28,12 @@ import {
 } from '../auth/session-service.js';
 import type { ApiKeyService } from '../services/apikey-service.js';
 
-const log = createLogger('auth-mw');
+/**
+ * Exported as a testing seam so tests can spy on `.warn` / `.error` calls
+ * (e.g. the non-blocking `markSeen` failure path). Not part of the public
+ * API — production callers should not depend on this binding.
+ */
+export const log = createLogger('auth-mw');
 
 export interface AuthenticatedRequest extends Request {
   auth?: Identity;


### PR DESCRIPTION
From \`internal-docs/design/code-review-remediation-tasks.md\`: T0.1, T0.3.

## T0.1 API key pre-T6 fallback — fail closed (P0 security)

**Finding:** \`buildAuthSubsystem\` at \`packages/api-gateway/src/app/auth-routes.ts:146-161\` constructs \`apiKeyService\` unconditionally in production. Only test files call \`createAuthMiddleware\` without it. → **Case A** (prod always provides it).

**Change:** \`createAuthMiddleware\` now throws at construction when \`deps.apiKeyService\` is missing AND \`NODE_ENV !== 'test'\`. Boot fails loudly rather than silently using the weaker raw-repo fallback (no SA/PAT distinction, no rate-limited audit, no PAT-principal-disabled parity).

The fallback branch itself is preserved for the in-test paths that haven't yet been migrated.

**Test:** \`refuses to boot without apiKeyService outside test mode\`.

## T0.3 markSeen observability (P1)

**Finding:** existing warn log already includes \`sessionId\` and stable event key \`session.markSeen.failed\`. No shape change needed.

**Change:** add the missing **test** documenting the intended behavior — auth must still succeed when \`markSeen\` rejects, and the warn must fire with the structured context.

Module-level pino logger in \`auth.ts\` exposed as documented testing seam so the warn is spy-able without intercepting pino's stdout plumbing.

**Test:** \`still authenticates when markSeen rejects and logs a structured warn\`.

## Test plan

- [x] 47/47 middleware tests pass (auth.test.ts 13/13, auth-apikey.test.ts 10/10)
- [ ] CI green