### PR TITLE
Cleanup: delete dead IShareRepository + legacy ShareLink type

### DIFF
--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -14,7 +14,6 @@ export type {
   IApprovalRepository,
   IApprovalRequestRepository,
   ApprovalScopeFilter,
-  IShareRepository,
   IShareLinkRepository,
   IDashboardRepository,
   IFolderRepository,
@@ -43,8 +42,6 @@ export type {
   ApprovalAction,
   ApprovalContext,
   SubmitApprovalParams,
-  ShareLink,
-  SharePermission,
 } from './types.js';
 
 export { InMemoryApprovalRequestRepository } from './memory/approval.js';

--- a/packages/data-layer/src/repository/interfaces.ts
+++ b/packages/data-layer/src/repository/interfaces.ts
@@ -29,7 +29,7 @@ import type {
   ChatMessage,
 } from '@agentic-obs/common';
 import type { ExplanationResult } from '@agentic-obs/common';
-import type { FeedEvent, Case, ApprovalRecord, ShareLink } from './types.js';
+import type { FeedEvent, Case, ApprovalRecord } from './types.js';
 import type { FollowUpRecord, FeedbackBody, StoredFeedback } from './types/investigation.js';
 import type {
   FeedItem,
@@ -220,14 +220,6 @@ export interface IApprovalRequestRepository {
   approve(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined>;
   reject(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined>;
   override(id: string, by: string, roles?: string[]): Promise<ApprovalRequest | undefined>;
-}
-
-// — ShareLink
-
-export interface IShareRepository extends IRepository<ShareLink> {
-  findByToken(token: string): MaybeAsync<ShareLink | undefined>;
-  findByInvestigation(investigationId: string): MaybeAsync<ShareLink[]>;
-  revoke(token: string): MaybeAsync<boolean>;
 }
 
 // — ShareLink (gateway-level, mirrors the store's ShareLink shape — no `id`)

--- a/packages/data-layer/src/repository/types.ts
+++ b/packages/data-layer/src/repository/types.ts
@@ -64,18 +64,6 @@ export interface ApprovalRecord {
   resolvedAt?: string;
 }
 
-export type SharePermission = 'view_only' | 'can_comment';
-
-export interface ShareLink {
-  id: string;
-  investigationId: string;
-  token: string;
-  createdBy: string;
-  permission: SharePermission;
-  expiresAt: string | null;
-  createdAt: string;
-}
-
 export interface FeedEvent {
   id: string;
   tenantId: string;


### PR DESCRIPTION
Post-M1..M4 sweep. Surgical only.

## Changes

- **Deleted dead \`IShareRepository\` interface** (\`repository/interfaces.ts:228\`) — zero callers (grep verified). Used the older \`ShareLink\` type from \`repository/types.ts\`, not the M4 canonical one.
- **Deleted unused legacy \`ShareLink\` + \`SharePermission\` types** from \`repository/types.ts\`. Canonical shapes live in \`stores/share-store.ts\` (M4 InMemoryShareLinkRepository).
- **Dropped 3 dangling re-exports** from \`repository/index.ts\` (IShareRepository, ShareLink, SharePermission).

## What was NOT changed (intentional)

- \`stores/index.ts\` — all 12 barrel lines still point to existing files (the 9 remaining domain stores — investigation, incident, feed, notification, etc. — are scope of future M5 PRs per ADR-001).
- \`packages/api-gateway/src/repositories/types.ts\` — kept; still referenced by \`routes/feed.ts\` and \`services/chat-service.ts\` for \`IGatewayFeedStore\` / \`IGatewayDashboardStore\` interfaces.
- Top-level \`packages/data-layer/src/index.ts\` — no dangling exports; legacy entries already left as explanatory comments by M1-M4.

## Test plan

- [x] typecheck clean
- [x] data-layer suite 377/377 pass (10 skipped postgres)
- [ ] CI green