### PR TITLE
R-5: plan executor terminal state + approval/share silent failures

### DIFF
--- a/packages/api-gateway/src/routes/approval.test.ts
+++ b/packages/api-gateway/src/routes/approval.test.ts
@@ -8,6 +8,24 @@
  *     does NOT broaden to `approvals:*` and so MUST NOT see `prod-eks` rows.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock('@agentic-obs/common/logging', async () => {
+  const actual = await vi.importActual<typeof import('@agentic-obs/common/logging')>(
+    '@agentic-obs/common/logging',
+  );
+  const stub: () => Record<string, unknown> = () => ({
+    info: () => {},
+    warn: warnSpy,
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: stub,
+  });
+  return { ...actual, createLogger: stub };
+});
+
 import express from 'express';
 import request from 'supertest';
 import type { Evaluator, Identity, ResolvedPermission } from '@agentic-obs/common';
@@ -239,5 +257,71 @@ describe('FIXED_ROLE_DEFINITIONS — multi-team approval roles', () => {
     expect(names).toContain('fixed:approvals:cluster_approver');
     expect(names).toContain('fixed:approvals:namespace_approver');
     expect(names).toContain('fixed:approvals:team_viewer');
+  });
+});
+
+// R-5 / T1.3: approval mutation failures must surface to the requestor (5xx)
+// and land in the logs with structured context. Earlier the catch in each
+// route just forwarded to Express's default error handler with no breadcrumb.
+describe('/api/approvals — failure surfacing', () => {
+  it('approve repo throw → 5xx response AND structured warn log', async () => {
+    const r = row('appr-boom');
+    const requests: IApprovalRequestRepository = {
+      findById: async () => r,
+      submit: async () => { throw new Error('not used'); },
+      listPending: async () => [r],
+      list: async () => [r],
+      approve: async () => { throw new Error('db write failed'); },
+      reject: async () => r,
+      override: async () => r,
+    };
+    const approvals: IGatewayApprovalStore = {
+      findById: requests.findById,
+      listPending: requests.listPending,
+      approve: requests.approve,
+      reject: requests.reject,
+      override: requests.override,
+    };
+    const accessControl: AccessControlSurface = {
+      getUserPermissions: async () => [],
+      ensurePermissions: async () => [],
+      filterByPermission: async (_id, items) => [...items],
+      evaluate: async () => true, // grant access so we reach the failing approve()
+    };
+    setAuthMiddleware((req, _res, next) => { next(); return undefined as unknown as void; });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as AuthenticatedRequest).auth = {
+        userId: 'u1',
+        orgId: 'org_a',
+        orgRole: 'Admin',
+        isServerAdmin: false,
+        authenticatedBy: 'session',
+      };
+      next();
+    });
+    app.use('/api/approvals', createApprovalRouter({
+      approvals,
+      approvalRequests: requests,
+      ac: accessControl,
+    }));
+
+    warnSpy.mockClear();
+    const res = await request(app).post('/api/approvals/appr-boom/approve').send({});
+
+    // User sees a definitive failure, not a hung request.
+    expect(res.status).toBeGreaterThanOrEqual(500);
+
+    // Structured warn carries the right fields for ops correlation.
+    const warnCall = warnSpy.mock.calls.find(
+      (c) => typeof c[1] === 'string' && c[1].includes('approve failed'),
+    );
+    expect(warnCall).toBeDefined();
+    const ctx = warnCall![0] as Record<string, unknown>;
+    expect(ctx.requestId).toBe('appr-boom');
+    expect(ctx.action).toBe('approve');
+    expect(ctx.err).toBe('db write failed');
   });
 });

--- a/packages/api-gateway/src/routes/approval.ts
+++ b/packages/api-gateway/src/routes/approval.ts
@@ -2,6 +2,31 @@ import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import type { ApiError, ResolvedPermission } from '@agentic-obs/common';
 import { ac, ACTIONS, approvalRowScopes, parseApprovalScope } from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/common/logging';
+
+const log = createLogger('approval-route');
+
+/**
+ * Structured warn before forwarding to Express's default error handler so a
+ * caught failure carries `{ requestId, action, error }` into the operator
+ * logs. The route still returns a 5xx via `next(err)` so the requestor sees
+ * a definitive failure rather than a silent dead state.
+ */
+function logRouteError(
+  action: string,
+  err: unknown,
+  context: { requestId?: string; userId?: string; orgId?: string },
+): void {
+  log.warn(
+    {
+      ...context,
+      action,
+      errClass: err instanceof Error ? err.constructor.name : typeof err,
+      err: err instanceof Error ? err.message : String(err),
+    },
+    `approval-route: ${action} failed`,
+  );
+}
 import type { IApprovalRequestRepository, IGatewayApprovalStore, ApprovalScopeFilter } from '@agentic-obs/data-layer';
 import { authMiddleware } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
@@ -140,6 +165,8 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         const rows = await requests.list(auth.orgId, { scopeFilter });
         res.json(rows);
       } catch (err) {
+        const auth = (req as AuthenticatedRequest).auth;
+        logRouteError('list', err, { userId: auth?.userId, orgId: auth?.orgId });
         next(err);
       }
     },
@@ -169,6 +196,9 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         }
         res.json(record);
       } catch (err) {
+        const auth = (req as AuthenticatedRequest).auth;
+        const requestId = req.params['id'];
+        logRouteError('get', err, { requestId, userId: auth?.userId, orgId: auth?.orgId });
         next(err);
       }
     },
@@ -209,6 +239,9 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         }
         res.json(updated);
       } catch (err) {
+        const auth = (req as AuthenticatedRequest).auth;
+        const requestId = req.params['id'];
+        logRouteError('approve', err, { requestId, userId: auth?.userId, orgId: auth?.orgId });
         next(err);
       }
     },
@@ -249,6 +282,9 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         }
         res.json(updated);
       } catch (err) {
+        const auth = (req as AuthenticatedRequest).auth;
+        const requestId = req.params['id'];
+        logRouteError('reject', err, { requestId, userId: auth?.userId, orgId: auth?.orgId });
         next(err);
       }
     },
@@ -285,6 +321,9 @@ export function createApprovalRouter(deps: ApprovalRouterDeps): Router {
         }
         res.json(updated);
       } catch (err) {
+        const auth = (req as AuthenticatedRequest).auth;
+        const requestId = req.params['id'];
+        logRouteError('override', err, { requestId, userId: auth?.userId, orgId: auth?.orgId });
         next(err);
       }
     },

--- a/packages/api-gateway/src/routes/shared.ts
+++ b/packages/api-gateway/src/routes/shared.ts
@@ -2,9 +2,34 @@
 
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
+import { createLogger } from '@agentic-obs/common/logging';
 import type { IGatewayShareStore, IGatewayInvestigationStore } from '@agentic-obs/data-layer';
+
+type ResolvedShareLink = NonNullable<Awaited<ReturnType<IGatewayShareStore['findByToken']>>>;
 import { authMiddleware } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
+
+const log = createLogger('shared-route');
+
+/**
+ * Resolve a share token using the store's status-aware lookup when available,
+ * falling back to the legacy `findByToken` (which can't distinguish expired
+ * from not-found — those callers will continue to see a generic 404).
+ */
+async function resolveShare(
+  shareRepo: IGatewayShareStore,
+  token: string,
+): Promise<
+  | { kind: 'ok'; link: ResolvedShareLink }
+  | { kind: 'expired' }
+  | { kind: 'not_found' }
+> {
+  if (typeof shareRepo.findByTokenStatus === 'function') {
+    return shareRepo.findByTokenStatus(token);
+  }
+  const link = await shareRepo.findByToken(token);
+  return link ? { kind: 'ok', link } : { kind: 'not_found' };
+}
 
 export interface SharedRouterDeps {
   shareRepo: IGatewayShareStore;
@@ -21,11 +46,25 @@ export function createSharedRouter(deps: SharedRouterDeps): Router {
   router.get('/:token', async (req: Request, res: Response, next: NextFunction) => {
     try {
       const token = req.params['token'] ?? '';
-      const link = await shareRepo.findByToken(token);
-      if (!link) {
-        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Share link not found or expired' } });
+      const lookup = await resolveShare(shareRepo, token);
+      if (lookup.kind === 'expired') {
+        log.warn(
+          { token },
+          'shared-route: token expired — returning 410',
+        );
+        res.status(410).json({
+          error: {
+            code: 'EXPIRED',
+            message: 'This share link has expired. Ask the owner to create a new one.',
+          },
+        });
         return;
       }
+      if (lookup.kind === 'not_found') {
+        res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Share link not found' } });
+        return;
+      }
+      const link = lookup.link;
 
       const inv = await investigationStore.findById(link.investigationId);
       if (!inv) {
@@ -61,11 +100,19 @@ export function createSharedRouter(deps: SharedRouterDeps): Router {
     try {
       const authReq = req as AuthenticatedRequest;
       const token = req.params['token'] ?? '';
-      const link = await shareRepo.findByToken(token);
-      if (!link) {
+      const lookup = await resolveShare(shareRepo, token);
+      if (lookup.kind === 'expired') {
+        // Expired link cannot be revoked — it's already effectively gone.
+        res.status(410).json({
+          error: { code: 'EXPIRED', message: 'This share link has expired and cannot be revoked.' },
+        });
+        return;
+      }
+      if (lookup.kind === 'not_found') {
         res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Share link not found' } });
         return;
       }
+      const link = lookup.link;
 
       if (authReq.auth?.userId !== link.createdBy) {
         res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Only the creator may revoke this share link' } });

--- a/packages/api-gateway/src/services/plan-executor-service.test.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.test.ts
@@ -5,6 +5,24 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock('@agentic-obs/common/logging', async () => {
+  const actual = await vi.importActual<typeof import('@agentic-obs/common/logging')>(
+    '@agentic-obs/common/logging',
+  );
+  const stub: () => Record<string, unknown> = () => ({
+    info: () => {},
+    warn: warnSpy,
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: stub,
+  });
+  return { ...actual, createLogger: stub };
+});
+
 import { createTestDb, SqliteRemediationPlanRepository, SqliteApprovalRequestRepository } from '@agentic-obs/data-layer';
 import type { SqliteClient, NewRemediationPlan } from '@agentic-obs/data-layer';
 import type { ExecutionAdapter } from '@agentic-obs/adapters';
@@ -159,6 +177,48 @@ describe('PlanExecutorService — autoEdit happy path', () => {
     await svc.approve('org_main', plan.id, true, ID);
     const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
     expect(fresh?.steps[0]?.outputText?.length).toBe(64 * 1024);
+  });
+
+  // R-5 / T1.3: adapter throw must not leave the step stuck in 'executing'.
+  // Asserts the terminal state transition AND the structured warn log.
+  it('marks step failed (terminal) + warn-logs when adapter throws', async () => {
+    const plan = await plansRepo.create(basePlan());
+    const throwingAdapter: ExecutionAdapter = {
+      capabilities: () => ['runtime.scale'],
+      async validate() { return { valid: true }; },
+      async dryRun() { return { estimatedImpact: 'ok', warnings: [], willAffect: [] }; },
+      async execute() {
+        throw new Error('adapter blew up');
+      },
+    };
+    const svc = new PlanExecutorService({
+      plans: plansRepo,
+      adapterFor: async () => throwingAdapter,
+    });
+    warnSpy.mockClear();
+    const outcome = await svc.approve('org_main', plan.id, true, ID);
+
+    expect(outcome.kind).toBe('failed');
+    const fresh = await plansRepo.findByIdInOrg('org_main', plan.id);
+    expect(fresh?.status).toBe('failed');
+    expect(fresh?.steps[0]?.status).toBe('failed');
+    // Critical: NOT stuck in executing.
+    expect(fresh?.steps[0]?.status).not.toBe('executing');
+    expect(fresh?.steps[0]?.errorText).toMatch(/adapter blew up/);
+    // Later steps are skipped (haltPlan).
+    expect(fresh?.steps[1]?.status).toBe('skipped');
+
+    // Structured warn fired with expected fields.
+    const warnCall = warnSpy.mock.calls.find(
+      (c) => typeof c[1] === 'string' && c[1].includes('adapter threw'),
+    );
+    expect(warnCall).toBeDefined();
+    const ctx = warnCall![0] as Record<string, unknown>;
+    expect(ctx.planId).toBe(plan.id);
+    expect(ctx.stepOrdinal).toBe(0);
+    expect(ctx.orgId).toBe('org_main');
+    expect(ctx.errClass).toBe('Error');
+    expect(ctx.err).toMatch(/adapter blew up/);
   });
 });
 

--- a/packages/api-gateway/src/services/plan-executor-service.ts
+++ b/packages/api-gateway/src/services/plan-executor-service.ts
@@ -440,12 +440,41 @@ export class PlanExecutorService {
       }
     }
 
-    const adapter = await this.opts.adapterFor(plan, step);
-    const result = await adapter.execute({
-      type: 'ops.run_command',
-      targetService: params.connectorId,
-      params: { argv: params.argv },
-    });
+    // Wrap adapter resolution + execution so a throw never leaves the step
+    // stuck in 'executing'. We translate the throw into a terminal 'failed'
+    // step with the error message preserved, mirroring the {success:false}
+    // path below.
+    let result: Awaited<ReturnType<ExecutionAdapter['execute']>>;
+    try {
+      const adapter = await this.opts.adapterFor(plan, step);
+      result = await adapter.execute({
+        type: 'ops.run_command',
+        targetService: params.connectorId,
+        params: { argv: params.argv },
+      });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      await this.opts.plans.updateStep(plan.id, step.ordinal, {
+        status: 'failed',
+        errorText: truncate(`adapter threw: ${errMsg}`, STDIO_CAP_BYTES),
+      });
+      log.warn(
+        {
+          planId: plan.id,
+          stepOrdinal: step.ordinal,
+          orgId: plan.orgId,
+          investigationId: plan.investigationId,
+          errClass: err instanceof Error ? err.constructor.name : typeof err,
+          err: errMsg,
+        },
+        'plan-executor: adapter threw — marking step failed',
+      );
+      void this.audit(plan, step, 'error', `adapter threw: ${errMsg}`, params);
+      if (!step.continueOnError) {
+        await this.haltPlan(plan.orgId, plan.id, step.ordinal, errMsg);
+      }
+      return;
+    }
 
     if (result.success) {
       await this.opts.plans.updateStep(plan.id, step.ordinal, {

--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -88,6 +88,7 @@ export {
   // Share
   ShareStore,
   defaultShareStore,
+  type ShareLookupResult,
 
   // Dashboard
   DashboardStore,

--- a/packages/data-layer/src/stores/__tests__/share-store.test.ts
+++ b/packages/data-layer/src/stores/__tests__/share-store.test.ts
@@ -1,0 +1,82 @@
+/**
+ * R-5 / T1.3: share-link expiry handling must distinguish expired from
+ * not-found so the route layer can return a specific 410 / "this link
+ * expired" response. Asserts both the result shape AND the structured
+ * warn log fires on expiry (captured via a mocked createLogger).
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock('@agentic-obs/common/logging', async () => {
+  const actual = await vi.importActual<typeof import('@agentic-obs/common/logging')>(
+    '@agentic-obs/common/logging',
+  );
+  const stub: () => Record<string, unknown> = () => ({
+    info: () => {},
+    warn: warnSpy,
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: stub,
+  });
+  return { ...actual, createLogger: stub };
+});
+
+import { ShareStore } from '../share-store.js';
+
+describe('ShareStore.findByTokenStatus — expiry vs not-found', () => {
+  let store: ShareStore;
+
+  beforeEach(() => {
+    store = new ShareStore();
+    warnSpy.mockClear();
+  });
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('returns not_found for an unknown token', () => {
+    const result = store.findByTokenStatus('does-not-exist');
+    expect(result.kind).toBe('not_found');
+  });
+
+  it('returns ok with the link for a valid token', () => {
+    const link = store.create({
+      investigationId: 'inv-1',
+      createdBy: 'user-1',
+      expiresInMs: 60_000,
+    });
+    const result = store.findByTokenStatus(link.token);
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.link.token).toBe(link.token);
+      expect(result.link.investigationId).toBe('inv-1');
+    }
+  });
+
+  it('returns expired (distinct from not_found) and warn-logs when token has elapsed', () => {
+    const link = store.create({
+      investigationId: 'inv-7',
+      createdBy: 'user-1',
+      expiresInMs: -1, // already expired
+    });
+    const result = store.findByTokenStatus(link.token);
+    expect(result.kind).toBe('expired');
+
+    // Structured warn fired with the right context fields.
+    expect(warnSpy).toHaveBeenCalled();
+    const warnCall = warnSpy.mock.calls.find(
+      (c) => typeof c[1] === 'string' && c[1].includes('token expired'),
+    );
+    expect(warnCall).toBeDefined();
+    const ctx = warnCall![0] as Record<string, unknown>;
+    expect(ctx.investigationId).toBe('inv-7');
+    expect(ctx.token).toBe(link.token);
+
+    // Subsequent lookups return not_found (record was purged).
+    const after = store.findByTokenStatus(link.token);
+    expect(after.kind).toBe('not_found');
+  });
+});

--- a/packages/data-layer/src/stores/approval-store.ts
+++ b/packages/data-layer/src/stores/approval-store.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from 'crypto';
+import { createLogger } from '@agentic-obs/common/logging';
+
+const log = createLogger('approval-store');
 
 // -- Types
 
@@ -165,8 +168,27 @@ export class ApprovalStore {
   }
 
   private notify(request: ApprovalRequest): void {
-    for (const cb of this.callbacks)
-      cb(request);
+    // Each callback runs in isolation: a throwing listener is logged with
+    // structured context but must not block the remaining listeners (the
+    // plan executor's onResolved hook is one of these — losing its signal
+    // because an unrelated subscriber threw would leave plan steps stuck
+    // in 'paused_for_approval' forever).
+    for (const cb of this.callbacks) {
+      try {
+        cb(request);
+      } catch (err) {
+        log.warn(
+          {
+            requestId: request.id,
+            action: request.action.type,
+            status: request.status,
+            errClass: err instanceof Error ? err.constructor.name : typeof err,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          'approval-store: onResolved callback threw — continuing',
+        );
+      }
+    }
   }
 }
 

--- a/packages/data-layer/src/stores/interfaces.ts
+++ b/packages/data-layer/src/stores/interfaces.ts
@@ -130,6 +130,17 @@ export interface IGatewayApprovalStore {
 
 export interface IGatewayShareStore {
   findByToken(token: string): MaybeAsync<ShareLink | undefined>
+  /**
+   * Like findByToken but distinguishes expired from not-found so the route
+   * layer can return a specific "this link expired" response. Default
+   * implementation just calls findByToken; concrete stores override to
+   * surface the difference.
+   */
+  findByTokenStatus?(token: string): MaybeAsync<
+    | { kind: 'ok'; link: ShareLink }
+    | { kind: 'expired' }
+    | { kind: 'not_found' }
+  >
   findByInvestigation(investigationId: string): MaybeAsync<ShareLink[]>
   revoke(token: string): MaybeAsync<boolean>
   create(params: {

--- a/packages/data-layer/src/stores/share-store.ts
+++ b/packages/data-layer/src/stores/share-store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { createLogger } from '@agentic-obs/common/logging';
 import type { Persistable } from './persistence.js';
 import { markDirty } from './persistence.js';
 
@@ -12,6 +13,20 @@ export interface ShareLink {
   createdAt: string;
   expiresAt: string | null;
 }
+
+/**
+ * Result type that distinguishes the three terminal states for a share-link
+ * lookup: hit, expired (so the UI can say "this link expired"), and absent
+ * (typo / revoked). Returned by `findByTokenStatus`. The legacy
+ * `findByToken` collapses expired and not-found to `undefined` and is kept
+ * for callers that don't need the distinction.
+ */
+export type ShareLookupResult =
+  | { kind: 'ok'; link: ShareLink }
+  | { kind: 'expired' }
+  | { kind: 'not_found' };
+
+const log = createLogger('share-store');
 
 export class ShareStore implements Persistable {
   private readonly shares = new Map<string, ShareLink>();
@@ -40,17 +55,36 @@ export class ShareStore implements Persistable {
   }
 
   findByToken(token: string): ShareLink | undefined {
+    const result = this.findByTokenStatus(token);
+    return result.kind === 'ok' ? result.link : undefined;
+  }
+
+  /**
+   * Distinguishes `expired` from `not_found` so the route layer can return a
+   * specific 410 / "this link expired" message instead of a generic 404. We
+   * also log a structured warn on expiry so operators can correlate failed
+   * share visits to expired links.
+   */
+  findByTokenStatus(token: string): ShareLookupResult {
     const link = this.shares.get(token);
     if (!link)
-      return undefined;
+      return { kind: 'not_found' };
 
-    // Check expiration
     if (link.expiresAt && new Date(link.expiresAt).getTime() < Date.now()) {
       this.shares.delete(token);
-      return undefined;
+      markDirty();
+      log.warn(
+        {
+          token,
+          investigationId: link.investigationId,
+          expiresAt: link.expiresAt,
+        },
+        'share-store: token expired — purging',
+      );
+      return { kind: 'expired' };
     }
 
-    return link;
+    return { kind: 'ok', link };
   }
 
   findByInvestigation(investigationId: string): ShareLink[] {


### PR DESCRIPTION
From \`internal-docs/design/code-review-remediation-tasks.md\` T1.3. Same pattern as R-1 (#188) but for plan executor, approval routes, and share links.

## Plan executor — \`executing → failed\` terminal state (P1)

**Bug:** \`plan-executor-service.ts\` had **no try/catch** around \`adapterFor()\` + \`adapter.execute()\`. An adapter throw left the step stuck in \`executing\` forever (parallel to the dashboard \`generating\` bug fixed in R-1).

**Fix:** wrap in try/catch; on throw, flip step to \`failed\`, honor \`continueOnError\`, otherwise trigger \`haltPlan\` (existing helper) so later pending steps flip to \`skipped\` and plan status becomes \`failed\`. Structured warn + audit \`outcome:'error'\`.

**Test:** \`marks step failed (terminal) + warn-logs when adapter throws\` — asserts step + plan + later-step state transitions.

## Approval routes — observability before forwarding (P1)

**Issue:** Every route catch in \`routes/approval.ts\` (list/get/approve/reject/override) was forwarding to \`next(err)\` with **no log breadcrumb**. User sees a 5xx with no operator-side trace.

**Fix:** 5 catches now log structured warn with \`{requestId, action, userId, orgId, errClass, err}\` before \`next(err)\`. Behavior preserved.

**Test:** \`approve repo throw → 5xx response AND structured warn log\`.

## Approval store — notify() callback isolation

**Bug:** \`approval-store.notify()\` iterated callbacks with no isolation. A throwing listener silently starved later subscribers (including plan executor's \`onResolved\` hook).

**Fix:** wrap each \`cb(request)\` in try/catch + structured warn. Loop continues.

## Share links — expired vs not-found distinction

**Issue:** \`shared.ts\` couldn't distinguish "this link expired" from "wrong token" — both 4xx with the same message.

**Fix:** new \`share-store.findByTokenStatus()\` returning \`{kind: 'ok' | 'expired' | 'not_found'}\` with structured warn on expiry. Route returns **410 Gone** for expired (distinct from 404). Legacy \`findByToken\` kept for back-compat — new callers use the new method.

**Test:** 3 tests in new \`share-store.test.ts\` covering all three kinds.

## What was NOT changed (intentional)

- \`findByToken\` legacy method (back-compat scope)
- No new event bus in plan-executor (audit \`outcome:'error'\` is the existing surfacing mechanism)
- No global \"no silent catch\" sweep — doc's \"What Not To Do\" explicitly forbids that

## Test plan

- [x] 38/38 affected tests pass
- [ ] CI green

## Note

\`approval-store.ts\` is in R-3 (#190)'s deprecation list. Touched anyway — the audit/log additions need to be present in whichever abstraction inherits them.