### PR TITLE
Wave 2.1: Promote flow (resource_promote + REST + UI)

### DIFF
--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -56,6 +56,8 @@ agentRegistry.register({
     'web_search',
     // Alert rules
     'alert_rule_write', 'alert_rule_list', 'alert_rule_history',
+    // Cross-folder promote (Wave 2 step 1)
+    'resource_promote',
     // Navigation
     'navigate',
     // Connector-model setup and allowlisted settings.

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -10,6 +10,8 @@ export type AgentToolName =
   | 'dashboard_rearrange' | 'dashboard_add_variable' | 'dashboard_set_title'
   // Folder tools (Wave 7)
   | 'folder_create' | 'folder_list'
+  // Promote a personal-draft resource into a shared/team folder (Wave 2 step 1)
+  | 'resource_promote'
   // Investigation lifecycle
   | 'investigation_create' | 'investigation_list'
   | 'investigation_add_section'

--- a/packages/agent-core/src/agent/handlers/index.ts
+++ b/packages/agent-core/src/agent/handlers/index.ts
@@ -58,6 +58,7 @@ export {
 export { handleWebSearch } from './web.js';
 export { handleNavigate } from './navigation.js';
 export { handleFolderCreate, handleFolderList } from './folder.js';
+export { handleResourcePromote } from './promote.js';
 export { handleOpsRunCommand } from './ops.js';
 
 export { handleRemediationPlanCreate, handleRemediationPlanCreateRescue } from './remediation-plan.js';

--- a/packages/agent-core/src/agent/handlers/promote.ts
+++ b/packages/agent-core/src/agent/handlers/promote.ts
@@ -1,0 +1,169 @@
+/**
+ * resource_promote — Wave 2 step 1.
+ *
+ * Promotes a personal-draft dashboard or alert rule into a shared folder.
+ * Mirrors the REST `/api/resources/:kind/:id/promote` semantics so the
+ * agent and the UI agree on classification and audit shape.
+ *
+ * Risk classification (matches docs/design/rfc-safety-patterns.md and the
+ * action-guard matrix):
+ *   - personal → shared:    risk = high
+ *     - user_conversation:  confirmationMode = strong_user_confirm
+ *     - background_agent:   confirmationMode = formal_approval
+ *   - shared → shared:      risk = medium (folder move within shared space)
+ *
+ * Audit: writes the matching `dashboard.promote` / `alert_rule.promote`
+ * entry through `ctx.auditWriter`.
+ *
+ * Provisioned: refuses via `assertWritable` — provisioned resources must
+ * be forked first (Wave 2 step 5).
+ */
+
+import {
+  ac,
+  ACTIONS,
+  AuditAction,
+  assertWritable,
+  ProvisionedResourceError,
+} from '@agentic-obs/common';
+import type { ActionContext } from './_context.js';
+import { withToolEventBoundary } from './_shared.js';
+
+type PromoteKind = 'dashboard' | 'alert_rule';
+
+function parseKind(raw: unknown): PromoteKind | null {
+  return raw === 'dashboard' || raw === 'alert_rule' ? raw : null;
+}
+
+export async function handleResourcePromote(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const kind = parseKind(args.kind);
+  if (!kind) {
+    return "Error: 'kind' must be 'dashboard' or 'alert_rule'.";
+  }
+  const id = typeof args.id === 'string' ? args.id.trim() : '';
+  if (!id) return "Error: 'id' is required.";
+  const targetFolderUid =
+    typeof args.target_folder_uid === 'string' ? args.target_folder_uid.trim() : '';
+  if (!targetFolderUid) return "Error: 'target_folder_uid' is required.";
+  const owner = typeof args.owner === 'string' ? args.owner : undefined;
+  const description = typeof args.description === 'string' ? args.description : undefined;
+
+  if (!ctx.folderRepository) {
+    return 'Error: folder backend not configured; cannot promote.';
+  }
+
+  return withToolEventBoundary(
+    ctx.sendEvent,
+    'resource_promote',
+    { kind, id, targetFolderUid },
+    `Promoting ${kind} ${id} → folder ${targetFolderUid}`,
+    async () => {
+      const target = await ctx.folderRepository!.findByUid(ctx.identity.orgId, targetFolderUid);
+      if (!target) {
+        return `Error: target folder ${targetFolderUid} not found.`;
+      }
+      if ((target.kind ?? 'shared') !== 'shared') {
+        return `Error: target folder ${target.uid} is not a shared folder (kind=${target.kind}).`;
+      }
+
+      // Resource lookup + source-folder detection.
+      let resourceName = '';
+      let currentFolderUid: string | null = null;
+      let ownerUserId = '';
+      let source: import('@agentic-obs/common').ResourceSource = 'manual';
+
+      if (kind === 'dashboard') {
+        const dashboard = await ctx.store.findById(id);
+        if (!dashboard || dashboard.workspaceId !== ctx.identity.orgId) {
+          return `Error: dashboard ${id} not found.`;
+        }
+        resourceName = dashboard.title;
+        currentFolderUid = dashboard.folder ?? null;
+        ownerUserId = dashboard.userId;
+        source = dashboard.source ?? 'manual';
+      } else {
+        if (!ctx.alertRuleStore.findById) {
+          return 'Error: alert rule store does not support findById.';
+        }
+        const rule = (await ctx.alertRuleStore.findById(id)) as
+          | import('@agentic-obs/common').AlertRule
+          | undefined;
+        if (!rule) return `Error: alert rule ${id} not found.`;
+        resourceName = rule.name;
+        currentFolderUid = rule.folderUid ?? null;
+        ownerUserId = rule.createdBy;
+        source = rule.source ?? 'manual';
+      }
+
+      try {
+        assertWritable({ kind, id, source });
+      } catch (err) {
+        if (err instanceof ProvisionedResourceError) {
+          return `Error: ${err.message}`;
+        }
+        throw err;
+      }
+
+      // Permission check: write on source UID + write on target folder.
+      const srcAction = kind === 'dashboard' ? ACTIONS.DashboardsWrite : ACTIONS.AlertRulesWrite;
+      const srcRes =
+        kind === 'dashboard' ? `dashboards:uid:${id}` : `alert.rules:uid:${id}`;
+      const srcOk = await ctx.accessControl.evaluate(
+        ctx.identity,
+        ac.eval(srcAction, srcRes),
+      );
+      if (!srcOk) {
+        return `Error: forbidden — missing ${srcAction} on ${kind} ${id}.`;
+      }
+      const dstOk = await ctx.accessControl.evaluate(
+        ctx.identity,
+        ac.eval(srcAction, `folders:uid:${target.uid}`),
+      );
+      if (!dstOk) {
+        return `Error: forbidden — missing ${srcAction} on target folder ${target.uid}.`;
+      }
+
+      // Apply the move. Description tidy-up rides along as a convenience for
+      // the chat surface (the user often refines the title/desc on promote).
+      if (kind === 'dashboard') {
+        await ctx.store.update(id, {
+          folder: target.uid,
+          ...(description !== undefined ? { description } : {}),
+        } as Parameters<typeof ctx.store.update>[1]);
+      } else if (ctx.alertRuleStore.update) {
+        await ctx.alertRuleStore.update(id, {
+          folderUid: target.uid,
+          ...(description !== undefined ? { description } : {}),
+          ...(owner !== undefined && owner !== ownerUserId ? { createdBy: owner } : {}),
+        });
+      } else {
+        return 'Error: alert rule store does not support update.';
+      }
+
+      const ownerChange =
+        owner !== undefined && owner !== ownerUserId
+          ? { from: ownerUserId, to: owner }
+          : undefined;
+      void ctx.auditWriter?.({
+        action: kind === 'dashboard' ? AuditAction.DashboardPromote : AuditAction.AlertRulePromote,
+        actorType: 'user',
+        actorId: ctx.identity.userId,
+        orgId: ctx.identity.orgId,
+        targetType: kind === 'dashboard' ? 'dashboard' : 'alert_rule',
+        targetId: id,
+        targetName: resourceName,
+        outcome: 'success',
+        metadata: {
+          fromFolder: currentFolderUid,
+          toFolder: target.uid,
+          ...(ownerChange ? { ownerChange } : {}),
+        },
+      });
+
+      return `Promoted ${kind} "${resourceName}" (id: ${id}) ${currentFolderUid ? `from folder ${currentFolderUid} ` : ''}to "${target.title}" (uid: ${target.uid}).`;
+    },
+  );
+}

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -42,6 +42,7 @@ export {
   handleNavigate,
   handleFolderCreate,
   handleFolderList,
+  handleResourcePromote,
   handleOpsRunCommand,
   handleRemediationPlanCreate,
   handleRemediationPlanCreateRescue,

--- a/packages/agent-core/src/agent/orchestrator-action-runner.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-runner.ts
@@ -39,6 +39,7 @@ import {
   handleNavigate,
   handleFolderCreate,
   handleFolderList,
+  handleResourcePromote,
   handleOpsRunCommand,
   handleRemediationPlanCreate,
   handleRemediationPlanCreateRescue,
@@ -194,6 +195,8 @@ async function dispatchAction(
     // Folder lifecycle (minimal — organize dashboards)
     case 'folder_create': return handleFolderCreate(ctx, args);
     case 'folder_list': return handleFolderList(ctx, args);
+    // Wave 2 step 1 — promote a personal-draft resource into a shared folder
+    case 'resource_promote': return handleResourcePromote(ctx, args);
     // Navigation
     case 'navigate': return handleNavigate(ctx, args);
     // Connector discovery (always allowed)

--- a/packages/agent-core/src/agent/permission-gate.ts
+++ b/packages/agent-core/src/agent/permission-gate.ts
@@ -44,6 +44,8 @@ const MUTATION_ACTIONS: ReadonlySet<string> = new Set([
   'investigation_create', 'investigation_add_section', 'investigation_complete',
   // alert_rule_write covers create / update / delete via the `op` discriminator
   'alert_rule_write',
+  // Wave 2 step 1 — moves a resource into a shared folder
+  'resource_promote',
 ]);
 
 /**

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -100,6 +100,16 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
     ),
   'folder_list': () => ac.eval('folders:read', 'folders:*'),
 
+  // -- Promote (Wave 2 step 1) ---------------------------------------------
+  // Layer-3 gate covers ONE side of the boundary — write on the source UID.
+  // The handler itself runs the second check (write on target folder) because
+  // the destination is only known once `target_folder_uid` is parsed.
+  'resource_promote': (args: Record<string, unknown>) => {
+    const kind = args.kind === 'alert_rule' ? 'alert.rules' : 'dashboards';
+    const resourceId = String(args.id ?? '*');
+    return ac.eval(`${kind}:write`, `${kind}:uid:${resourceId}`);
+  },
+
   // -- Investigation lifecycle ---------------------------------------------
   'investigation_create': () => ac.eval('investigations:create'),
   'investigation_list': () =>

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -969,6 +969,40 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
       },
     },
   },
+
+  // -------------------------------------------------------------------------
+  // Promote (Wave 2 step 1) — personal draft → shared folder
+  // -------------------------------------------------------------------------
+  'resource_promote': {
+    category: 'deferred',
+    schema: {
+      name: 'resource_promote',
+      description:
+        'Promote a personal-draft dashboard or alert rule into a shared/team folder. ' +
+        'Crosses a permission boundary — the move is HIGH risk and (when invoked from a ' +
+        'user conversation) requires `strong_user_confirm`; the background agent gets ' +
+        '`formal_approval`. The resource UID stays the same so existing links keep ' +
+        'working. Provisioned resources are refused — fork them first.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['dashboard', 'alert_rule'],
+            description: 'Which resource type to promote.',
+          },
+          id: { type: 'string', description: 'Resource id (dashboard.id or alert rule id).' },
+          target_folder_uid: {
+            type: 'string',
+            description: 'Destination shared folder uid. Must have folder.kind === "shared".',
+          },
+          owner: { type: 'string', description: 'Optional new owner userId. Defaults to current owner.' },
+          description: { type: 'string', description: 'Optional updated description.' },
+        },
+        required: ['kind', 'id', 'target_folder_uid'],
+      },
+    },
+  },
 };
 
 /**

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -42,6 +42,8 @@ import { createQueryRouter } from '../routes/dashboard/query.js';
 import { createSystemRouter } from '../routes/system.js';
 import { createDashboardRouter } from '../routes/dashboard/router.js';
 import { createAlertRulesRouter } from '../routes/alert-rules.js';
+import { createResourcesPromoteRouter } from '../routes/resources-promote.js';
+import { PromoteService } from '../services/promote-service.js';
 import { createNotificationsRouter } from '../routes/notifications.js';
 import { createVersionRouter } from '../routes/versions.js';
 import { createSearchRouter } from '../routes/search.js';
@@ -243,6 +245,16 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     ...(deps.runner ? { runner: deps.runner } : {}),
   }));
   // /api/folders is mounted in rbac-routes.ts (T7.1).
+  // Wave 2 step 1 — cross-folder promote endpoint for dashboards + alert rules.
+  app.use('/api/resources', createResourcesPromoteRouter({
+    promoteService: new PromoteService({
+      dashboards: repos.dashboards,
+      alertRules: eventAlertRuleStore,
+      folders: sharedFolderRepo,
+      accessControl,
+      audit: authSub.audit,
+    }),
+  }));
   app.use('/api/search', createSearchRouter({
     dashboardStore: repos.dashboards,
     alertRuleStore: eventAlertRuleStore,

--- a/packages/api-gateway/src/routes/resources-promote.ts
+++ b/packages/api-gateway/src/routes/resources-promote.ts
@@ -1,0 +1,119 @@
+/**
+ * /api/resources/:kind/:id/promote — Wave 2 step 1.
+ *
+ * Single endpoint that powers the promote-confirm flow:
+ *   - GET /preview is folded into POST without `?confirmed=true`.
+ *   - With `?confirmed=true` the promote actually runs.
+ *
+ * Body: `{ targetFolderUid, owner?, description? }`
+ *
+ * RBAC: PromoteService asserts BOTH source resource write AND target
+ * folder write. The route itself doesn't pre-gate (the service does the
+ * check during preview anyway — a single 403 path keeps the message
+ * consistent between preview and confirm).
+ */
+
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { authMiddleware } from '../middleware/auth.js';
+import {
+  PromoteService,
+  PromoteServiceError,
+  type PromoteKind,
+} from '../services/promote-service.js';
+import type { Identity } from '@agentic-obs/common';
+
+export interface ResourcesPromoteRouterDeps {
+  promoteService: PromoteService;
+}
+
+function parseKind(raw: string | undefined): PromoteKind | null {
+  if (raw === 'dashboard' || raw === 'alert_rule') return raw;
+  return null;
+}
+
+function handleError(err: unknown, res: Response): void {
+  if (err instanceof PromoteServiceError) {
+    const code = err.statusCode === 404
+      ? 'NOT_FOUND'
+      : err.statusCode === 403
+        ? 'FORBIDDEN'
+        : err.statusCode === 409
+          ? 'CONFLICT'
+          : 'VALIDATION';
+    res.status(err.statusCode).json({ error: { code, message: err.message } });
+    return;
+  }
+  res.status(500).json({
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: err instanceof Error ? err.message : 'internal error',
+    },
+  });
+}
+
+export function createResourcesPromoteRouter(deps: ResourcesPromoteRouterDeps): Router {
+  const router = Router();
+  router.use(authMiddleware);
+
+  router.post(
+    '/:kind/:id/promote',
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const kind = parseKind(req.params['kind']);
+        if (!kind) {
+          res.status(400).json({
+            error: {
+              code: 'VALIDATION',
+              message: "kind must be 'dashboard' or 'alert_rule'",
+            },
+          });
+          return;
+        }
+        const id = req.params['id'] ?? '';
+        if (!id) {
+          res.status(400).json({ error: { code: 'VALIDATION', message: 'id is required' } });
+          return;
+        }
+        const body = (req.body ?? {}) as {
+          targetFolderUid?: string;
+          owner?: string;
+          description?: string;
+        };
+        if (!body.targetFolderUid) {
+          res.status(400).json({
+            error: { code: 'VALIDATION', message: 'targetFolderUid is required' },
+          });
+          return;
+        }
+
+        const identity = (req as AuthenticatedRequest).auth as Identity;
+        const input = {
+          kind,
+          id,
+          targetFolderUid: body.targetFolderUid,
+          ...(body.owner !== undefined ? { owner: body.owner } : {}),
+          ...(body.description !== undefined ? { description: body.description } : {}),
+        };
+
+        const confirmed = req.query['confirmed'] === 'true' || req.query['confirmed'] === '1';
+        if (!confirmed) {
+          const preview = await deps.promoteService.preview(identity, input);
+          res.status(200).json({ kind: 'preview', preview });
+          return;
+        }
+        const result = await deps.promoteService.promote(identity, input);
+        res.status(200).json({ kind: 'result', result });
+      } catch (err) {
+        if (err instanceof PromoteServiceError) {
+          handleError(err, res);
+          return;
+        }
+        next(err);
+      }
+    },
+  );
+
+  return router;
+}

--- a/packages/api-gateway/src/services/promote-service.ts
+++ b/packages/api-gateway/src/services/promote-service.ts
@@ -1,0 +1,313 @@
+/**
+ * Promote service — Wave 2 step 1.
+ *
+ * Moves a personal-draft resource (dashboard or alert rule) out of a
+ * user's "My Workspace" (folder.kind === 'personal') into a shared
+ * team/service folder (folder.kind === 'shared').
+ *
+ * Promote does NOT copy. The resource UID stays the same — only the
+ * containing folder pointer (`dashboard.folder` / `alertRule.folderUid`)
+ * is updated. Cross-resource links remain unbroken.
+ *
+ * Why a separate service (vs. a PUT/folder patch):
+ *   1. Permission boundary crosses — RBAC asserts BOTH source and
+ *      target folder write access in one place.
+ *   2. GuardedAction integration — promote is classified as `high` risk
+ *      and (for user-driven calls) requires `strong_user_confirm`.
+ *   3. Distinct audit action — `DashboardPromote` / `AlertRulePromote`
+ *      so operators can filter promotions out of routine `update` noise.
+ *   4. Refuses provisioned resources (must `fork` first — Wave 2 step 5).
+ *
+ * The agent tool `resource_promote` is a thin wrapper around this service.
+ */
+
+import {
+  ACTIONS,
+  ac,
+  AuditAction,
+  assertWritable,
+  ProvisionedResourceError,
+} from '@agentic-obs/common';
+import type {
+  AlertRule,
+  Dashboard,
+  GrafanaFolder,
+  Identity,
+  IFolderRepository,
+} from '@agentic-obs/common';
+import type { IAlertRuleRepository, IGatewayDashboardStore } from '@agentic-obs/data-layer';
+import type { AuditWriter } from '../auth/audit-writer.js';
+import type { AccessControlSurface } from './accesscontrol-holder.js';
+
+export type PromoteKind = 'dashboard' | 'alert_rule';
+
+export interface PromoteInput {
+  kind: PromoteKind;
+  id: string;
+  targetFolderUid: string;
+  /** Optional new owner for the promoted resource. */
+  owner?: string;
+  /** Optional updated description (UI lets users tidy the draft on promote). */
+  description?: string;
+}
+
+export interface PromotePreview {
+  kind: PromoteKind;
+  id: string;
+  resourceName: string;
+  currentFolderUid: string | null;
+  currentFolderTitle: string | null;
+  targetFolderUid: string;
+  targetFolderTitle: string;
+  /** Visibility expansion message for the confirm dialog. */
+  visibility: string;
+  ownerUserId: string;
+  ownerChange?: { from: string; to: string };
+  /** Per the action-guard matrix for user_conversation/manual_ui × high. */
+  confirmationMode: 'strong_user_confirm';
+}
+
+export interface PromoteResult {
+  kind: PromoteKind;
+  id: string;
+  fromFolderUid: string | null;
+  toFolderUid: string;
+  ownerChange?: { from: string; to: string };
+}
+
+export class PromoteServiceError extends Error {
+  constructor(public readonly statusCode: number, message: string) {
+    super(message);
+    this.name = 'PromoteServiceError';
+  }
+}
+
+export interface PromoteServiceDeps {
+  dashboards: IGatewayDashboardStore;
+  alertRules: IAlertRuleRepository;
+  folders: IFolderRepository;
+  accessControl: AccessControlSurface;
+  audit?: AuditWriter;
+}
+
+/**
+ * Result of fetching a resource + its current folder. Internal-only; the
+ * preview/promote paths share the lookup.
+ */
+interface ResourceLookup {
+  kind: PromoteKind;
+  id: string;
+  name: string;
+  /** Resource's current folder uid (dashboard.folder / alertRule.folderUid). */
+  currentFolderUid: string | null;
+  ownerUserId: string;
+  source: import('@agentic-obs/common').ResourceSource;
+  /** The current folder row (null when the resource has no folder pointer). */
+  currentFolder: GrafanaFolder | null;
+}
+
+export class PromoteService {
+  constructor(private readonly deps: PromoteServiceDeps) {}
+
+  // -- Public API ------------------------------------------------------------
+
+  async preview(identity: Identity, input: PromoteInput): Promise<PromotePreview> {
+    const { lookup, target } = await this.resolve(identity.orgId, input);
+    await this.assertPermissions(identity, lookup, target);
+    return buildPreview(lookup, target, input);
+  }
+
+  async promote(identity: Identity, input: PromoteInput): Promise<PromoteResult> {
+    const { lookup, target } = await this.resolve(identity.orgId, input);
+    await this.assertPermissions(identity, lookup, target);
+
+    // Provisioned resources cannot be promoted — they're owned by a file
+    // or GitOps pipeline. The user has to fork first (Wave 2 step 5).
+    try {
+      assertWritable({ kind: lookup.kind, id: lookup.id, source: lookup.source });
+    } catch (err) {
+      if (err instanceof ProvisionedResourceError) {
+        throw new PromoteServiceError(409, err.message);
+      }
+      throw err;
+    }
+
+    const ownerChange =
+      input.owner !== undefined && input.owner !== lookup.ownerUserId
+        ? { from: lookup.ownerUserId, to: input.owner }
+        : undefined;
+
+    if (input.kind === 'dashboard') {
+      await this.deps.dashboards.update(input.id, {
+        folder: input.targetFolderUid,
+        ...(input.description !== undefined ? { description: input.description } : {}),
+      });
+    } else {
+      await this.deps.alertRules.update(input.id, {
+        folderUid: input.targetFolderUid,
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        ...(ownerChange ? { createdBy: ownerChange.to } : {}),
+      });
+    }
+
+    const auditAction =
+      input.kind === 'dashboard' ? AuditAction.DashboardPromote : AuditAction.AlertRulePromote;
+    void this.deps.audit?.log({
+      action: auditAction,
+      actorType: 'user',
+      actorId: identity.userId,
+      orgId: identity.orgId,
+      targetType: input.kind === 'dashboard' ? 'dashboard' : 'alert_rule',
+      targetId: input.id,
+      targetName: lookup.name,
+      outcome: 'success',
+      metadata: {
+        fromFolder: lookup.currentFolderUid,
+        toFolder: input.targetFolderUid,
+        ...(ownerChange ? { ownerChange } : {}),
+      },
+    });
+
+    return {
+      kind: input.kind,
+      id: input.id,
+      fromFolderUid: lookup.currentFolderUid,
+      toFolderUid: input.targetFolderUid,
+      ...(ownerChange ? { ownerChange } : {}),
+    };
+  }
+
+  // -- Internal --------------------------------------------------------------
+
+  private async resolve(
+    orgId: string,
+    input: PromoteInput,
+  ): Promise<{ lookup: ResourceLookup; target: GrafanaFolder }> {
+    const target = await this.deps.folders.findByUid(orgId, input.targetFolderUid);
+    if (!target) {
+      throw new PromoteServiceError(404, `target folder ${input.targetFolderUid} not found`);
+    }
+    // Default `kind` to 'shared' on absence — folders predating the field
+    // are team folders. Refusing here keeps the user from accidentally
+    // "promoting" into another personal workspace.
+    if ((target.kind ?? 'shared') !== 'shared') {
+      throw new PromoteServiceError(
+        400,
+        `target folder ${target.uid} is not a shared folder (kind=${target.kind})`,
+      );
+    }
+
+    const lookup = await this.fetchResource(orgId, input.kind, input.id);
+    return { lookup, target };
+  }
+
+  private async fetchResource(
+    orgId: string,
+    kind: PromoteKind,
+    id: string,
+  ): Promise<ResourceLookup> {
+    if (kind === 'dashboard') {
+      const dashboard = (await this.deps.dashboards.findById(id)) as Dashboard | undefined;
+      if (!dashboard || dashboard.workspaceId !== orgId) {
+        throw new PromoteServiceError(404, `dashboard ${id} not found`);
+      }
+      const folderUid = dashboard.folder ?? null;
+      const currentFolder = folderUid
+        ? await this.deps.folders.findByUid(orgId, folderUid)
+        : null;
+      return {
+        kind: 'dashboard',
+        id,
+        name: dashboard.title,
+        currentFolderUid: folderUid,
+        ownerUserId: dashboard.userId,
+        source: dashboard.source ?? 'manual',
+        currentFolder,
+      };
+    }
+    const rule = (await this.deps.alertRules.findById(id)) as AlertRule | undefined;
+    if (!rule || (rule as AlertRule & { workspaceId?: string }).workspaceId !== orgId) {
+      throw new PromoteServiceError(404, `alert rule ${id} not found`);
+    }
+    const folderUid = rule.folderUid ?? null;
+    const currentFolder = folderUid
+      ? await this.deps.folders.findByUid(orgId, folderUid)
+      : null;
+    return {
+      kind: 'alert_rule',
+      id,
+      name: rule.name,
+      currentFolderUid: folderUid,
+      ownerUserId: rule.createdBy,
+      source: rule.source ?? 'manual',
+      currentFolder,
+    };
+  }
+
+  private async assertPermissions(
+    identity: Identity,
+    lookup: ResourceLookup,
+    target: GrafanaFolder,
+  ): Promise<void> {
+    // Source: must have write on the existing resource (per UID).
+    const srcAction =
+      lookup.kind === 'dashboard' ? ACTIONS.DashboardsWrite : ACTIONS.AlertRulesWrite;
+    const srcRes =
+      lookup.kind === 'dashboard'
+        ? `dashboards:uid:${lookup.id}`
+        : `alert.rules:uid:${lookup.id}`;
+    const srcOk = await this.deps.accessControl.evaluate(identity, ac.eval(srcAction, srcRes));
+    if (!srcOk) {
+      throw new PromoteServiceError(
+        403,
+        `forbidden: missing write on source ${lookup.kind} ${lookup.id}`,
+      );
+    }
+
+    // Target: dashboards:write on the target folder (mirrors the
+    // dashboard create gate which authorizes against the destination
+    // folder, not the dashboard uid that doesn't exist yet).
+    const dstAction =
+      lookup.kind === 'dashboard' ? ACTIONS.DashboardsWrite : ACTIONS.AlertRulesWrite;
+    const dstOk = await this.deps.accessControl.evaluate(
+      identity,
+      ac.eval(dstAction, `folders:uid:${target.uid}`),
+    );
+    if (!dstOk) {
+      throw new PromoteServiceError(
+        403,
+        `forbidden: missing write on target folder ${target.uid}`,
+      );
+    }
+  }
+}
+
+function buildPreview(
+  lookup: ResourceLookup,
+  target: GrafanaFolder,
+  input: PromoteInput,
+): PromotePreview {
+  const targetTitle = target.title;
+  const visibility = `Will be visible to everyone with access to "${targetTitle}". Currently visible only to ${lookup.ownerUserId} (personal workspace).`;
+  const ownerChange =
+    input.owner !== undefined && input.owner !== lookup.ownerUserId
+      ? { from: lookup.ownerUserId, to: input.owner }
+      : undefined;
+  return {
+    kind: lookup.kind,
+    id: lookup.id,
+    resourceName: lookup.name,
+    currentFolderUid: lookup.currentFolderUid,
+    currentFolderTitle: lookup.currentFolder?.title ?? null,
+    targetFolderUid: target.uid,
+    targetFolderTitle: targetTitle,
+    visibility,
+    ownerUserId: lookup.ownerUserId,
+    ...(ownerChange ? { ownerChange } : {}),
+    // From action-guard.ts pickConfirmationMode: source=manual_ui/user_conversation,
+    // risk=high → 'strong_user_confirm'. Promote is high risk because it
+    // crosses a permission boundary (personal → shared) and the UID stays
+    // the same, so dangling references can't be re-checked after the fact.
+    confirmationMode: 'strong_user_confirm',
+  };
+}

--- a/packages/common/src/audit/actions.ts
+++ b/packages/common/src/audit/actions.ts
@@ -104,6 +104,10 @@ export const AuditAction = {
   AlertRuleCreate: 'alert_rule.create',
   AlertRuleUpdate: 'alert_rule.update',
   AlertRuleDelete: 'alert_rule.delete',
+  // Wave 2 step 1 — promotion of a personal draft alert rule into a
+  // shared/team folder. Crosses a permission boundary; written by the
+  // promote handler in addition to the GuardedAction audit.
+  AlertRulePromote: 'alert_rule.promote',
   InvestigationCreate: 'investigation.create',
   InvestigationUpdate: 'investigation.update',
   ServiceAttributionConfirm: 'service.attribution_confirm',

--- a/packages/common/src/models/folder.ts
+++ b/packages/common/src/models/folder.ts
@@ -10,6 +10,17 @@
  */
 import type { ResourceSource, ResourceProvenance } from '../resources/writable-gate.js';
 
+/**
+ * Workspace kind. `'personal'` folders are scoped to a single user's
+ * "My Workspace" — drafts live here while being authored. `'shared'`
+ * folders are team/service folders that other people can read. The
+ * promote flow (Wave 2 step 1) moves a resource personal → shared.
+ *
+ * Treat absence as `'shared'` (most folders pre-dating this field are
+ * team folders; personal folders are explicitly seeded with the marker).
+ */
+export type FolderKind = 'personal' | 'shared';
+
 export interface GrafanaFolder {
   id: string;
   uid: string;
@@ -17,6 +28,10 @@ export interface GrafanaFolder {
   title: string;
   description: string | null;
   parentUid: string | null;
+  /** See {@link FolderKind}. Absence → `'shared'`. */
+  kind?: FolderKind;
+  /** When `kind === 'personal'`, the userId that owns the workspace. */
+  ownerUserId?: string | null;
   created: string;
   updated: string;
   createdBy: string | null;
@@ -33,6 +48,8 @@ export interface NewGrafanaFolder {
   title: string;
   description?: string | null;
   parentUid?: string | null;
+  kind?: FolderKind;
+  ownerUserId?: string | null;
   createdBy?: string | null;
   updatedBy?: string | null;
   source?: ResourceSource;

--- a/packages/web/src/components/FolderPicker.tsx
+++ b/packages/web/src/components/FolderPicker.tsx
@@ -1,0 +1,91 @@
+/**
+ * FolderPicker — minimal &lt;select&gt; that lists folders accessible to the
+ * current user, optionally filtered to `kind === 'shared'`.
+ *
+ * Built on `/api/folders` (already RBAC-gated). The promote flow needs to
+ * exclude personal workspaces so the destination is always a team folder
+ * — `?kind=shared` is the canonical filter; we also defensively drop any
+ * `personal` rows the server might return (back-compat with folder rows
+ * predating the field, which default to `'shared'`).
+ *
+ * This is a small primitive on purpose. Tree drill-down / search can wait
+ * for a follow-up — the promote dialog only needs to pick ONE uid.
+ */
+
+import { useEffect, useState } from 'react';
+
+interface FolderRow {
+  uid: string;
+  title: string;
+  kind?: 'personal' | 'shared';
+}
+
+export interface FolderPickerProps {
+  kind?: 'personal' | 'shared';
+  value: string;
+  onChange: (uid: string) => void;
+}
+
+export default function FolderPicker({
+  kind,
+  value,
+  onChange,
+}: FolderPickerProps): React.ReactElement {
+  const [folders, setFolders] = useState<FolderRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const url = kind ? `/api/folders?kind=${kind}` : '/api/folders';
+    fetch(url, { credentials: 'include' })
+      .then(async (res) => {
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err?.error?.message ?? `request failed: ${res.status}`);
+        }
+        return res.json() as Promise<{ items?: FolderRow[] } | FolderRow[]>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const rows = Array.isArray(data) ? data : (data.items ?? []);
+        const filtered = kind
+          ? rows.filter((f) => (f.kind ?? 'shared') === kind)
+          : rows;
+        setFolders(filtered);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [kind]);
+
+  if (error) {
+    return <div className="text-sm text-[var(--color-error)]">{error}</div>;
+  }
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={loading}
+      className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)]"
+    >
+      <option value="">
+        {loading ? 'Loading folders…' : 'Pick a folder'}
+      </option>
+      {folders.map((f) => (
+        <option key={f.uid} value={f.uid}>
+          {f.title}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/web/src/components/PromoteDialog.tsx
+++ b/packages/web/src/components/PromoteDialog.tsx
@@ -1,0 +1,196 @@
+/**
+ * PromoteDialog — Wave 2 step 1.
+ *
+ * Two-phase flow against /api/resources/:kind/:id/promote:
+ *   1. Mount: POST without `?confirmed=true` to fetch the preview payload.
+ *   2. Confirm: POST with `?confirmed=true` after the user picks a target.
+ *
+ * The user picks `targetFolderUid` via <FolderPicker>, which is filtered
+ * server-side (via /api/folders?kind=shared) so personal workspaces never
+ * appear as a destination. The button copy mirrors the spec:
+ *   "Promote <name> to team?" → [Cancel] [Confirm promote]
+ *
+ * Wiring: drop this dialog onto any list row that exposes a draft. The
+ * MyWorkspace page (planned Wave 1 PR-C) is the canonical home; the
+ * existing Dashboards / Alerts list pages can adopt it incrementally.
+ */
+
+import { useEffect, useState } from 'react';
+import FolderPicker from './FolderPicker';
+
+export type PromoteResourceKind = 'dashboard' | 'alert_rule';
+
+export interface PromoteDialogProps {
+  open: boolean;
+  kind: PromoteResourceKind;
+  id: string;
+  /** Display name for the title (e.g. dashboard.title). */
+  resourceName: string;
+  onCancel: () => void;
+  onSuccess: (result: PromoteResultPayload) => void;
+}
+
+interface PromotePreview {
+  kind: PromoteResourceKind;
+  id: string;
+  resourceName: string;
+  currentFolderUid: string | null;
+  currentFolderTitle: string | null;
+  targetFolderUid: string;
+  targetFolderTitle: string;
+  visibility: string;
+  ownerUserId: string;
+  ownerChange?: { from: string; to: string };
+  confirmationMode: 'strong_user_confirm';
+}
+
+export interface PromoteResultPayload {
+  kind: PromoteResourceKind;
+  id: string;
+  fromFolderUid: string | null;
+  toFolderUid: string;
+  ownerChange?: { from: string; to: string };
+}
+
+async function callPromote(
+  kind: PromoteResourceKind,
+  id: string,
+  body: { targetFolderUid: string; owner?: string; description?: string },
+  confirmed: boolean,
+): Promise<{ kind: 'preview'; preview: PromotePreview } | { kind: 'result'; result: PromoteResultPayload }> {
+  const url = `/api/resources/${kind}/${id}/promote${confirmed ? '?confirmed=true' : ''}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err?.error?.message ?? `request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export default function PromoteDialog({
+  open,
+  kind,
+  id,
+  resourceName,
+  onCancel,
+  onSuccess,
+}: PromoteDialogProps): React.ReactElement | null {
+  const [targetFolderUid, setTargetFolderUid] = useState<string>('');
+  const [preview, setPreview] = useState<PromotePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch preview whenever the target changes. The body itself is the
+  // single source of truth — no separate GET endpoint needed.
+  useEffect(() => {
+    if (!open || !targetFolderUid) {
+      setPreview(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    callPromote(kind, id, { targetFolderUid }, false)
+      .then((data) => {
+        if (cancelled || data.kind !== 'preview') return;
+        setPreview(data.preview);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, kind, id, targetFolderUid]);
+
+  if (!open) return null;
+
+  const handleConfirm = async (): Promise<void> => {
+    if (!preview) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await callPromote(kind, id, { targetFolderUid: preview.targetFolderUid }, true);
+      if (data.kind === 'result') {
+        onSuccess(data.result);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onCancel} />
+      <div className="relative bg-[var(--color-surface-highest)] border border-[var(--color-outline-variant)] rounded-2xl shadow-2xl w-full max-w-md">
+        <div className="p-6">
+          <h3 className="text-base font-semibold text-[var(--color-on-surface)] mb-1">
+            Promote &ldquo;{resourceName}&rdquo; to team?
+          </h3>
+          <hr className="border-[var(--color-outline-variant)] my-3" />
+
+          <div className="space-y-3 text-sm text-[var(--color-on-surface-variant)]">
+            <div>
+              <label className="block text-xs uppercase tracking-wide mb-1">Promote to</label>
+              <FolderPicker
+                kind="shared"
+                value={targetFolderUid}
+                onChange={setTargetFolderUid}
+              />
+            </div>
+
+            {loading && <div>Loading preview…</div>}
+            {error && (
+              <div className="text-[var(--color-error)] text-sm">{error}</div>
+            )}
+            {preview && !loading && (
+              <>
+                <div>
+                  <span className="font-medium text-[var(--color-on-surface)]">Will be visible to:</span>{' '}
+                  {preview.targetFolderTitle}
+                </div>
+                <div>
+                  <span className="font-medium text-[var(--color-on-surface)]">Owner:</span>{' '}
+                  {preview.ownerChange ? `${preview.ownerChange.from} → ${preview.ownerChange.to}` : preview.ownerUserId}
+                </div>
+                <div>
+                  <span className="font-medium text-[var(--color-on-surface)]">Permissions:</span>{' '}
+                  team can read/edit
+                </div>
+                <div className="text-xs">{preview.visibility}</div>
+              </>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-3 mt-6">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2 text-sm font-medium text-[var(--color-on-surface-variant)] hover:text-[var(--color-on-surface)] border border-[var(--color-outline-variant)] rounded-lg hover:bg-[var(--color-surface-high)] transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={!preview || loading}
+              className="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-[var(--color-primary)] text-white disabled:opacity-50"
+            >
+              Confirm promote
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Wave 2 Step 1 — promote personal draft to shared team/service folder, with GuardedAction confirm + audit log.

**⚠️ Status:** agent hit rate limit before final test run. Typecheck clean. CI required to verify behavior.

## Changes

### Backend
- New agent tool \`resource_promote\` (\`handlers/promote.ts\`)
- New REST \`POST /api/resources/:kind/:id/promote\`
  - Without \`?confirmed\` → returns preview JSON (target name, visibility expansion)
  - With \`?confirmed=true\` → executes and returns result
- \`promote-service.ts\` orchestrates preview/confirm
- GuardedAction: high × user-driven → \`strong_user_confirm\`
- Reuses \`assertWritable\` — provisioned resources can't promote (must fork first)
- New audit action \`ALERT_RULE_PROMOTE\` (DASHBOARD_PROMOTE already in enum from Wave 1 PR-A)
- Audit logged with \`metadata: { fromFolder, toFolder }\`

### Frontend
- \`PromoteDialog.tsx\` — confirm dialog
- \`FolderPicker.tsx\` — filters to \`kind === 'shared'\` only

Resource UID preserved (move, not copy) — existing links/references stay intact.

## Test plan

- [x] typecheck clean
- [ ] CI green
- [ ] Manual: create dashboard in My Workspace, promote, verify it moves to selected folder and audit entry written
- [ ] Try promoting a \`provisioned_git\` dashboard — should reject with hint to fork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added resource promotion capability enabling users to move personal draft dashboards and alert rules into shared/team folders while maintaining the same resource ID
  * Implemented promotion preview with high-risk confirmation flow to ensure intentional cross-permission moves
  * Added folder picker component for selecting target shared folders
  * Promotion includes support for optional owner reassignment and description updates
  * Permission validation enforces write access on both source and target locations with comprehensive audit logging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/199)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->