### PR TITLE
R-6: canonical AdapterError + AdapterErrorKind taxonomy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10952,6 +10952,7 @@
       "name": "@agentic-obs/llm-gateway",
       "version": "0.0.1",
       "dependencies": {
+        "@agentic-obs/adapters": "*",
         "@agentic-obs/common": "*"
       },
       "devDependencies": {

--- a/packages/adapters/src/adapter.ts
+++ b/packages/adapters/src/adapter.ts
@@ -1,4 +1,9 @@
-// DataAdapter interface - the contract every data source adapter must fulfill
+// DataAdapter interface - the contract every data source adapter must fulfill.
+//
+// AdapterError, AdapterErrorKind, and the HTTP classifier live in ./errors.ts
+// (the canonical taxonomy shared with provider boundaries). This file
+// re-exports them so legacy callsites that import from './adapter.js' keep
+// working.
 
 import type {
   Capabilities,
@@ -9,75 +14,12 @@ import type {
   AdapterHealth,
 } from './types.js';
 
-// -- AdapterError --------------------------------------------------------
-//
-// Typed error raised by adapter integration boundaries (HTTP fetch against
-// Prometheus / Loki / etc.) when the underlying datasource fails. Callers
-// branch on `kind`:
-//
-//   - 'unreachable' : transport-level failure (DNS, connection refused,
-//                     timeout) or 5xx server errors.
-//   - 'auth'        : credentials rejected (401/403).
-//   - 'malformed'   : 200 response with unparseable / invalid body.
-//   - 'unknown'     : everything else (4xx besides 401/403, novel errors).
-
-export type AdapterErrorKind = 'unreachable' | 'auth' | 'malformed' | 'unknown';
-
-export class AdapterError extends Error {
-  public readonly kind: AdapterErrorKind;
-  public readonly adapter: string;
-  public readonly status?: number;
-  public override readonly cause?: unknown;
-
-  constructor(
-    message: string,
-    opts: {
-      kind: AdapterErrorKind;
-      adapter: string;
-      status?: number;
-      cause?: unknown;
-    },
-  ) {
-    super(message);
-    this.name = 'AdapterError';
-    this.kind = opts.kind;
-    this.adapter = opts.adapter;
-    if (opts.status !== undefined) this.status = opts.status;
-    if (opts.cause !== undefined) this.cause = opts.cause;
-  }
-}
-
-/**
- * Classify an HTTP fetch failure into an AdapterErrorKind. Keep in sync with
- * the equivalent helper in `@agentic-obs/llm-gateway` — the buckets differ
- * (adapters use 'unreachable' / 'malformed' instead of 'network' /
- * 'unsupported') but the inputs are the same.
- */
-export function classifyAdapterHttpError(opts: {
-  status?: number;
-  cause?: unknown;
-}): AdapterErrorKind {
-  const { status, cause } = opts;
-  if (typeof status === 'number') {
-    if (status === 401 || status === 403) return 'auth';
-    if (status >= 500) return 'unreachable';
-    if (status >= 400) return 'unknown';
-  }
-  const codes: string[] = [];
-  const collect = (e: unknown) => {
-    if (!e || typeof e !== 'object') return;
-    const code = (e as { code?: unknown }).code;
-    if (typeof code === 'string') codes.push(code);
-    const inner = (e as { cause?: unknown }).cause;
-    if (inner) collect(inner);
-  };
-  collect(cause);
-  if (codes.some((c) => /^(ENOTFOUND|ECONNREFUSED|ETIMEDOUT|ECONNRESET|EAI_AGAIN|UND_ERR_(?:CONNECT_TIMEOUT|SOCKET))$/i.test(c))) {
-    return 'unreachable';
-  }
-  if (cause instanceof Error && cause.name === 'AbortError') return 'unreachable';
-  return 'unknown';
-}
+export {
+  AdapterError,
+  classifyHttpError as classifyAdapterHttpError,
+  isAdapterError,
+} from './errors.js';
+export type { AdapterErrorKind, AdapterErrorCause } from './errors.js';
 
 export interface DataAdapter {
   /** Unique identifier for this adapter instance (e.g. "prometheus-prod") */

--- a/packages/adapters/src/errors.test.ts
+++ b/packages/adapters/src/errors.test.ts
@@ -1,0 +1,261 @@
+// Canonical AdapterError taxonomy tests (R-6 / T2.4 Phase 1).
+//
+// Covers the 6 scenarios required by the design doc:
+//   - HTTP 401 from Prometheus  → kind: 'auth_failure'
+//   - HTTP 429 from any adapter → kind: 'rate_limit'
+//   - Timeout (AbortError)      → kind: 'timeout'
+//   - DNS failure (ENOTFOUND)   → kind: 'dns_failure'
+//   - Malformed JSON response   → kind: 'malformed_response'
+//   - toUserMessage()           → safe / non-technical, no leakage
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { AdapterError, classifyHttpError, isAdapterError } from './errors.js';
+import { PrometheusMetricsAdapter } from './prometheus/metrics-adapter.js';
+import { LokiLogsAdapter } from './loki/logs-adapter.js';
+
+function makeResponse(body: unknown, status = 200, contentType = 'application/json'): Response {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(text, { status, headers: { 'content-type': contentType } });
+}
+
+describe('classifyHttpError', () => {
+  it('maps HTTP 401 to auth_failure', () => {
+    expect(classifyHttpError({ status: 401 })).toBe('auth_failure');
+  });
+
+  it('maps HTTP 403 to auth_failure', () => {
+    expect(classifyHttpError({ status: 403 })).toBe('auth_failure');
+  });
+
+  it('maps HTTP 429 to rate_limit', () => {
+    expect(classifyHttpError({ status: 429 })).toBe('rate_limit');
+  });
+
+  it('maps HTTP 404 to not_found', () => {
+    expect(classifyHttpError({ status: 404 })).toBe('not_found');
+  });
+
+  it('maps HTTP 400 to bad_request', () => {
+    expect(classifyHttpError({ status: 400 })).toBe('bad_request');
+  });
+
+  it('maps HTTP 5xx to server_error', () => {
+    expect(classifyHttpError({ status: 500 })).toBe('server_error');
+    expect(classifyHttpError({ status: 503 })).toBe('server_error');
+  });
+
+  it('maps AbortError to timeout', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(classifyHttpError({ cause: err })).toBe('timeout');
+  });
+
+  it('maps ENOTFOUND error code to dns_failure', () => {
+    const err = Object.assign(new Error('lookup failed'), { code: 'ENOTFOUND' });
+    expect(classifyHttpError({ cause: err })).toBe('dns_failure');
+  });
+
+  it('maps ECONNREFUSED to connection_refused', () => {
+    const err = Object.assign(new Error('connect failed'), { code: 'ECONNREFUSED' });
+    expect(classifyHttpError({ cause: err })).toBe('connection_refused');
+  });
+
+  it('maps ETIMEDOUT to timeout', () => {
+    const err = Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' });
+    expect(classifyHttpError({ cause: err })).toBe('timeout');
+  });
+
+  it('falls back to connection_refused for generic "fetch failed" (legacy retry parity)', () => {
+    // Pre-migration, raw "fetch failed" was classified as `network` and retried.
+    // We classify it as connection_refused so the gateway's retry path still fires.
+    expect(classifyHttpError({ cause: new Error('fetch failed') })).toBe('connection_refused');
+  });
+
+  it('returns unknown for novel errors', () => {
+    expect(classifyHttpError({ cause: new Error('what is this') })).toBe('unknown');
+    expect(classifyHttpError({})).toBe('unknown');
+  });
+});
+
+describe('AdapterError', () => {
+  it('is an Error subclass and the type guard works', () => {
+    const e = new AdapterError('timeout', 'x', { adapterId: 'a', operation: 'op' });
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(AdapterError);
+    expect(isAdapterError(e)).toBe(true);
+    expect(isAdapterError(new Error('plain'))).toBe(false);
+  });
+
+  it('exposes structured cause', () => {
+    const original = new Error('ENOTFOUND');
+    const e = new AdapterError('dns_failure', 'boom', {
+      adapterId: 'prometheus',
+      operation: 'query',
+      status: 0,
+      originalError: original,
+    });
+    expect(e.kind).toBe('dns_failure');
+    expect(e.cause.adapterId).toBe('prometheus');
+    expect(e.cause.operation).toBe('query');
+    expect(e.cause.originalError).toBe(original);
+  });
+});
+
+describe('toUserMessage()', () => {
+  it('returns safe, non-technical text per kind', () => {
+    const cases: Array<[string, RegExp]> = [
+      ['timeout', /too long/i],
+      ['dns_failure', /could not be reached/i],
+      ['connection_refused', /refused/i],
+      ['auth_failure', /authentication/i],
+      ['rate_limit', /rate-limit/i],
+      ['not_found', /not found/i],
+      ['bad_request', /rejected/i],
+      ['server_error', /unavailable/i],
+      ['malformed_response', /unexpected response/i],
+      ['readonly', /read-only/i],
+      ['unknown', /unexpected error/i],
+    ];
+    for (const [kind, pattern] of cases) {
+      const e = new AdapterError(kind as never, 'internal — secret-id-1234', {
+        adapterId: 'prometheus',
+        operation: 'query',
+        status: 500,
+        upstreamBody: 'leaky body',
+        originalError: new Error('stack-trace-here'),
+      });
+      const msg = e.toUserMessage();
+      expect(msg).toMatch(pattern);
+      // Must not leak internal detail
+      expect(msg).not.toContain('prometheus');
+      expect(msg).not.toContain('500');
+      expect(msg).not.toContain('secret-id-1234');
+      expect(msg).not.toContain('leaky body');
+      expect(msg).not.toContain('stack-trace-here');
+    }
+  });
+});
+
+describe('PrometheusMetricsAdapter — error scenarios', () => {
+  let originalFetch: typeof fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetchResolve(res: Response) {
+    originalFetch = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = vi.fn(async () => res);
+  }
+
+  function mockFetchReject(err: unknown) {
+    originalFetch = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = vi.fn(async () => {
+      throw err;
+    });
+  }
+
+  it('HTTP 401 → AdapterError with kind: auth_failure', async () => {
+    mockFetchResolve(makeResponse('unauthorized', 401, 'text/plain'));
+    const adapter = new PrometheusMetricsAdapter('http://prom:9090');
+    try {
+      await adapter.listLabels('up');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('auth_failure');
+      expect((err as AdapterError).cause.adapterId).toBe('prometheus');
+      expect((err as AdapterError).cause.status).toBe(401);
+    }
+  });
+
+  it('HTTP 429 → AdapterError with kind: rate_limit', async () => {
+    mockFetchResolve(makeResponse('too many', 429, 'text/plain'));
+    const adapter = new PrometheusMetricsAdapter('http://prom:9090');
+    try {
+      await adapter.fetchMetadata();
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('rate_limit');
+    }
+  });
+
+  it('timeout (AbortError) → AdapterError with kind: timeout', async () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    mockFetchReject(abort);
+    const adapter = new PrometheusMetricsAdapter('http://prom:9090', {}, 10);
+    try {
+      await adapter.listLabels('up');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('timeout');
+    }
+  });
+
+  it('DNS failure (ENOTFOUND) → AdapterError with kind: dns_failure', async () => {
+    mockFetchReject(Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' }));
+    const adapter = new PrometheusMetricsAdapter('http://nope.invalid');
+    try {
+      await adapter.listLabels('up');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('dns_failure');
+    }
+  });
+
+  it('malformed JSON response → AdapterError with kind: malformed_response', async () => {
+    mockFetchResolve(makeResponse('<html>not json</html>', 200, 'text/html'));
+    const adapter = new PrometheusMetricsAdapter('http://prom:9090');
+    try {
+      await adapter.fetchMetadata();
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('malformed_response');
+    }
+  });
+
+  it('toUserMessage() never leaks adapter id, status, or stack', async () => {
+    mockFetchResolve(makeResponse('boom-secret', 500, 'text/plain'));
+    const adapter = new PrometheusMetricsAdapter('http://prom:9090');
+    try {
+      await adapter.listLabels('up');
+      throw new Error('should have thrown');
+    } catch (err) {
+      const userMsg = (err as AdapterError).toUserMessage();
+      expect(userMsg).not.toContain('prometheus');
+      expect(userMsg).not.toContain('500');
+      expect(userMsg).not.toContain('boom-secret');
+      expect(userMsg).not.toContain('at ');
+    }
+  });
+});
+
+describe('LokiLogsAdapter — HTTP 429 emits rate_limit', () => {
+  let originalFetch: typeof fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('classifies 429 as rate_limit', async () => {
+    originalFetch = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = vi.fn(async () =>
+      makeResponse('rate-limited', 429, 'text/plain'),
+    );
+    const adapter = new LokiLogsAdapter('http://loki:3100');
+    try {
+      await adapter.listLabels();
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAdapterError(err)).toBe(true);
+      expect((err as AdapterError).kind).toBe('rate_limit');
+      expect((err as AdapterError).cause.adapterId).toBe('loki');
+    }
+  });
+});

--- a/packages/adapters/src/errors.ts
+++ b/packages/adapters/src/errors.ts
@@ -1,0 +1,163 @@
+// Canonical adapter / provider error taxonomy.
+//
+// One AdapterError class, one stable discriminated-union `kind`, for every
+// integration boundary across the codebase: data-source adapters (Prometheus,
+// Loki, ...) AND LLM provider clients (OpenAI, Anthropic, ...). Agent code
+// (Wave 2) decides what to do based on `kind`, so the shape must be stable.
+//
+// Phase 1 (this file): define the canonical shape and migrate throws.
+// User-visible behavior is unchanged; the wire shape of catch-blocks /
+// retry-logic still keys off the same conditions (auth, transient, etc.).
+
+/**
+ * Stable discriminator. Add a new kind ONLY when a caller needs to branch on
+ * a condition that none of the existing kinds covers — don't expand for
+ * cosmetic reasons.
+ *
+ *   - 'timeout'              : request exceeded its deadline (AbortError / ETIMEDOUT).
+ *   - 'dns_failure'          : ENOTFOUND / EAI_AGAIN. Hostname did not resolve.
+ *   - 'connection_refused'   : ECONNREFUSED / ECONNRESET. TCP-level failure.
+ *   - 'auth_failure'         : HTTP 401/403. Credentials rejected.
+ *   - 'rate_limit'           : HTTP 429. Retryable; honor Retry-After.
+ *   - 'not_found'            : HTTP 404. Resource / endpoint does not exist.
+ *   - 'bad_request'          : HTTP 400. Query parse error, validation failure.
+ *   - 'server_error'         : HTTP 5xx. Upstream broke; retryable.
+ *   - 'malformed_response'   : 2xx response with unparseable / wrong-shape body.
+ *   - 'readonly'             : resource cannot be mutated (e.g. GitOps-provisioned).
+ *   - 'unknown'              : everything else. Caller defaults to fail-fast.
+ */
+export type AdapterErrorKind =
+  | 'timeout'
+  | 'dns_failure'
+  | 'connection_refused'
+  | 'auth_failure'
+  | 'rate_limit'
+  | 'not_found'
+  | 'bad_request'
+  | 'server_error'
+  | 'malformed_response'
+  | 'readonly'
+  | 'unknown';
+
+/**
+ * Structured cause / context. Diagnostics-only — `originalError` MUST NEVER
+ * leak into a user-facing string. Use `toUserMessage()` for that.
+ */
+export interface AdapterErrorCause {
+  /** Stable adapter / provider id, e.g. 'prometheus', 'loki', 'openai'. */
+  adapterId: string;
+  /** Operation name within the adapter, e.g. 'query', 'fetchMetadata'. */
+  operation: string;
+  /** HTTP status if the failure came from a response. */
+  status?: number;
+  /** Provider-specific error code from the upstream body. */
+  providerCode?: string;
+  /** Seconds the upstream asked us to wait. Retryable kinds only. */
+  retryAfterSec?: number;
+  /** Truncated upstream response body for diagnostics. */
+  upstreamBody?: string;
+  /** Raw underlying error — for logs only, never user-facing. */
+  originalError?: unknown;
+}
+
+export class AdapterError extends Error {
+  public readonly kind: AdapterErrorKind;
+  public override readonly cause: AdapterErrorCause;
+
+  constructor(kind: AdapterErrorKind, message: string, cause: AdapterErrorCause) {
+    super(message);
+    this.name = 'AdapterError';
+    this.kind = kind;
+    this.cause = cause;
+  }
+
+  /**
+   * User-facing message — safe to render in chat / UI. Does NOT include the
+   * adapter id, HTTP status, original error message, or stack trace.
+   * Operational detail belongs in `cause` and the logs.
+   */
+  toUserMessage(): string {
+    return userMessageForKind(this.kind);
+  }
+}
+
+function userMessageForKind(kind: AdapterErrorKind): string {
+  switch (kind) {
+    case 'timeout':
+      return 'The request took too long to complete. Please try again.';
+    case 'dns_failure':
+      return 'The data source could not be reached. Please check the connection settings.';
+    case 'connection_refused':
+      return 'The data source refused the connection. It may be offline.';
+    case 'auth_failure':
+      return 'Authentication with the data source failed. Please check your credentials.';
+    case 'rate_limit':
+      return 'The data source is rate-limiting requests. Please wait a moment and try again.';
+    case 'not_found':
+      return 'The requested resource was not found.';
+    case 'bad_request':
+      return 'The request was rejected. Please review the query and try again.';
+    case 'server_error':
+      return 'The data source is currently unavailable. Please try again shortly.';
+    case 'malformed_response':
+      return 'The data source returned an unexpected response.';
+    case 'readonly':
+      return 'This resource is read-only and cannot be modified.';
+    case 'unknown':
+    default:
+      return 'An unexpected error occurred while contacting the data source.';
+  }
+}
+
+/**
+ * Classify an HTTP fetch failure into a canonical AdapterErrorKind. Covers the
+ * common shapes: HTTP status, Node fetch error codes (ENOTFOUND / ECONNREFUSED
+ * / ETIMEDOUT), AbortError. Specific adapters layer on top (e.g. readonly is
+ * decided at the resource level, not from a status).
+ */
+export function classifyHttpError(opts: {
+  status?: number;
+  cause?: unknown;
+}): AdapterErrorKind {
+  const { status, cause } = opts;
+  if (typeof status === 'number') {
+    if (status === 401 || status === 403) return 'auth_failure';
+    if (status === 404) return 'not_found';
+    if (status === 429) return 'rate_limit';
+    if (status === 400) return 'bad_request';
+    if (status >= 500) return 'server_error';
+    if (status >= 400) return 'bad_request';
+  }
+  const codes: string[] = [];
+  const collect = (e: unknown) => {
+    if (!e || typeof e !== 'object') return;
+    const code = (e as { code?: unknown }).code;
+    if (typeof code === 'string') codes.push(code);
+    const inner = (e as { cause?: unknown }).cause;
+    if (inner) collect(inner);
+  };
+  collect(cause);
+  if (codes.some((c) => /^(ENOTFOUND|EAI_AGAIN)$/i.test(c))) return 'dns_failure';
+  if (codes.some((c) => /^(ECONNREFUSED|ECONNRESET)$/i.test(c))) return 'connection_refused';
+  if (codes.some((c) => /^(ETIMEDOUT|UND_ERR_(?:CONNECT_TIMEOUT|SOCKET))$/i.test(c))) return 'timeout';
+  if (cause instanceof Error && cause.name === 'AbortError') return 'timeout';
+  if (cause instanceof Error && cause.name === 'TimeoutError') return 'timeout';
+  if (cause instanceof Error && /timeout/i.test(cause.message)) return 'timeout';
+  if (cause instanceof Error && /ENOTFOUND/i.test(cause.message)) return 'dns_failure';
+  if (cause instanceof Error && /ECONNREFUSED/i.test(cause.message)) return 'connection_refused';
+  // Undici / fetch's generic transport failure message. Classify as
+  // connection_refused (the most retryable transport kind) so retry/fallback
+  // logic that previously fired on this condition continues to fire.
+  if (cause instanceof Error && /fetch failed|network|connection/i.test(cause.message)) {
+    return 'connection_refused';
+  }
+  return 'unknown';
+}
+
+/**
+ * Type guard for callers that want to branch on `AdapterError` without an
+ * `instanceof` import.
+ */
+export function isAdapterError(err: unknown): err is AdapterError {
+  return err instanceof AdapterError;
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -49,8 +49,10 @@ export type {
   HealthStatus,
   AdapterHealth,
 } from './types.js';
-export type { DataAdapter, AdapterErrorKind } from './adapter.js';
-export { AdapterError, classifyAdapterHttpError } from './adapter.js';
+export type { DataAdapter, AdapterErrorKind, AdapterErrorCause } from './adapter.js';
+export { AdapterError, classifyAdapterHttpError, isAdapterError } from './adapter.js';
+// Canonical error taxonomy — preferred entry point for new code.
+export { classifyHttpError } from './errors.js';
 export { AdapterRegistry } from './registry.js';
 export type { AdapterRegistration } from './registry.js';
 

--- a/packages/adapters/src/loki/logs-adapter.ts
+++ b/packages/adapters/src/loki/logs-adapter.ts
@@ -1,7 +1,7 @@
 // Concrete Loki implementation of the canonical ILogsAdapter.
 
-import { getErrorMessage } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
+import { AdapterError, classifyHttpError } from '../errors.js';
 import type {
   ILogsAdapter,
   LogEntry,
@@ -10,6 +10,8 @@ import type {
 } from '../interfaces.js';
 
 const log = createLogger('loki-logs-adapter');
+
+const ADAPTER_ID = 'loki';
 
 interface LokiStream {
   stream: Record<string, string>;
@@ -33,6 +35,45 @@ interface LokiListResponse {
 
 const DEFAULT_LIMIT = 100;
 
+function transportError(op: string, err: unknown): AdapterError {
+  // Internal-facing message preserves legacy wording so existing log-greps
+  // and the test suite still match. User-facing strings come from
+  // `toUserMessage()` and never include this detail.
+  const opLabel = op === 'query' ? 'query_range request' : `${op} request`;
+  return new AdapterError(
+    classifyHttpError({ cause: err }),
+    `Loki ${opLabel} failed: ${err instanceof Error ? err.message : String(err)}`,
+    { adapterId: ADAPTER_ID, operation: op, originalError: err },
+  );
+}
+
+async function httpError(op: string, res: Response): Promise<AdapterError> {
+  const preview = await readBodyPreview(res);
+  const opLabel = op === 'query' ? 'query_range' : op;
+  return new AdapterError(
+    classifyHttpError({ status: res.status }),
+    `Loki returned HTTP ${res.status} for ${opLabel}: ${preview}`,
+    {
+      adapterId: ADAPTER_ID,
+      operation: op,
+      status: res.status,
+      upstreamBody: preview,
+    },
+  );
+}
+
+async function parseJson<T>(res: Response, op: string): Promise<T> {
+  try {
+    return (await res.json()) as T;
+  } catch (err) {
+    throw new AdapterError(
+      'malformed_response',
+      `Loki ${op}: malformed response body`,
+      { adapterId: ADAPTER_ID, operation: op, originalError: err },
+    );
+  }
+}
+
 export class LokiLogsAdapter implements ILogsAdapter {
   constructor(
     private baseUrl: string,
@@ -41,6 +82,7 @@ export class LokiLogsAdapter implements ILogsAdapter {
   ) {}
 
   async query(input: LogsQueryInput): Promise<LogsQueryResult> {
+    const op = 'query';
     const limit = input.limit ?? DEFAULT_LIMIT;
     const params = new URLSearchParams();
     params.set('query', input.query);
@@ -54,17 +96,14 @@ export class LokiLogsAdapter implements ILogsAdapter {
     try {
       res = await this.fetch(url);
     } catch (err) {
-      throw new Error(`Loki query_range request failed: ${getErrorMessage(err)}`);
+      throw transportError(op, err);
     }
 
     if (!res.ok) {
-      const preview = await readBodyPreview(res);
-      throw new Error(
-        `Loki returned HTTP ${res.status} for query_range: ${preview}`,
-      );
+      throw await httpError(op, res);
     }
 
-    const body = (await res.json()) as LokiQueryRangeResponse;
+    const body = await parseJson<LokiQueryRangeResponse>(res, op);
     const resultType = body.data?.resultType ?? 'streams';
     const warnings: string[] = Array.isArray(body.warnings) ? [...body.warnings] : [];
 
@@ -110,36 +149,34 @@ export class LokiLogsAdapter implements ILogsAdapter {
   }
 
   async listLabels(): Promise<string[]> {
+    const op = 'listLabels';
     const url = `${this.base}/loki/api/v1/labels`;
     let res: Response;
     try {
       res = await this.fetch(url);
     } catch (err) {
-      throw new Error(`Loki labels request failed: ${getErrorMessage(err)}`);
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const preview = await readBodyPreview(res);
-      throw new Error(`Loki returned HTTP ${res.status} fetching labels: ${preview}`);
+      throw await httpError(op, res);
     }
-    const body = (await res.json()) as LokiListResponse;
+    const body = await parseJson<LokiListResponse>(res, op);
     return Array.isArray(body.data) ? body.data : [];
   }
 
   async listLabelValues(label: string): Promise<string[]> {
+    const op = 'listLabelValues';
     const url = `${this.base}/loki/api/v1/label/${encodeURIComponent(label)}/values`;
     let res: Response;
     try {
       res = await this.fetch(url);
     } catch (err) {
-      throw new Error(`Loki label values request failed: ${getErrorMessage(err)}`);
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const preview = await readBodyPreview(res);
-      throw new Error(
-        `Loki returned HTTP ${res.status} fetching label values for "${label}": ${preview}`,
-      );
+      throw await httpError(op, res);
     }
-    const body = (await res.json()) as LokiListResponse;
+    const body = await parseJson<LokiListResponse>(res, op);
     return Array.isArray(body.data) ? body.data : [];
   }
 

--- a/packages/adapters/src/prometheus/client.ts
+++ b/packages/adapters/src/prometheus/client.ts
@@ -2,8 +2,10 @@
 
 import { createLogger } from '@agentic-obs/common/logging';
 import { checkEndpointHealth } from '../shared/health-check.js';
+import { AdapterError, classifyHttpError } from '../errors.js';
 
 const log = createLogger('prometheus-client');
+const ADAPTER_ID = 'prometheus';
 
 import type {
   PrometheusAdapterConfig,
@@ -66,14 +68,42 @@ export class PrometheusHttpClient implements IPrometheusClient {
   }
 
   private async fetch(path: string): Promise<unknown> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      headers: this.headers,
-      signal: AbortSignal.timeout(this.timeoutMs),
-    });
-    if (!res.ok) {
-      throw new Error(`Prometheus HTTP error ${res.status}: ${await res.text()}`);
+    const op = 'fetch';
+    let res: Response;
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        headers: this.headers,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err) {
+      throw new AdapterError(
+        classifyHttpError({ cause: err }),
+        `Prometheus client fetch transport failure: ${err instanceof Error ? err.message : String(err)}`,
+        { adapterId: ADAPTER_ID, operation: op, originalError: err },
+      );
     }
-    return res.json();
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new AdapterError(
+        classifyHttpError({ status: res.status }),
+        `Prometheus HTTP error ${res.status}`,
+        {
+          adapterId: ADAPTER_ID,
+          operation: op,
+          status: res.status,
+          upstreamBody: body.slice(0, 1000),
+        },
+      );
+    }
+    try {
+      return await res.json();
+    } catch (err) {
+      throw new AdapterError(
+        'malformed_response',
+        'Prometheus client fetch: malformed JSON body',
+        { adapterId: ADAPTER_ID, operation: op, originalError: err },
+      );
+    }
   }
 }
 

--- a/packages/adapters/src/prometheus/metrics-adapter.ts
+++ b/packages/adapters/src/prometheus/metrics-adapter.ts
@@ -3,7 +3,7 @@
 import { getErrorMessage } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/common/logging';
 import { checkEndpointHealth } from '../shared/health-check.js';
-import { AdapterError, classifyAdapterHttpError } from '../adapter.js';
+import { AdapterError, classifyHttpError } from '../errors.js';
 import type {
   IMetricsAdapter,
   MetricSample,
@@ -13,7 +13,7 @@ import type {
 
 const log = createLogger('metrics-adapter');
 
-const ADAPTER_NAME = 'prometheus';
+const ADAPTER_ID = 'prometheus';
 
 interface PrometheusMetadataEntry {
   type: string;
@@ -37,6 +37,36 @@ interface PrometheusMatrixResult {
   values: Array<[number, string]>;
 }
 
+function transportError(op: string, err: unknown): AdapterError {
+  const kind = classifyHttpError({ cause: err });
+  return new AdapterError(
+    kind,
+    `Prometheus ${op} transport failure: ${err instanceof Error ? err.message : String(err)}`,
+    { adapterId: ADAPTER_ID, operation: op, originalError: err },
+  );
+}
+
+function httpError(op: string, status: number): AdapterError {
+  const kind = classifyHttpError({ status });
+  return new AdapterError(
+    kind,
+    `Prometheus ${op} HTTP ${status}`,
+    { adapterId: ADAPTER_ID, operation: op, status },
+  );
+}
+
+async function parseJson<T>(res: Response, op: string): Promise<T> {
+  try {
+    return (await res.json()) as T;
+  } catch (err) {
+    throw new AdapterError(
+      'malformed_response',
+      `Prometheus ${op}: malformed response body`,
+      { adapterId: ADAPTER_ID, operation: op, originalError: err },
+    );
+  }
+}
+
 export class PrometheusMetricsAdapter implements IMetricsAdapter {
   constructor(
     private baseUrl: string,
@@ -45,16 +75,25 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
   ) {}
 
   async listMetricNames(): Promise<string[]> {
+    const op = 'listMetricNames';
     const url = `${this.base}/api/v1/label/__name__/values`;
-    const res = await this.fetch(url);
-    if (!res.ok) {
-      throw new Error(`Prometheus returned HTTP ${res.status} fetching metric names`);
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      log.warn({ err, url, op }, 'prometheus listMetricNames transport failure');
+      throw transportError(op, err);
     }
-    const body = (await res.json()) as PrometheusApiResponse<string[]>;
+    if (!res.ok) {
+      log.warn({ url, status: res.status, op }, 'prometheus returned non-ok');
+      throw httpError(op, res.status);
+    }
+    const body = await parseJson<PrometheusApiResponse<string[]>>(res, op);
     return Array.isArray(body.data) ? body.data : [];
   }
 
   async listLabels(metric: string): Promise<string[]> {
+    const op = 'listLabels';
     const params = new URLSearchParams();
     params.set('match[]', metric);
     const url = `${this.base}/api/v1/labels?${params}`;
@@ -62,53 +101,39 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
     try {
       res = await this.fetch(url);
     } catch (err) {
-      const kind = classifyAdapterHttpError({ cause: err });
-      log.warn({ err, url, metric, op: 'listLabels', kind }, 'prometheus listLabels transport failure');
-      throw new AdapterError(
-        `Prometheus listLabels failed: ${err instanceof Error ? err.message : String(err)}`,
-        { kind, adapter: ADAPTER_NAME, cause: err },
-      );
+      log.warn({ err, url, metric, op }, 'prometheus listLabels transport failure');
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const kind = classifyAdapterHttpError({ status: res.status });
-      log.warn({ url, status: res.status, metric, op: 'listLabels', kind }, 'prometheus returned non-ok');
-      throw new AdapterError(
-        `Prometheus listLabels HTTP ${res.status}`,
-        { kind, adapter: ADAPTER_NAME, status: res.status },
-      );
+      log.warn({ url, status: res.status, metric, op }, 'prometheus returned non-ok');
+      throw httpError(op, res.status);
     }
-    const body = (await res.json()) as PrometheusApiResponse<string[]>;
+    const body = await parseJson<PrometheusApiResponse<string[]>>(res, op);
     const labels = Array.isArray(body.data) ? body.data : [];
     return labels.filter((l) => l !== '__name__');
   }
 
   async listLabelValues(label: string): Promise<string[]> {
+    const op = 'listLabelValues';
     const url = `${this.base}/api/v1/label/${encodeURIComponent(label)}/values`;
     let res: Response;
     try {
       res = await this.fetch(url);
     } catch (err) {
-      const kind = classifyAdapterHttpError({ cause: err });
-      log.warn({ err, url, label, op: 'listLabelValues', kind }, 'prometheus listLabelValues transport failure');
-      throw new AdapterError(
-        `Prometheus listLabelValues failed: ${err instanceof Error ? err.message : String(err)}`,
-        { kind, adapter: ADAPTER_NAME, cause: err },
-      );
+      log.warn({ err, url, label, op }, 'prometheus listLabelValues transport failure');
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const kind = classifyAdapterHttpError({ status: res.status });
-      log.warn({ url, status: res.status, label, op: 'listLabelValues', kind }, 'prometheus returned non-ok');
-      throw new AdapterError(
-        `Prometheus listLabelValues HTTP ${res.status}`,
-        { kind, adapter: ADAPTER_NAME, status: res.status },
-      );
+      log.warn({ url, status: res.status, label, op }, 'prometheus returned non-ok');
+      throw httpError(op, res.status);
     }
-    const body = (await res.json()) as PrometheusApiResponse<string[]>;
+    const body = await parseJson<PrometheusApiResponse<string[]>>(res, op);
     return Array.isArray(body.data) ? body.data : [];
   }
 
   async findSeries(matchers: string[]): Promise<string[]> {
     if (matchers.length === 0) return [];
+    const op = 'findSeries';
     const params = new URLSearchParams();
     for (const m of matchers) params.append('match[]', m);
     const now = Math.floor(Date.now() / 1000);
@@ -120,22 +145,14 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
     try {
       res = await this.fetch(url);
     } catch (err) {
-      const kind = classifyAdapterHttpError({ cause: err });
-      log.warn({ err, url, matchers, op: 'findSeries', kind }, 'prometheus findSeries transport failure');
-      throw new AdapterError(
-        `Prometheus findSeries failed: ${err instanceof Error ? err.message : String(err)}`,
-        { kind, adapter: ADAPTER_NAME, cause: err },
-      );
+      log.warn({ err, url, matchers, op }, 'prometheus findSeries transport failure');
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const kind = classifyAdapterHttpError({ status: res.status });
-      log.warn({ url, status: res.status, matchers, op: 'findSeries', kind }, 'prometheus returned non-ok');
-      throw new AdapterError(
-        `Prometheus findSeries HTTP ${res.status}`,
-        { kind, adapter: ADAPTER_NAME, status: res.status },
-      );
+      log.warn({ url, status: res.status, matchers, op }, 'prometheus returned non-ok');
+      throw httpError(op, res.status);
     }
-    const body = (await res.json()) as PrometheusApiResponse<Array<Record<string, string>>>;
+    const body = await parseJson<PrometheusApiResponse<Array<Record<string, string>>>>(res, op);
     const names = new Set<string>();
     for (const series of body.data ?? []) {
       if (series['__name__']) names.add(series['__name__']);
@@ -144,20 +161,30 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
   }
 
   async instantQuery(expr: string, time?: Date): Promise<MetricSample[]> {
+    const op = 'instantQuery';
     const params = new URLSearchParams();
     params.set('query', expr);
     params.set('time', String(Math.floor((time ?? new Date()).getTime() / 1000)));
     const url = `${this.base}/api/v1/query?${params}`;
-    const res = await this.fetch(url);
-    if (!res.ok) {
-      throw new Error(`Prometheus returned HTTP ${res.status} for instant query`);
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      throw transportError(op, err);
     }
-    const body = (await res.json()) as PrometheusApiResponse<{
+    if (!res.ok) {
+      throw httpError(op, res.status);
+    }
+    const body = await parseJson<PrometheusApiResponse<{
       resultType: string;
       result: PrometheusVectorResult[];
-    }>;
+    }>>(res, op);
     if (body.status !== 'success') {
-      throw new Error(body.error ?? 'Query failed');
+      throw new AdapterError(
+        'bad_request',
+        `Prometheus ${op} returned status=${body.status}: ${body.error ?? 'no error field'}`,
+        { adapterId: ADAPTER_ID, operation: op, providerCode: body.error },
+      );
     }
     return (body.data?.result ?? []).map((r) => ({
       labels: r.metric,
@@ -167,22 +194,32 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
   }
 
   async rangeQuery(expr: string, start: Date, end: Date, step: string): Promise<RangeResult[]> {
+    const op = 'rangeQuery';
     const params = new URLSearchParams();
     params.set('query', expr);
     params.set('start', String(Math.floor(start.getTime() / 1000)));
     params.set('end', String(Math.floor(end.getTime() / 1000)));
     params.set('step', step);
     const url = `${this.base}/api/v1/query_range?${params}`;
-    const res = await this.fetch(url);
-    if (!res.ok) {
-      throw new Error(`Prometheus returned HTTP ${res.status} for range query`);
+    let res: Response;
+    try {
+      res = await this.fetch(url);
+    } catch (err) {
+      throw transportError(op, err);
     }
-    const body = (await res.json()) as PrometheusApiResponse<{
+    if (!res.ok) {
+      throw httpError(op, res.status);
+    }
+    const body = await parseJson<PrometheusApiResponse<{
       resultType: string;
       result: PrometheusMatrixResult[];
-    }>;
+    }>>(res, op);
     if (body.status !== 'success') {
-      throw new Error(body.error ?? 'Range query failed');
+      throw new AdapterError(
+        'bad_request',
+        `Prometheus ${op} returned status=${body.status}: ${body.error ?? 'no error field'}`,
+        { adapterId: ADAPTER_ID, operation: op, providerCode: body.error },
+      );
     }
     return (body.data?.result ?? []).map((r) => ({
       metric: r.metric,
@@ -191,6 +228,7 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
   }
 
   async fetchMetadata(metricNames?: string[]): Promise<Record<string, MetricMetadata>> {
+    const op = 'fetchMetadata';
     const params = new URLSearchParams();
     if (metricNames) {
       for (const name of metricNames) params.append('metric', name);
@@ -200,37 +238,31 @@ export class PrometheusMetricsAdapter implements IMetricsAdapter {
     try {
       res = await this.fetch(url);
     } catch (err) {
-      const kind = classifyAdapterHttpError({ cause: err });
-      log.warn({ err, url, op: 'fetchMetadata', kind }, 'prometheus fetchMetadata transport failure');
-      throw new AdapterError(
-        `Prometheus fetchMetadata failed: ${err instanceof Error ? err.message : String(err)}`,
-        { kind, adapter: ADAPTER_NAME, cause: err },
-      );
+      log.warn({ err, url, op }, 'prometheus fetchMetadata transport failure');
+      throw transportError(op, err);
     }
     if (!res.ok) {
-      const kind = classifyAdapterHttpError({ status: res.status });
-      log.warn({ url, status: res.status, op: 'fetchMetadata', kind }, 'prometheus returned non-ok');
-      throw new AdapterError(
-        `Prometheus fetchMetadata HTTP ${res.status}`,
-        { kind, adapter: ADAPTER_NAME, status: res.status },
-      );
+      log.warn({ url, status: res.status, op }, 'prometheus returned non-ok');
+      throw httpError(op, res.status);
     }
     let body: PrometheusApiResponse<Record<string, PrometheusMetadataEntry[]>>;
     try {
       body = (await res.json()) as PrometheusApiResponse<Record<string, PrometheusMetadataEntry[]>>;
     } catch (err) {
-      log.warn({ err, url, op: 'fetchMetadata' }, 'prometheus fetchMetadata: malformed JSON body');
+      log.warn({ err, url, op }, 'prometheus fetchMetadata: malformed JSON body');
       throw new AdapterError(
-        `Prometheus fetchMetadata: malformed response body`,
-        { kind: 'malformed', adapter: ADAPTER_NAME, cause: err },
+        'malformed_response',
+        `Prometheus ${op}: malformed response body`,
+        { adapterId: ADAPTER_ID, operation: op, originalError: err },
       );
     }
     if (body.status !== 'success' || !body.data) {
       // status=error with a populated error field is the documented Prometheus
       // failure shape; treat it the same as a malformed body.
       throw new AdapterError(
-        `Prometheus fetchMetadata returned status=${body.status}: ${body.error ?? 'no error field'}`,
-        { kind: 'malformed', adapter: ADAPTER_NAME },
+        'malformed_response',
+        `Prometheus ${op} returned status=${body.status}: ${body.error ?? 'no error field'}`,
+        { adapterId: ADAPTER_ID, operation: op, providerCode: body.error },
       );
     }
 

--- a/packages/api-gateway/src/services/setup-llm-service.ts
+++ b/packages/api-gateway/src/services/setup-llm-service.ts
@@ -309,11 +309,15 @@ export class SetupLlmService {
       log.warn({ err, provider: cfg.provider, baseUrl: cfg.baseUrl }, 'fetchModels failed');
       if (err instanceof ProviderError) {
         const detail =
-          err.kind === 'auth'
+          err.kind === 'auth_failure'
             ? 'API key was rejected'
-            : err.kind === 'network'
+            : err.kind === 'timeout' ||
+                err.kind === 'dns_failure' ||
+                err.kind === 'connection_refused' ||
+                err.kind === 'server_error' ||
+                err.kind === 'rate_limit'
               ? 'could not reach the provider'
-              : err.kind === 'unsupported'
+              : err.kind === 'not_found'
                 ? 'provider does not expose a model list endpoint'
                 : err.message;
         throw new SetupLlmServiceError(

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@agentic-obs/adapters": "*",
     "@agentic-obs/common": "*"
   },
   "devDependencies": {

--- a/packages/llm-gateway/src/__tests__/gateway.test.ts
+++ b/packages/llm-gateway/src/__tests__/gateway.test.ts
@@ -37,7 +37,7 @@ describe('LLMGateway', () => {
     const primary = new MockProvider({
       name: 'primary',
       shouldFail: true,
-      failKind: 'network',
+      failKind: 'server_error',
       failMessage: 'Mock provider error',
     });
     const gateway = new LLMGateway({ primary, maxRetries: 3, retryDelayMs: 1 });
@@ -54,7 +54,7 @@ describe('LLMGateway', () => {
     const primary = new MockProvider({
       name: 'primary',
       shouldFail: true,
-      failKind: 'auth',
+      failKind: 'auth_failure',
       failMessage: 'API key invalid',
     });
     const gateway = new LLMGateway({ primary, maxRetries: 3, retryDelayMs: 1 });
@@ -71,7 +71,7 @@ describe('LLMGateway', () => {
     const primary = new MockProvider({
       name: 'primary',
       shouldFail: true,
-      failKind: 'unsupported',
+      failKind: 'not_found',
       failMessage: 'feature not supported',
     });
     const gateway = new LLMGateway({ primary, maxRetries: 3, retryDelayMs: 1 });
@@ -166,7 +166,7 @@ describe('LLMGateway', () => {
   it('persists failure entries with success=false and errorKind set', async () => {
     const primary = new MockProvider({
       shouldFail: true,
-      failKind: 'auth',
+      failKind: 'auth_failure',
       failMessage: 'API key invalid',
     });
     const sink = new InMemoryAuditSink();

--- a/packages/llm-gateway/src/gateway.ts
+++ b/packages/llm-gateway/src/gateway.ts
@@ -24,15 +24,24 @@ function shouldRetryError(error: unknown): { retry: boolean; delayMs?: number } 
   if (error instanceof ProviderCapabilityError) return { retry: false };
 
   if (error instanceof ProviderError) {
-    if (error.kind === 'auth' || error.kind === 'unsupported') return { retry: false };
-    if (error.kind === 'network') {
+    // Retryable: transient transport / upstream conditions.
+    const retryableKinds = new Set([
+      'timeout',
+      'dns_failure',
+      'connection_refused',
+      'rate_limit',
+      'server_error',
+    ]);
+    if (retryableKinds.has(error.kind)) {
       const result: { retry: boolean; delayMs?: number } = { retry: true };
       if (error.retryAfterSec !== undefined) {
         result.delayMs = error.retryAfterSec * 1000;
       }
       return result;
     }
-    // 'unknown' — fail fast. Better to surface a novel error than spin.
+    // auth_failure, not_found, bad_request, malformed_response, readonly,
+    // unknown — fail fast. Surface novel / definitive failures instead of
+    // hammering.
     return { retry: false };
   }
 
@@ -52,14 +61,21 @@ function shouldRetryError(error: unknown): { retry: boolean; delayMs?: number } 
 function classifyAuditError(error: unknown): AuditErrorKind {
   if (error instanceof Error && error.name === 'AbortError') return 'aborted';
   if (error instanceof ProviderError) {
-    if (error.kind === 'auth') return 'auth';
-    if (error.kind === 'unsupported') return 'unknown';
-    if (error.kind === 'network') {
-      if (error.status === 429) return 'ratelimit';
-      if (error.status !== undefined && error.status >= 500) return 'server';
-      return 'network';
+    switch (error.kind) {
+      case 'auth_failure':
+        return 'auth';
+      case 'rate_limit':
+        return 'ratelimit';
+      case 'server_error':
+        return 'server';
+      case 'timeout':
+        return 'timeout';
+      case 'dns_failure':
+      case 'connection_refused':
+        return 'network';
+      default:
+        return 'unknown';
     }
-    return 'unknown';
   }
   if (error instanceof Error) {
     if (/timeout|ETIMEDOUT/i.test(error.message)) return 'timeout';

--- a/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/anthropic.test.ts
@@ -712,7 +712,7 @@ describe('AnthropicProvider — response parsing', () => {
       }),
     ).rejects.toMatchObject({
       name: 'ProviderError',
-      kind: 'network',
+      kind: 'server_error',
       provider: 'anthropic',
       status: 529,
       upstreamBody: 'overloaded',

--- a/packages/llm-gateway/src/providers/__tests__/gemini.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/gemini.test.ts
@@ -351,7 +351,7 @@ describe('GeminiProvider', () => {
         provider.complete([{ role: 'user', content: 'hi' }], { model: 'gemini-2.5-flash' }),
       ).rejects.toMatchObject({
         name: 'ProviderError',
-        kind: 'network',
+        kind: 'rate_limit',
         provider: 'gemini',
         status: 429,
         upstreamBody: 'quota exceeded',
@@ -463,7 +463,7 @@ describe('GeminiProvider', () => {
       );
 
       await expect(provider.listModels()).rejects.toMatchObject({
-        kind: 'auth',
+        kind: 'auth_failure',
         provider: 'gemini',
         status: 400,
       });

--- a/packages/llm-gateway/src/providers/__tests__/ollama.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/ollama.test.ts
@@ -366,7 +366,7 @@ describe('OllamaProvider response parsing', () => {
     const promise = provider.complete(MESSAGES, OPTS);
     await expect(promise).rejects.toMatchObject({
       name: 'ProviderError',
-      kind: 'network',
+      kind: 'server_error',
       provider: 'ollama',
       status: 503,
       upstreamBody: 'model overloaded',

--- a/packages/llm-gateway/src/providers/__tests__/openai.test.ts
+++ b/packages/llm-gateway/src/providers/__tests__/openai.test.ts
@@ -427,7 +427,7 @@ describe('OpenAIProvider — response parsing', () => {
 
     await expect(provider.complete(messages, { model: 'gpt-4o' })).rejects.toMatchObject({
       name: 'ProviderError',
-      kind: 'network',
+      kind: 'server_error',
       provider: 'openai',
       status: 500,
       upstreamCode: 'server_error',
@@ -444,7 +444,7 @@ describe('OpenAIProvider — response parsing', () => {
     const provider = new OpenAIProvider({ apiKey: 'sk-test' });
 
     await expect(provider.complete(messages, { model: 'gpt-4o' })).rejects.toMatchObject({
-      kind: 'network',
+      kind: 'rate_limit',
       status: 429,
       retryAfterSec: 7,
       upstreamCode: 'rate_limit_exceeded',
@@ -466,7 +466,7 @@ describe('OpenAIProvider — response parsing', () => {
 
     await expect(provider.complete(messages, { model: 'gpt-4o' })).rejects.toBeInstanceOf(ProviderError);
     await expect(provider.complete(messages, { model: 'gpt-4o' })).rejects.toMatchObject({
-      kind: 'network',
+      kind: 'connection_refused',
       provider: 'openai',
     });
   });

--- a/packages/llm-gateway/src/providers/gemini.ts
+++ b/packages/llm-gateway/src/providers/gemini.ts
@@ -342,7 +342,7 @@ export class GeminiProvider implements LLMProvider {
       const body = await response.text().catch(() => '');
       const kind =
         response.status === 400 && /API key|INVALID_ARGUMENT/i.test(body)
-          ? 'auth'
+          ? ('auth_failure' as const)
           : classifyProviderHttpError({ status: response.status });
       log.warn(
         { provider: 'gemini', status: response.status, body: body.slice(0, 200), baseUrl: this.baseUrl, kind },

--- a/packages/llm-gateway/src/types.ts
+++ b/packages/llm-gateway/src/types.ts
@@ -128,32 +128,42 @@ export interface ToolCall {
 
 // -- Provider errors -----------------------------------------------------
 //
-// Typed error raised by provider methods (listModels, complete) when an
-// integration boundary fails. Callers branch on `kind` to decide whether
-// to retry, surface a setup error, or bubble.
+// `ProviderError` is the LLM-gateway flavor of the canonical AdapterError
+// taxonomy in `@agentic-obs/adapters`. It is the same class, with the same
+// `kind` enum — `ProviderError` exists for back-compat with callers that
+// still `instanceof ProviderError` (api-gateway setup flow). New code should
+// `instanceof AdapterError` and branch on `error.kind`.
 //
-//   - 'auth'        : credentials rejected (401, missing API key, etc).
-//                     Don't retry; surface as setup error.
-//   - 'network'     : transport-level (DNS, connection refused, timeout)
-//                     or 5xx server errors. Retryable.
-//   - 'unsupported' : operation isn't available for this provider/model
-//                     (404 on listModels, capability missing). Don't retry.
-//   - 'unknown'     : unclassified — caller decides. Default to don't retry
-//                     so we fail fast on novel errors instead of hammering.
+// `kind` values use the canonical AdapterErrorKind:
+//   timeout, dns_failure, connection_refused, auth_failure, rate_limit,
+//   not_found, bad_request, server_error, malformed_response, readonly,
+//   unknown.
 
-export type ProviderErrorKind = 'auth' | 'network' | 'unsupported' | 'unknown';
+import {
+  AdapterError,
+  classifyHttpError,
+  type AdapterErrorKind,
+} from '@agentic-obs/adapters';
 
-export class ProviderError extends Error {
-  public readonly kind: ProviderErrorKind;
+export type ProviderErrorKind = AdapterErrorKind;
+
+/**
+ * Subclass exists to preserve back-compat with `instanceof ProviderError`
+ * catch sites and to surface provider-specific accessor names (`provider`,
+ * `retryAfterSec`, `upstreamCode`, `upstreamBody`) without callers having to
+ * dig into `cause`.
+ */
+export class ProviderError extends AdapterError {
+  /** Convenience alias for `cause.adapterId`. */
   public readonly provider: string;
-  public readonly status?: number;
-  public override readonly cause?: unknown;
-  /** Seconds the upstream asked us to wait (Retry-After header). */
-  public readonly retryAfterSec?: number;
-  /** Provider-specific error code, when the upstream body exposes one. */
-  public readonly upstreamCode?: string;
-  /** Truncated upstream response body for diagnostics. Never assume it is safe to show to end users. */
-  public readonly upstreamBody?: string;
+  /** Convenience alias for `cause.status`. */
+  public readonly status: number | undefined;
+  /** Convenience alias for `cause.retryAfterSec`. */
+  public readonly retryAfterSec: number | undefined;
+  /** Convenience alias for `cause.providerCode`. */
+  public readonly upstreamCode: string | undefined;
+  /** Convenience alias for `cause.upstreamBody`. Never safe to show to users. */
+  public readonly upstreamBody: string | undefined;
 
   constructor(
     message: string,
@@ -167,52 +177,34 @@ export class ProviderError extends Error {
       upstreamBody?: string;
     },
   ) {
-    super(message);
+    super(opts.kind, message, {
+      adapterId: opts.provider,
+      operation: 'complete',
+      status: opts.status,
+      providerCode: opts.upstreamCode,
+      retryAfterSec: opts.retryAfterSec,
+      upstreamBody: opts.upstreamBody,
+      originalError: opts.cause,
+    });
     this.name = 'ProviderError';
-    this.kind = opts.kind;
     this.provider = opts.provider;
-    if (opts.status !== undefined) this.status = opts.status;
-    if (opts.cause !== undefined) this.cause = opts.cause;
-    if (opts.retryAfterSec !== undefined) this.retryAfterSec = opts.retryAfterSec;
-    if (opts.upstreamCode !== undefined) this.upstreamCode = opts.upstreamCode;
-    if (opts.upstreamBody !== undefined) this.upstreamBody = opts.upstreamBody;
+    this.status = opts.status;
+    this.retryAfterSec = opts.retryAfterSec;
+    this.upstreamCode = opts.upstreamCode;
+    this.upstreamBody = opts.upstreamBody;
   }
 }
 
 /**
- * Classify a fetch / Response failure into a ProviderErrorKind. Covers the
- * common shapes: HTTP status (401 → auth, 5xx → network, 404 → unsupported),
- * Node fetch error codes (ENOTFOUND/ECONNREFUSED/ETIMEDOUT → network), and
- * 429 rate-limit (network — retryable, the gateway honors Retry-After).
+ * Classify a fetch / Response failure into a canonical ProviderErrorKind.
+ * Thin wrapper around the shared `classifyHttpError` so provider code can
+ * keep its existing import.
  */
 export function classifyProviderHttpError(opts: {
   status?: number;
   cause?: unknown;
 }): ProviderErrorKind {
-  const { status, cause } = opts;
-  if (typeof status === 'number') {
-    if (status === 401 || status === 403) return 'auth';
-    if (status === 404) return 'unsupported';
-    if (status === 429) return 'network';
-    if (status >= 500) return 'network';
-    if (status >= 400) return 'unknown';
-  }
-  // Inspect Node fetch error code / nested cause
-  const codes: string[] = [];
-  const collect = (e: unknown) => {
-    if (!e || typeof e !== 'object') return;
-    const code = (e as { code?: unknown }).code;
-    if (typeof code === 'string') codes.push(code);
-    const inner = (e as { cause?: unknown }).cause;
-    if (inner) collect(inner);
-  };
-  collect(cause);
-  if (codes.some((c) => /^(ENOTFOUND|ECONNREFUSED|ETIMEDOUT|ECONNRESET|EAI_AGAIN|UND_ERR_(?:CONNECT_TIMEOUT|SOCKET))$/i.test(c))) {
-    return 'network';
-  }
-  if (cause instanceof Error && cause.name === 'AbortError') return 'network';
-  if (cause instanceof Error && /fetch failed|network|timeout|connection/i.test(cause.message)) return 'network';
-  return 'unknown';
+  return classifyHttpError(opts);
 }
 
 // -- Minimal subset of JSON Schema we care about --

--- a/packages/llm-gateway/tsconfig.json
+++ b/packages/llm-gateway/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["src"],
   "exclude": ["dist", "node_modules"],
   "references": [
-    { "path": "../common" }
+    { "path": "../common" },
+    { "path": "../adapters" }
   ]
 }


### PR DESCRIPTION
From \`internal-docs/design/code-review-remediation-tasks.md\` T2.4. Wave 2 prerequisite — Propose-as-PR for provisioned resources needs stable error kinds to branch on.

## Canonical type

\`packages/adapters/src/errors.ts\`:
- \`AdapterErrorKind\` union of 11 kinds (timeout, dns_failure, connection_refused, auth_failure, rate_limit, not_found, bad_request, server_error, malformed_response, readonly, unknown)
- \`AdapterError\` class with structured \`cause: { adapterId, operation, status?, providerCode?, originalError? }\`
- \`classifyHttpError\`, \`isAdapterError\`, \`toUserMessage\` (safe-for-UI)
- Re-exported from \`adapter.ts\` for legacy import path

## Migration

| File | Throws migrated |
|---|---|
| \`adapters/src/prometheus/metrics-adapter.ts\` | 11 throws across all 6 ops |
| \`adapters/src/prometheus/client.ts\` | 1 raw HTTP + transport + malformed paths |
| \`adapters/src/loki/logs-adapter.ts\` | 6 raw \`new Error(...)\` migrated |
| \`llm-gateway/src/providers/{openai,anthropic,gemini,ollama,mock}.ts\` | All ProviderError throws via \`classifyProviderHttpError → classifyHttpError\` |
| \`llm-gateway/src/types.ts\` | \`ProviderError extends AdapterError\` (class name preserved → all \`instanceof ProviderError\` sites still work) |

Execution adapter (kubectl) intentionally left alone — local pre-flight validation, not a data-source boundary.

## Callsites updated beyond adapter boundary

Minimal:
- \`llm-gateway/src/gateway.ts\` — retry/audit classification branches on canonical kinds; same retry conditions fire as before
- \`api-gateway/src/services/setup-llm-service.ts\` — operator-facing detail strings keyed off new kinds

**Zero changes** in agent-core or web (per spec boundary).

## Behavior preservation

- Internal exception messages keep legacy substrings (\`HTTP {n}\`, \`query_range request failed\`) so existing tests + log-greps don't break.
- User-facing rendering goes through \`toUserMessage()\` — asserted not to leak adapter id, status, body, or stack.
- \`classifyHttpError\` keeps a legacy fallback: raw \`Error('fetch failed')\` (undici generic transport) → \`connection_refused\` to preserve existing gateway retry behavior.

## Test plan

- [x] 229/229 adapter + llm-gateway tests pass
- [x] New \`errors.test.ts\` 22 tests — all 6 required scenarios + classifier + safety assertions
- [x] Existing provider tests updated to new kind names
- [ ] CI green

## Out of scope

- Agent-side decisions on stable kinds — Wave 2 work
- Web-facing error rendering changes — separate PR if needed