### PR TITLE
Wave 2.4: Dashboard variable inference confirm (first-open ack)

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -215,6 +215,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     accessControl,
     setupConfig,
     audit: authSub.audit,
+    variableAcks: repos.dashboardVariableAcks,
   }));
   app.use('/api/chat', createChatRouter({
     dashboardStore: repos.dashboards,

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -7,7 +7,8 @@ import { authMiddleware } from '../../middleware/auth.js'
 import { createRequirePermission } from '../../middleware/require-permission.js'
 import type { IGatewayDashboardStore } from '@agentic-obs/data-layer'
 import { VariableResolver } from './variable-resolver.js'
-import { ac, ACTIONS, AuditAction, assertWritable, ProvisionedResourceError } from '@agentic-obs/common'
+import { ac, ACTIONS, AuditAction, assertWritable, ProvisionedResourceError, hashVariables } from '@agentic-obs/common'
+import type { IDashboardVariableAckRepository } from '@agentic-obs/common'
 import type { Dashboard, PanelConfig } from '@agentic-obs/common'
 import type { SetupConfigService } from '../../services/setup-config-service.js'
 import type { AuditWriter } from '../../auth/audit-writer.js'
@@ -37,6 +38,12 @@ export interface DashboardRouterDeps {
    * one; production wires the same writer used by auth routes.
    */
   audit?: AuditWriter
+  /**
+   * Wave 2 / Step 4 — per-user-per-dashboard ack store for inferred URL
+   * variables. Optional so legacy tests can omit it; routes that depend
+   * on it return 503 when missing.
+   */
+  variableAcks?: IDashboardVariableAckRepository
 }
 
 export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter {
@@ -44,6 +51,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
   const accessControl = deps.accessControl
   const setupConfig = deps.setupConfig
   const audit = deps.audit
+  const variableAcks = deps.variableAcks
 
   const router = Router()
   const requirePermission = createRequirePermission(accessControl)
@@ -395,6 +403,77 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       next(err)
     }
   })
+
+  // ── Wave 2 / Step 4: variable-inference ack endpoints ────────────────
+  //
+  // GET  /:uid/variable-ack?vars=<hash>     → { acked: boolean }
+  // POST /:uid/variable-ack body { vars }   → server hashes, upserts row
+  //
+  // Both require dashboards:read on the target dashboard. Ack is keyed by
+  // (userId, dashboardUid, varsHash) — see packages/common/src/utils/variable-hash.ts.
+
+  router.get(
+    '/:uid/variable-ack',
+    requirePermission((req) => ac.eval(ACTIONS.DashboardsRead, `dashboards:uid:${req.params['uid']}`)),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        if (!variableAcks) {
+          res.status(503).json({ error: { code: 'NOT_CONFIGURED', message: 'variable-ack repository not wired' } })
+          return
+        }
+        const uid = req.params['uid'] ?? ''
+        const varsHash = typeof req.query['vars'] === 'string' ? req.query['vars'] : ''
+        if (!varsHash) {
+          res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'vars query param required' } })
+          return
+        }
+        const userId = (req as AuthenticatedRequest).auth?.userId ?? 'anonymous'
+        const row = await variableAcks.findAck(userId, uid, varsHash)
+        res.json({ acked: row != null })
+      }
+      catch (err) {
+        next(err)
+      }
+    },
+  )
+
+  router.post(
+    '/:uid/variable-ack',
+    requirePermission((req) => ac.eval(ACTIONS.DashboardsRead, `dashboards:uid:${req.params['uid']}`)),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        if (!variableAcks) {
+          res.status(503).json({ error: { code: 'NOT_CONFIGURED', message: 'variable-ack repository not wired' } })
+          return
+        }
+        const uid = req.params['uid'] ?? ''
+        const body = req.body as { vars?: Record<string, unknown> } | undefined
+        const rawVars = body?.vars
+        if (!rawVars || typeof rawVars !== 'object' || Array.isArray(rawVars)) {
+          res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'vars object required' } })
+          return
+        }
+        // Coerce all values to strings — anything else (e.g. someone POSTing
+        // a nested object) is rejected so the hash domain stays {string→string}.
+        const vars: Record<string, string> = {}
+        for (const [k, v] of Object.entries(rawVars)) {
+          if (typeof v !== 'string') {
+            res.status(400).json({ error: { code: 'INVALID_INPUT', message: `vars.${k} must be a string` } })
+            return
+          }
+          vars[k] = v
+        }
+        const userId = (req as AuthenticatedRequest).auth?.userId ?? 'anonymous'
+        const orgId = resolveOrgId(req)
+        const varsHash = hashVariables(vars)
+        await variableAcks.ackVariables({ orgId, userId, dashboardUid: uid, varsHash })
+        res.json({ acked: true })
+      }
+      catch (err) {
+        next(err)
+      }
+    },
+  )
 
   return router
 }

--- a/packages/api-gateway/src/routes/dashboard/variable-ack.test.ts
+++ b/packages/api-gateway/src/routes/dashboard/variable-ack.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Wave 2 / Step 4 — variable-inference ack endpoint integration tests.
+ *
+ * Covers:
+ *   - first GET → acked:false; POST → 200; second GET (same hash) → acked:true
+ *   - GET with a different hash after acking → acked:false (banner returns)
+ *   - 400 on bad request bodies
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Dashboard } from '@agentic-obs/common';
+import { hashVariables } from '../../../../common/src/utils/variable-hash.js';
+import { InMemoryDashboardVariableAckRepository } from '../../../../data-layer/src/repository/memory/dashboard-variable-ack.js';
+import type { IGatewayDashboardStore } from '@agentic-obs/data-layer';
+
+// Patch the @agentic-obs/common module resolution so the router under test
+// uses the worktree-local hashVariables (the dist at the workspace symlink
+// target is built from an older revision that doesn't ship the helper).
+// Vitest's vi.mock with the canonical specifier ensures the same module
+// instance is returned regardless of which file imports it.
+import * as commonLocal from '../../../../common/src/index.js';
+vi.mock('@agentic-obs/common', () => commonLocal);
+import type { AccessControlSurface } from '../../services/accesscontrol-holder.js';
+import type { SetupConfigService } from '../../services/setup-config-service.js';
+import { createDashboardRouter } from './router.js';
+
+vi.mock('../../middleware/auth.js', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.auth = {
+      userId: req.headers['x-test-user'] ?? 'user_1',
+      orgId: 'org_main',
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  },
+}));
+
+function dashboard(): Dashboard {
+  return {
+    id: 'dash_1',
+    type: 'dashboard',
+    title: 'D',
+    description: '',
+    prompt: '',
+    userId: 'user_1',
+    status: 'ready',
+    panels: [],
+    variables: [],
+    refreshIntervalSec: 30,
+    datasourceIds: [],
+    useExistingMetrics: true,
+    workspaceId: 'org_main',
+    source: 'manual',
+    createdAt: '2026-04-26T00:00:00.000Z',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+  };
+}
+
+function makeStore(d: Dashboard): IGatewayDashboardStore {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(async () => d),
+    findAll: vi.fn(async () => [d]),
+    listByWorkspace: vi.fn(async () => [d]),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    updatePanels: vi.fn(),
+    updateVariables: vi.fn(),
+    delete: vi.fn(),
+    getFolderUid: vi.fn(async () => null),
+    size: vi.fn(async () => 0),
+    clear: vi.fn(),
+    toJSON: vi.fn(async () => []),
+    loadJSON: vi.fn(),
+  } as unknown as IGatewayDashboardStore;
+}
+
+function makeApp(opts: { variableAcks?: InMemoryDashboardVariableAckRepository } = {}) {
+  const accessControl: AccessControlSurface = {
+    evaluate: vi.fn(async () => true),
+    getUserPermissions: vi.fn(async () => []),
+    ensurePermissions: vi.fn(async () => []),
+    filterByPermission: vi.fn(async (_identity, items) => [...items]),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/dashboards',
+    createDashboardRouter({
+      store: makeStore(dashboard()),
+      accessControl,
+      setupConfig: { listConnectors: vi.fn() } as unknown as SetupConfigService,
+      variableAcks: opts.variableAcks,
+    }),
+  );
+  return app;
+}
+
+describe('GET/POST /dashboards/:uid/variable-ack', () => {
+  it('first GET returns acked:false; POST then GET returns acked:true', async () => {
+    const variableAcks = new InMemoryDashboardVariableAckRepository();
+    const app = makeApp({ variableAcks });
+
+    const vars = { service: 'ingress', namespace: 'prod' };
+    const hash = hashVariables(vars);
+
+    const before = await request(app).get(`/dashboards/dash_1/variable-ack?vars=${hash}`);
+    expect(before.status).toBe(200);
+    expect(before.body).toEqual({ acked: false });
+
+    const post = await request(app)
+      .post('/dashboards/dash_1/variable-ack')
+      .send({ vars });
+    expect(post.status).toBe(200);
+    expect(post.body).toEqual({ acked: true });
+
+    const after = await request(app).get(`/dashboards/dash_1/variable-ack?vars=${hash}`);
+    expect(after.status).toBe(200);
+    expect(after.body).toEqual({ acked: true });
+  });
+
+  it('different vars hash after ack still returns acked:false', async () => {
+    const variableAcks = new InMemoryDashboardVariableAckRepository();
+    const app = makeApp({ variableAcks });
+
+    await request(app)
+      .post('/dashboards/dash_1/variable-ack')
+      .send({ vars: { service: 'ingress' } });
+
+    const otherHash = hashVariables({ service: 'payments' });
+    const res = await request(app).get(`/dashboards/dash_1/variable-ack?vars=${otherHash}`);
+    expect(res.body).toEqual({ acked: false });
+  });
+
+  it('POST rejects non-object vars', async () => {
+    const variableAcks = new InMemoryDashboardVariableAckRepository();
+    const app = makeApp({ variableAcks });
+    const res = await request(app)
+      .post('/dashboards/dash_1/variable-ack')
+      .send({ vars: 'nope' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST rejects non-string values', async () => {
+    const variableAcks = new InMemoryDashboardVariableAckRepository();
+    const app = makeApp({ variableAcks });
+    const res = await request(app)
+      .post('/dashboards/dash_1/variable-ack')
+      .send({ vars: { service: 1 } });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET requires vars query param', async () => {
+    const variableAcks = new InMemoryDashboardVariableAckRepository();
+    const app = makeApp({ variableAcks });
+    const res = await request(app).get('/dashboards/dash_1/variable-ack');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when repo is not wired', async () => {
+    const app = makeApp({});
+    const res = await request(app).get('/dashboards/dash_1/variable-ack?vars=abc');
+    expect(res.status).toBe(503);
+  });
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -23,6 +23,7 @@ export * from './models/index.js';
 export * from './repositories/index.js';
 export * from './adapter-types.js';
 export * from './resources/index.js';
+export * from './utils/variable-hash.js';
 
 // Auth / perm types + pure helpers.
 export * from './auth/index.js';

--- a/packages/common/src/repositories/dashboard-variable-ack/index.ts
+++ b/packages/common/src/repositories/dashboard-variable-ack/index.ts
@@ -1,0 +1,1 @@
+export * from './interfaces.js';

--- a/packages/common/src/repositories/dashboard-variable-ack/interfaces.ts
+++ b/packages/common/src/repositories/dashboard-variable-ack/interfaces.ts
@@ -1,0 +1,56 @@
+/**
+ * Repository interface for per-user-per-dashboard variable inference acks
+ * (Wave 2 / Step 4).
+ *
+ * When a user lands on a dashboard with `?_inf_<key>=...` URL params we
+ * surface a banner so they can confirm those bindings before any panel
+ * query fires with them. Once they click "Use these" we persist a row
+ * here keyed by (user, dashboard, hash-of-vars). On subsequent opens
+ * with the same hash we apply silently. If the hash changes (e.g. the
+ * user navigates from a different service context) the banner returns.
+ *
+ * Implementations live in:
+ *   packages/data-layer/src/repository/sqlite/dashboard-variable-ack.ts
+ *   packages/data-layer/src/repository/postgres/dashboard-variable-ack.ts
+ *   packages/data-layer/src/repository/memory/dashboard-variable-ack.ts
+ */
+
+export interface DashboardVariableAck {
+  id: string;
+  orgId: string;
+  userId: string;
+  dashboardUid: string;
+  varsHash: string;
+  ackedAt: string;
+}
+
+export interface IDashboardVariableAckRepository {
+  /**
+   * Returns the existing ack row, or `null` if none. Callers typically only
+   * care about the boolean (`!= null`).
+   */
+  findAck(
+    userId: string,
+    dashboardUid: string,
+    varsHash: string,
+  ): Promise<DashboardVariableAck | null>;
+
+  /**
+   * Idempotent upsert keyed on (user, dashboard, hash). Re-acking the same
+   * variable set is a no-op (preserves the original `acked_at`).
+   */
+  ackVariables(input: {
+    orgId: string;
+    userId: string;
+    dashboardUid: string;
+    varsHash: string;
+  }): Promise<DashboardVariableAck>;
+
+  /**
+   * Clear every ack for one dashboard. Intended to be called when the
+   * dashboard's variable schema changes server-side; not currently wired
+   * to any caller — kept on the interface so the wiring is local when a
+   * future change needs it.
+   */
+  clearAcksForDashboard(dashboardUid: string): Promise<void>;
+}

--- a/packages/common/src/repositories/index.ts
+++ b/packages/common/src/repositories/index.ts
@@ -1,5 +1,6 @@
 export * from './auth/index.js';
 export * from './instance/index.js';
 export * from './dashboard/index.js';
+export * from './dashboard-variable-ack/index.js';
 export * from './investigation/index.js';
 export * from './alert-rule/index.js';

--- a/packages/common/src/utils/variable-hash.test.ts
+++ b/packages/common/src/utils/variable-hash.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { hashVariables, canonicalizeVariables } from './variable-hash.js';
+
+describe('hashVariables', () => {
+  it('produces the same hash regardless of key order', () => {
+    const a = hashVariables({ service: 'ingress', namespace: 'prod' });
+    const b = hashVariables({ namespace: 'prod', service: 'ingress' });
+    expect(a).toBe(b);
+  });
+
+  it('changes when any value changes', () => {
+    const a = hashVariables({ service: 'ingress', namespace: 'prod' });
+    const b = hashVariables({ service: 'ingress', namespace: 'staging' });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when a key is added', () => {
+    const a = hashVariables({ service: 'ingress' });
+    const b = hashVariables({ service: 'ingress', namespace: 'prod' });
+    expect(a).not.toBe(b);
+  });
+
+  it('drops keys with empty-string values', () => {
+    const a = hashVariables({ service: 'ingress' });
+    const b = hashVariables({ service: 'ingress', namespace: '' });
+    expect(a).toBe(b);
+  });
+
+  it('canonicalizes to sorted JSON', () => {
+    expect(canonicalizeVariables({ b: '2', a: '1' })).toBe('{"a":"1","b":"2"}');
+  });
+
+  it('returns 8 hex chars', () => {
+    expect(hashVariables({ x: 'y' })).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('treats {} as a stable hash', () => {
+    expect(hashVariables({})).toBe(hashVariables({}));
+    expect(canonicalizeVariables({})).toBe('{}');
+  });
+});

--- a/packages/common/src/utils/variable-hash.ts
+++ b/packages/common/src/utils/variable-hash.ts
@@ -1,0 +1,44 @@
+/**
+ * Stable hash for an inferred dashboard variable set.
+ *
+ * Wave 2 / Step 4 — used by both the frontend (to look up an existing ack)
+ * and the backend (to persist one). Same vars → same hash regardless of
+ * insertion order; one value changed → different hash. Keys with empty-
+ * string values are dropped so URLs like `?_inf_service=foo&_inf_namespace=`
+ * don't produce a different hash than `?_inf_service=foo`.
+ *
+ * The hash itself is a hex-encoded FNV-1a of the canonical JSON. FNV-1a is
+ * not cryptographic — we only need a stable, short, collision-resistant-
+ * enough identifier for a per-user-per-dashboard cache lookup. Avoiding
+ * `node:crypto` keeps this module importable from the web bundle (see the
+ * BOUNDARY RULE in packages/common/src/index.ts).
+ */
+
+/**
+ * Build the canonical string form of a variable set:
+ *   `{"k1":"v1","k2":"v2"}` with keys sorted lexicographically and entries
+ *   with empty string values removed.
+ *
+ * Exported for tests; production code should call `hashVariables` instead.
+ */
+export function canonicalizeVariables(vars: Record<string, string>): string {
+  const entries = Object.entries(vars)
+    .filter(([, v]) => v !== '')
+    .map(([k, v]) => [k, v] as const)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  // Hand-built JSON to avoid any platform variance in object key ordering.
+  const parts = entries.map(([k, v]) => `${JSON.stringify(k)}:${JSON.stringify(v)}`);
+  return `{${parts.join(',')}}`;
+}
+
+export function hashVariables(vars: Record<string, string>): string {
+  const canon = canonicalizeVariables(vars);
+  // FNV-1a 32-bit. Sufficient for cache-key use; not for security.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < canon.length; i++) {
+    hash ^= canon.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // Convert to unsigned then hex.
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -903,3 +903,25 @@ CREATE INDEX IF NOT EXISTS ix_llm_audit_org_id      ON llm_audit(org_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_user_id     ON llm_audit(user_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_session_id  ON llm_audit(session_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_model       ON llm_audit(model);
+
+-- ============================================================================
+-- Dashboard variable inference acks (Wave 2 / Step 4)
+--
+-- One row per (user, dashboard, vars-hash). The presence of a row means the
+-- user has confirmed those inferred variables for this dashboard and the
+-- banner should not re-prompt them on future opens with the same hash. See
+-- packages/common/src/utils/variable-hash.ts for the canonical hash form.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS dashboard_variable_ack (
+  id             TEXT PRIMARY KEY,
+  org_id         TEXT NOT NULL,
+  user_id        TEXT NOT NULL,
+  dashboard_uid  TEXT NOT NULL,
+  vars_hash      TEXT NOT NULL,
+  acked_at       TEXT NOT NULL,
+  UNIQUE(user_id, dashboard_uid, vars_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_var_ack
+  ON dashboard_variable_ack(user_id, dashboard_uid);

--- a/packages/data-layer/src/db/sqlite-schema.ts
+++ b/packages/data-layer/src/db/sqlite-schema.ts
@@ -590,3 +590,27 @@ export const chatSessionEvents = sqliteTable(
     index('chat_session_events_seq_idx').on(t.sessionId, t.seq),
   ],
 );
+
+// — dashboard variable inference acks (Wave 2 / Step 4). One row per
+//   (user, dashboard, hash-of-inferred-vars). Banner is suppressed when a
+//   row exists. See packages/common/src/utils/variable-hash.ts.
+
+export const dashboardVariableAck = sqliteTable(
+  'dashboard_variable_ack',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    userId: text('user_id').notNull(),
+    dashboardUid: text('dashboard_uid').notNull(),
+    varsHash: text('vars_hash').notNull(),
+    ackedAt: text('acked_at').notNull(),
+  },
+  (t) => [
+    uniqueIndex('dashboard_variable_ack_unique').on(
+      t.userId,
+      t.dashboardUid,
+      t.varsHash,
+    ),
+    index('idx_var_ack').on(t.userId, t.dashboardUid),
+  ],
+);

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -20,6 +20,7 @@ import type {
 import type { IInvestigationRepository as SqliteInvestigationRepositoryInterface } from './sqlite/investigation.js';
 import type {
   IDashboardRepository,
+  IDashboardVariableAckRepository,
   IInstanceConfigRepository,
   INotificationChannelRepository,
 } from '@agentic-obs/common';
@@ -37,6 +38,7 @@ import { SqliteFeedItemRepository } from './sqlite/feed.js';
 import { SqliteApprovalRequestRepository } from './sqlite/approval.js';
 import { SqliteShareLinkRepository } from './sqlite/share.js';
 import { DashboardRepository as SqliteDashboardRepository } from './sqlite/dashboard.js';
+import { SqliteDashboardVariableAckRepository } from './sqlite/dashboard-variable-ack.js';
 import { SqliteFolderRepository } from './sqlite/folder.js';
 import { SqliteAlertRuleRepository } from './sqlite/alert-rule.js';
 import { SqliteNotificationRepository } from './sqlite/notification.js';
@@ -56,6 +58,7 @@ import { PostgresFeedItemRepository } from './postgres/feed.js';
 import { PostgresApprovalRequestRepository } from './postgres/approval.js';
 import { PostgresShareLinkRepository } from './postgres/share.js';
 import { DashboardRepository as PostgresDashboardRepository } from './postgres/dashboard.js';
+import { PostgresDashboardVariableAckRepository } from './postgres/dashboard-variable-ack.js';
 import { PostgresFolderRepository } from './postgres/folder.js';
 import { PostgresAlertRuleRepository } from './postgres/alert-rule.js';
 import { PostgresNotificationRepository } from './postgres/notification.js';
@@ -95,6 +98,7 @@ export interface RepositoryBundle {
   approvals: IApprovalRequestRepository & IGatewayApprovalStore;
   shares: IShareLinkRepository & IGatewayShareStore;
   dashboards: IDashboardRepository;
+  dashboardVariableAcks: IDashboardVariableAckRepository;
   folders: IFolderRepository;
   alertRules: IAlertRuleRepository;
   notifications: INotificationRepository;
@@ -122,6 +126,7 @@ export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
     approvals: new SqliteApprovalRequestRepository(db),
     shares: new SqliteShareLinkRepository(db),
     dashboards: new SqliteDashboardRepository(db),
+    dashboardVariableAcks: new SqliteDashboardVariableAckRepository(db),
     folders: new SqliteFolderRepository(db),
     alertRules: new SqliteAlertRuleRepository(db),
     notifications: new SqliteNotificationRepository(db),
@@ -150,6 +155,7 @@ export function createPostgresRepositories(db: DbClient): RepositoryBundle {
     approvals: new PostgresApprovalRequestRepository(db),
     shares: new PostgresShareLinkRepository(db),
     dashboards: new PostgresDashboardRepository(db),
+    dashboardVariableAcks: new PostgresDashboardVariableAckRepository(db),
     folders: new PostgresFolderRepository(db),
     alertRules: new PostgresAlertRuleRepository(db),
     notifications: new PostgresNotificationRepository(db),

--- a/packages/data-layer/src/repository/memory/dashboard-variable-ack.ts
+++ b/packages/data-layer/src/repository/memory/dashboard-variable-ack.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory implementation of `IDashboardVariableAckRepository`
+ * (Wave 2 / Step 4). Test fixture only — production wiring uses the
+ * SQLite or Postgres repository.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  DashboardVariableAck,
+  IDashboardVariableAckRepository,
+} from '@agentic-obs/common';
+
+function key(userId: string, dashboardUid: string, varsHash: string): string {
+  return `${userId}|${dashboardUid}|${varsHash}`;
+}
+
+export class InMemoryDashboardVariableAckRepository
+  implements IDashboardVariableAckRepository
+{
+  private readonly rows = new Map<string, DashboardVariableAck>();
+
+  async findAck(
+    userId: string,
+    dashboardUid: string,
+    varsHash: string,
+  ): Promise<DashboardVariableAck | null> {
+    return this.rows.get(key(userId, dashboardUid, varsHash)) ?? null;
+  }
+
+  async ackVariables(input: {
+    orgId: string;
+    userId: string;
+    dashboardUid: string;
+    varsHash: string;
+  }): Promise<DashboardVariableAck> {
+    const k = key(input.userId, input.dashboardUid, input.varsHash);
+    const existing = this.rows.get(k);
+    if (existing) return existing;
+    const row: DashboardVariableAck = {
+      id: randomUUID(),
+      orgId: input.orgId,
+      userId: input.userId,
+      dashboardUid: input.dashboardUid,
+      varsHash: input.varsHash,
+      ackedAt: new Date().toISOString(),
+    };
+    this.rows.set(k, row);
+    return row;
+  }
+
+  async clearAcksForDashboard(dashboardUid: string): Promise<void> {
+    for (const [k, row] of this.rows.entries()) {
+      if (row.dashboardUid === dashboardUid) this.rows.delete(k);
+    }
+  }
+}

--- a/packages/data-layer/src/repository/memory/index.ts
+++ b/packages/data-layer/src/repository/memory/index.ts
@@ -5,3 +5,4 @@
 
 export { InMemoryAlertRuleRepository } from './alert-rule.js';
 export { InMemoryDashboardRepository } from './dashboard.js';
+export { InMemoryDashboardVariableAckRepository } from './dashboard-variable-ack.js';

--- a/packages/data-layer/src/repository/postgres/dashboard-variable-ack.ts
+++ b/packages/data-layer/src/repository/postgres/dashboard-variable-ack.ts
@@ -1,0 +1,84 @@
+/**
+ * Postgres implementation of `IDashboardVariableAckRepository`
+ * (Wave 2 / Step 4). Mirror of the SQLite implementation.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import type {
+  DashboardVariableAck,
+  IDashboardVariableAckRepository,
+} from '@agentic-obs/common';
+import { dashboardVariableAck } from './schema.js';
+
+type Row = typeof dashboardVariableAck.$inferSelect;
+
+function rowToAck(row: Row): DashboardVariableAck {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    userId: row.userId,
+    dashboardUid: row.dashboardUid,
+    varsHash: row.varsHash,
+    ackedAt: row.ackedAt,
+  };
+}
+
+export class PostgresDashboardVariableAckRepository
+  implements IDashboardVariableAckRepository
+{
+  constructor(private readonly db: any) {}
+
+  async findAck(
+    userId: string,
+    dashboardUid: string,
+    varsHash: string,
+  ): Promise<DashboardVariableAck | null> {
+    const [row] = await this.db
+      .select()
+      .from(dashboardVariableAck)
+      .where(
+        and(
+          eq(dashboardVariableAck.userId, userId),
+          eq(dashboardVariableAck.dashboardUid, dashboardUid),
+          eq(dashboardVariableAck.varsHash, varsHash),
+        ),
+      );
+    return row ? rowToAck(row) : null;
+  }
+
+  async ackVariables(input: {
+    orgId: string;
+    userId: string;
+    dashboardUid: string;
+    varsHash: string;
+  }): Promise<DashboardVariableAck> {
+    const existing = await this.findAck(
+      input.userId,
+      input.dashboardUid,
+      input.varsHash,
+    );
+    if (existing) return existing;
+    const row: Row = {
+      id: randomUUID(),
+      orgId: input.orgId,
+      userId: input.userId,
+      dashboardUid: input.dashboardUid,
+      varsHash: input.varsHash,
+      ackedAt: new Date().toISOString(),
+    };
+    await this.db.insert(dashboardVariableAck).values(row).onConflictDoNothing();
+    const fresh = await this.findAck(
+      input.userId,
+      input.dashboardUid,
+      input.varsHash,
+    );
+    return fresh ?? rowToAck(row);
+  }
+
+  async clearAcksForDashboard(dashboardUid: string): Promise<void> {
+    await this.db
+      .delete(dashboardVariableAck)
+      .where(eq(dashboardVariableAck.dashboardUid, dashboardUid));
+  }
+}

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -891,3 +891,20 @@ CREATE INDEX IF NOT EXISTS ix_llm_audit_org_id      ON llm_audit(org_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_user_id     ON llm_audit(user_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_session_id  ON llm_audit(session_id);
 CREATE INDEX IF NOT EXISTS ix_llm_audit_model       ON llm_audit(model);
+
+-- ============================================================================
+-- Dashboard variable inference acks (Wave 2 / Step 4). See sqlite-schema.sql.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS dashboard_variable_ack (
+  id             TEXT PRIMARY KEY,
+  org_id         TEXT NOT NULL,
+  user_id        TEXT NOT NULL,
+  dashboard_uid  TEXT NOT NULL,
+  vars_hash      TEXT NOT NULL,
+  acked_at       TEXT NOT NULL,
+  UNIQUE(user_id, dashboard_uid, vars_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_var_ack
+  ON dashboard_variable_ack(user_id, dashboard_uid);

--- a/packages/data-layer/src/repository/postgres/schema.ts
+++ b/packages/data-layer/src/repository/postgres/schema.ts
@@ -301,3 +301,26 @@ export const chatSessionEvents = pgTable(
     index('pg_repo_chat_session_events_seq_idx').on(t.sessionId, t.seq),
   ],
 );
+
+// — dashboard variable inference acks (Wave 2 / Step 4). Mirror of the
+//   SQLite table. See packages/common/src/utils/variable-hash.ts for the hash.
+
+export const dashboardVariableAck = pgTable(
+  'dashboard_variable_ack',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    userId: text('user_id').notNull(),
+    dashboardUid: text('dashboard_uid').notNull(),
+    varsHash: text('vars_hash').notNull(),
+    ackedAt: text('acked_at').notNull(),
+  },
+  (t) => [
+    uniqueIndex('pg_repo_dashboard_variable_ack_unique').on(
+      t.userId,
+      t.dashboardUid,
+      t.varsHash,
+    ),
+    index('pg_repo_idx_var_ack').on(t.userId, t.dashboardUid),
+  ],
+);

--- a/packages/data-layer/src/repository/sqlite/dashboard-variable-ack.test.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard-variable-ack.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from '../../test-support/test-db.js';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { SqliteDashboardVariableAckRepository } from './dashboard-variable-ack.js';
+
+describe('SqliteDashboardVariableAckRepository', () => {
+  let db: SqliteClient;
+  let repo: SqliteDashboardVariableAckRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new SqliteDashboardVariableAckRepository(db);
+  });
+
+  it('findAck returns null when no row exists', async () => {
+    expect(await repo.findAck('u1', 'd1', 'h1')).toBeNull();
+  });
+
+  it('ackVariables inserts a row that findAck returns', async () => {
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    const row = await repo.findAck('u1', 'd1', 'h1');
+    expect(row).not.toBeNull();
+    expect(row!.userId).toBe('u1');
+    expect(row!.dashboardUid).toBe('d1');
+    expect(row!.varsHash).toBe('h1');
+    expect(row!.orgId).toBe('org_main');
+  });
+
+  it('ackVariables is idempotent on (user, dashboard, hash)', async () => {
+    const first = await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    const second = await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    expect(second.id).toBe(first.id);
+    expect(second.ackedAt).toBe(first.ackedAt);
+  });
+
+  it('distinguishes acks by hash', async () => {
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    expect(await repo.findAck('u1', 'd1', 'h1')).not.toBeNull();
+    expect(await repo.findAck('u1', 'd1', 'h2')).toBeNull();
+  });
+
+  it('distinguishes acks by user', async () => {
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    expect(await repo.findAck('u2', 'd1', 'h1')).toBeNull();
+  });
+
+  it('clearAcksForDashboard removes every row for that dashboard', async () => {
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd1', varsHash: 'h1' });
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u2', dashboardUid: 'd1', varsHash: 'h2' });
+    await repo.ackVariables({ orgId: 'org_main', userId: 'u1', dashboardUid: 'd2', varsHash: 'h1' });
+    await repo.clearAcksForDashboard('d1');
+    expect(await repo.findAck('u1', 'd1', 'h1')).toBeNull();
+    expect(await repo.findAck('u2', 'd1', 'h2')).toBeNull();
+    // unrelated dashboard untouched
+    expect(await repo.findAck('u1', 'd2', 'h1')).not.toBeNull();
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/dashboard-variable-ack.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard-variable-ack.ts
@@ -1,0 +1,87 @@
+/**
+ * SQLite implementation of `IDashboardVariableAckRepository`
+ * (Wave 2 / Step 4 — dashboard variable inference confirm).
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import type {
+  DashboardVariableAck,
+  IDashboardVariableAckRepository,
+} from '@agentic-obs/common';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { dashboardVariableAck } from '../../db/sqlite-schema.js';
+
+type Row = typeof dashboardVariableAck.$inferSelect;
+
+function rowToAck(row: Row): DashboardVariableAck {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    userId: row.userId,
+    dashboardUid: row.dashboardUid,
+    varsHash: row.varsHash,
+    ackedAt: row.ackedAt,
+  };
+}
+
+export class SqliteDashboardVariableAckRepository
+  implements IDashboardVariableAckRepository
+{
+  constructor(private readonly db: SqliteClient) {}
+
+  async findAck(
+    userId: string,
+    dashboardUid: string,
+    varsHash: string,
+  ): Promise<DashboardVariableAck | null> {
+    const [row] = await this.db
+      .select()
+      .from(dashboardVariableAck)
+      .where(
+        and(
+          eq(dashboardVariableAck.userId, userId),
+          eq(dashboardVariableAck.dashboardUid, dashboardUid),
+          eq(dashboardVariableAck.varsHash, varsHash),
+        ),
+      );
+    return row ? rowToAck(row) : null;
+  }
+
+  async ackVariables(input: {
+    orgId: string;
+    userId: string;
+    dashboardUid: string;
+    varsHash: string;
+  }): Promise<DashboardVariableAck> {
+    const existing = await this.findAck(
+      input.userId,
+      input.dashboardUid,
+      input.varsHash,
+    );
+    if (existing) return existing;
+    const row: Row = {
+      id: randomUUID(),
+      orgId: input.orgId,
+      userId: input.userId,
+      dashboardUid: input.dashboardUid,
+      varsHash: input.varsHash,
+      ackedAt: new Date().toISOString(),
+    };
+    await this.db.insert(dashboardVariableAck).values(row).onConflictDoNothing();
+    // Re-read to cover the race where two requests upsert the same key — the
+    // returned row is always the one persisted.
+    const fresh = await this.findAck(
+      input.userId,
+      input.dashboardUid,
+      input.varsHash,
+    );
+    return fresh ?? rowToAck(row);
+  }
+
+  async clearAcksForDashboard(dashboardUid: string): Promise<void> {
+    await this.db
+      .delete(dashboardVariableAck)
+      .where(eq(dashboardVariableAck.dashboardUid, dashboardUid));
+  }
+}

--- a/packages/web/src/components/VariableInferenceBanner.tsx
+++ b/packages/web/src/components/VariableInferenceBanner.tsx
@@ -1,0 +1,69 @@
+/**
+ * Wave 2 / Step 4 — banner shown above the panel grid when a dashboard is
+ * opened with `?_inf_<key>=...` URL params the current user hasn't yet
+ * acked. See packages/web/src/hooks/useInferredVariables.ts.
+ *
+ *   ╔════════════════════════════════════════════════════════════════╗
+ *   ║ Showing data for                                               ║
+ *   ║   service = ingress-gateway   namespace = prod                 ║
+ *   ║   (inferred from Service page context)                         ║
+ *   ║   [Use these]  [Change variables]  [Don't auto-bind]           ║
+ *   ╚════════════════════════════════════════════════════════════════╝
+ */
+
+import React from 'react';
+
+interface Props {
+  vars: Record<string, string>;
+  onAccept: () => void | Promise<void>;
+  onChange: () => void;
+  onDismiss: () => void;
+}
+
+export default function VariableInferenceBanner({ vars, onAccept, onChange, onDismiss }: Props) {
+  const entries = Object.entries(vars);
+  return (
+    <div
+      className="shrink-0 px-6 py-3 border-b border-outline-variant bg-primary-container/30 text-on-surface"
+      role="region"
+      aria-label="Inferred dashboard variables"
+    >
+      <div className="text-sm font-medium mb-1">Showing data for</div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+        {entries.map(([k, v]) => (
+          <span key={k} className="font-mono">
+            <span className="text-on-surface-variant">{k}</span>
+            <span className="mx-1">=</span>
+            <span className="font-semibold">{v}</span>
+          </span>
+        ))}
+      </div>
+      <div className="mt-1 text-xs text-on-surface-variant">
+        (inferred from Service page context)
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => void onAccept()}
+          className="px-3 py-1.5 text-sm rounded-md bg-primary text-on-primary hover:opacity-90"
+        >
+          Use these
+        </button>
+        <button
+          type="button"
+          onClick={onChange}
+          className="px-3 py-1.5 text-sm rounded-md border border-outline-variant hover:bg-surface-low"
+        >
+          Change variables
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="px-3 py-1.5 text-sm rounded-md hover:bg-surface-low text-on-surface-variant"
+        >
+          Don't auto-bind
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/useInferredVariables.ts
+++ b/packages/web/src/hooks/useInferredVariables.ts
@@ -1,0 +1,116 @@
+/**
+ * Wave 2 / Step 4 — dashboard variable inference confirm.
+ *
+ * Reads `?_inf_<key>=<value>` query params from the URL. If any are present
+ * and the user hasn't yet acked this exact variable set for this dashboard,
+ * the hook reports `state: 'needs-ack'` and the workspace renders the
+ * VariableInferenceBanner. The user can then:
+ *   - "Use these": POST the ack, hook flips to 'applied', vars are bound.
+ *   - "Change variables": parent opens the existing variable picker.
+ *   - "Don't auto-bind": session-only dismiss; nothing persisted.
+ *
+ * If the URL params change (e.g. user navigates from a different service
+ * context) the hash changes and the banner re-appears even if previously
+ * acked. This is the whole point — wrong-namespace data is high stakes.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { hashVariables } from '@agentic-obs/common';
+import { apiClient } from '../api/client.js';
+
+const INF_PREFIX = '_inf_';
+
+export type InferredState =
+  | { kind: 'none' }
+  | { kind: 'checking'; vars: Record<string, string>; hash: string }
+  | { kind: 'needs-ack'; vars: Record<string, string>; hash: string }
+  | { kind: 'applied'; vars: Record<string, string>; hash: string }
+  | { kind: 'dismissed'; vars: Record<string, string>; hash: string };
+
+export interface UseInferredVariablesResult {
+  state: InferredState;
+  /** Persist the ack and transition to 'applied'. */
+  accept: () => Promise<void>;
+  /** Session-only dismiss — does not persist. Banner stays hidden this page load only. */
+  dismiss: () => void;
+}
+
+/**
+ * Parse `?_inf_<k>=<v>` params out of a query string. Keys with empty
+ * values are dropped (matches the hash semantics — see variable-hash.ts).
+ *
+ * Edge case: if the same `_inf_` key appears twice we take the *first*
+ * value. `URLSearchParams.get` already does this; the explicit comment
+ * is for the next reader.
+ */
+export function parseInferredFromSearch(search: string): Record<string, string> {
+  const params = new URLSearchParams(search);
+  const out: Record<string, string> = {};
+  for (const [k, v] of params.entries()) {
+    if (!k.startsWith(INF_PREFIX)) continue;
+    if (v === '') continue;
+    const stripped = k.slice(INF_PREFIX.length);
+    if (stripped in out) continue;
+    out[stripped] = v;
+  }
+  return out;
+}
+
+export function useInferredVariables(dashboardUid: string | undefined): UseInferredVariablesResult {
+  const location = useLocation();
+  const vars = useMemo(() => parseInferredFromSearch(location.search), [location.search]);
+  const hasVars = Object.keys(vars).length > 0;
+  const hash = useMemo(() => (hasVars ? hashVariables(vars) : ''), [vars, hasVars]);
+
+  const [state, setState] = useState<InferredState>(() =>
+    hasVars ? { kind: 'checking', vars, hash } : { kind: 'none' },
+  );
+
+  // Reset state when URL hash changes — different service context, new ack.
+  useEffect(() => {
+    if (!hasVars) {
+      setState({ kind: 'none' });
+      return;
+    }
+    setState({ kind: 'checking', vars, hash });
+  }, [hash, hasVars, vars]);
+
+  // Fetch the ack status.
+  useEffect(() => {
+    if (!hasVars || !dashboardUid) return;
+    let cancelled = false;
+    void apiClient
+      .get<{ acked: boolean }>(`/dashboards/${dashboardUid}/variable-ack?vars=${hash}`)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.error || !res.data) {
+          // If we can't check, fall back to showing the banner. Better to
+          // ask the user than silently bind possibly-wrong variables.
+          setState({ kind: 'needs-ack', vars, hash });
+          return;
+        }
+        setState(
+          res.data.acked
+            ? { kind: 'applied', vars, hash }
+            : { kind: 'needs-ack', vars, hash },
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hash, hasVars, dashboardUid, vars]);
+
+  const accept = useCallback(async () => {
+    if (!dashboardUid || !hasVars) return;
+    await apiClient.post(`/dashboards/${dashboardUid}/variable-ack`, { vars });
+    setState({ kind: 'applied', vars, hash });
+  }, [dashboardUid, hasVars, vars, hash]);
+
+  const dismiss = useCallback(() => {
+    if (!hasVars) return;
+    setState({ kind: 'dismissed', vars, hash });
+  }, [hasVars, vars, hash]);
+
+  return { state, accept, dismiss };
+}

--- a/packages/web/src/pages/DashboardWorkspace.tsx
+++ b/packages/web/src/pages/DashboardWorkspace.tsx
@@ -6,6 +6,8 @@ import { queryScheduler } from '../api/query-scheduler.js';
 import DashboardGrid from '../components/DashboardGrid.js';
 import PanelEditor from '../components/PanelEditor.js';
 import VariableBar from '../components/VariableBar.js';
+import VariableInferenceBanner from '../components/VariableInferenceBanner.js';
+import { useInferredVariables } from '../hooks/useInferredVariables.js';
 import InvestigationReportView from '../components/InvestigationReportView.js';
 import { useDashboardChat } from '../hooks/useDashboardChat.js';
 import { useGlobalChat } from '../contexts/ChatContext.js';
@@ -330,6 +332,11 @@ export default function DashboardWorkspace() {
     [setVariables],
   );
 
+  // Wave 2.4 — variable inference confirm. When the URL carries _inf_<k>=...
+  // params we surface a banner; only `state.kind === 'applied'` flows the
+  // inferred bindings into panel queries. 'needs-ack' / 'dismissed' do not.
+  const inferred = useInferredVariables(id);
+
   // Resolved variable values for `${name}` substitution in panel queries.
   // Today only `$datasource` flows through here, but the map shape lets us
   // add label/tag substitution later without touching every panel.
@@ -338,8 +345,13 @@ export default function DashboardWorkspace() {
     for (const v of variables) {
       if (v.current) out[v.name] = v.current;
     }
+    if (inferred.state.kind === 'applied') {
+      for (const [k, v] of Object.entries(inferred.state.vars)) {
+        out[k] = v;
+      }
+    }
     return out;
-  }, [variables]);
+  }, [variables, inferred.state]);
 
   // Title editing
 
@@ -744,6 +756,17 @@ export default function DashboardWorkspace() {
 
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 flex flex-col min-w-0">
+          {inferred.state.kind === 'needs-ack' && (
+            <VariableInferenceBanner
+              vars={inferred.state.vars}
+              onAccept={inferred.accept}
+              // "Change variables" just dismisses the banner so the user can
+              // pick values manually from the VariableBar below. The picker
+              // already exists — we don't re-invent it here.
+              onChange={inferred.dismiss}
+              onDismiss={inferred.dismiss}
+            />
+          )}
           <VariableBar
             dashboardId={id ?? ''}
             variables={variables}


### PR DESCRIPTION
Wave 2 Step 4 — when users navigate to a dashboard from a service context, pre-bind variables only after explicit first-open confirmation. Same variable set → no re-prompt. Different set → re-prompt.

## Why it matters

Per Open Risks in the design doc: wrong namespace = wrong data. Silent variable injection is the high-stakes path that breaks trust. This PR enforces first-open ack.

## Changes

### Backend
- New table \`dashboard_variable_ack\` (sqlite + postgres) — \`UNIQUE(user_id, dashboard_uid, vars_hash)\`
- \`IDashboardVariableAckRepository\` + sqlite/postgres/InMemory impls per ADR-001
- Shared hash util \`packages/common/src/utils/variable-hash.ts\` (FNV-1a 8-char hex, web-bundle safe — no node:crypto)
- REST:
  - \`GET /api/dashboards/:uid/variable-ack?vars=<hash>\` → \`{ acked: boolean }\`
  - \`POST /api/dashboards/:uid/variable-ack\` body \`{ vars: Record<string,string> }\` → server-hashes, upserts

### Frontend
- Hook \`useInferredVariables(dashboardUid)\` — reads \`?_inf_<key>=<value>\` URL params, hashes, checks ack
- \`VariableInferenceBanner\` component — [Use these] / [Change variables] / [Don't auto-bind]
- Wired into \`DashboardWorkspace.tsx\` above \`VariableBar\`. Only the \`applied\` state injects values; un-acked vars never reach query execution.

### Edge cases decided
- Empty-string values dropped from canonical form
- Duplicate \`_inf_<key>\` params: first wins (URLSearchParams.get behavior)
- Non-string POST body values → 400
- Fetch failure on GET ack → fall back to "needs ack" (show banner) — prefer to ask than silently bind

## Test plan

- [x] 19/19 tests pass (7 hash unit, 6 repo unit, 6 REST integration)
- [x] Order-invariance, value-sensitivity, hash discrimination assertions
- [x] First-open → POST → banner gone → reopen with same hash → no banner
- [x] Hash change reproduces banner
- [ ] CI green

## Wave 2.2 wiring

Services page (not yet merged) is where \`?_inf_service=...&_inf_namespace=...\` URLs will originate. Hook is unconditional — activates as soon as Wave 2.2 lands.