### PR TITLE
Wave 2.3: AI Suggestions Inbox (Home single-channel)

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -44,6 +44,8 @@ import { createDashboardRouter } from '../routes/dashboard/router.js';
 import { createAlertRulesRouter } from '../routes/alert-rules.js';
 import { createResourcesPromoteRouter } from '../routes/resources-promote.js';
 import { PromoteService } from '../services/promote-service.js';
+import { createSuggestionsRouter } from '../routes/suggestions.js';
+import { defaultGenerators } from '../services/suggestion-generators.js';
 import { createNotificationsRouter } from '../routes/notifications.js';
 import { createVersionRouter } from '../routes/versions.js';
 import { createSearchRouter } from '../routes/search.js';
@@ -255,6 +257,17 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
       accessControl,
       audit: authSub.audit,
     }),
+  }));
+  // Wave 2 step 3 — AI Suggestions inbox (one inbox on Home).
+  app.use('/api/suggestions', createSuggestionsRouter({
+    repo: repos.aiSuggestions,
+    generators: defaultGenerators(),
+    generatorDeps: {
+      dashboards: repos.dashboards,
+      alertRules: eventAlertRuleStore,
+    },
+    actionDeps: {},
+    audit: authSub.audit,
   }));
   app.use('/api/search', createSearchRouter({
     dashboardStore: repos.dashboards,

--- a/packages/api-gateway/src/routes/suggestions.test.ts
+++ b/packages/api-gateway/src/routes/suggestions.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration tests for /api/suggestions.
+ *
+ * Auth middleware is stubbed so we can drive the router with a fixed
+ * identity and exercise the end-to-end repo + handler dispatch.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { InMemoryAiSuggestionRepository } from '../../../data-layer/src/repository/memory/ai-suggestion.js';
+import { createSuggestionsRouter } from './suggestions.js';
+import type { SuggestionGenerator } from '../services/suggestion-generators.js';
+
+const authState = vi.hoisted(() => ({ orgId: 'org_a', userId: 'user_a' }));
+
+vi.mock('../middleware/auth.js', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.auth = {
+      userId: authState.userId,
+      orgId: authState.orgId,
+      orgRole: 'Editor',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  },
+}));
+
+function makeApp(generators: SuggestionGenerator[] = []) {
+  const repo = new InMemoryAiSuggestionRepository();
+  const audit = { log: vi.fn(async () => undefined) } as any;
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/suggestions',
+    createSuggestionsRouter({
+      repo,
+      generators,
+      generatorDeps: {
+        dashboards: {} as any,
+        alertRules: {} as any,
+      },
+      actionDeps: {},
+      audit,
+    }),
+  );
+  return { app, repo, audit };
+}
+
+describe('/api/suggestions integration', () => {
+  beforeEach(() => {
+    authState.orgId = 'org_a';
+    authState.userId = 'user_a';
+    vi.clearAllMocks();
+  });
+
+  it('GET returns generated + previously stored suggestions and excludes future-snoozed rows', async () => {
+    // Seed a generator that always proposes one row (idempotent via dedup_key).
+    const gen: SuggestionGenerator = {
+      kind: 'missing_dashboard',
+      generate: async (ctx) => [
+        {
+          orgId: ctx.orgId,
+          userId: ctx.userId,
+          kind: 'missing_dashboard',
+          title: 'Test',
+          body: 'Body',
+          dedupKey: 'gen:1',
+        },
+      ],
+    };
+    const { app, repo } = makeApp([gen]);
+
+    // First call seeds the row.
+    let res = await request(app).get('/api/suggestions');
+    expect(res.status).toBe(200);
+    expect(res.body.data.suggestions).toHaveLength(1);
+
+    // Snooze that row to the far future.
+    const id = res.body.data.suggestions[0].id;
+    res = await request(app)
+      .post(`/api/suggestions/${id}/snooze`)
+      .send({ days: 7 });
+    expect(res.status).toBe(200);
+    expect(res.body.data.suggestion.state).toBe('snoozed');
+
+    // GET should now exclude it (snoozed_until is 7 days in the future).
+    res = await request(app).get('/api/suggestions');
+    // Generator re-ran but the dedup_key matched an existing row — no new row.
+    // The existing row is snoozed to the future, so it's hidden.
+    expect(res.body.data.suggestions).toHaveLength(0);
+
+    // Verify state directly via repo.
+    const row = await repo.findById(id);
+    expect(row?.state).toBe('snoozed');
+    expect(row?.snoozedUntil).toBeTruthy();
+  });
+
+  it('snooze → snoozed_until passes → row resurfaces', async () => {
+    const { app, repo } = makeApp([]);
+    const seeded = await repo.create({
+      orgId: 'org_a', userId: 'user_a', kind: 'stale_draft',
+      title: '', body: '', dedupKey: 'k',
+    });
+
+    // Snooze the row 7d.
+    let res = await request(app)
+      .post(`/api/suggestions/${seeded.id}/snooze`)
+      .send({ days: 7 });
+    expect(res.status).toBe(200);
+
+    // While still snoozed, not visible.
+    res = await request(app).get('/api/suggestions');
+    expect(res.body.data.suggestions).toHaveLength(0);
+
+    // Simulate elapsed snooze by rewriting the row.
+    await repo.updateState(seeded.id, 'snoozed', '2000-01-01T00:00:00.000Z');
+
+    res = await request(app).get('/api/suggestions');
+    expect(res.body.data.suggestions).toHaveLength(1);
+  });
+
+  it('dismiss is terminal — row stays hidden', async () => {
+    const { app, repo } = makeApp([]);
+    const s = await repo.create({
+      orgId: 'org_a', userId: 'user_a', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k',
+    });
+    const res = await request(app).post(`/api/suggestions/${s.id}/dismiss`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.suggestion.state).toBe('dismissed');
+
+    const list = await request(app).get('/api/suggestions');
+    expect(list.body.data.suggestions).toHaveLength(0);
+  });
+
+  it('snooze-all snoozes only the current user/org open rows', async () => {
+    const { app, repo } = makeApp([]);
+    await repo.create({
+      orgId: 'org_a', userId: 'user_a', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k1',
+    });
+    await repo.create({
+      orgId: 'org_a', userId: 'user_a', kind: 'stale_draft',
+      title: '', body: '', dedupKey: 'k2',
+    });
+    // Different user — must not be touched.
+    await repo.create({
+      orgId: 'org_a', userId: 'other', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k1',
+    });
+
+    const res = await request(app)
+      .post('/api/suggestions/snooze-all')
+      .send({ days: 7 });
+    expect(res.status).toBe(200);
+    expect(res.body.data.count).toBe(2);
+
+    const list = await repo.findOpenForUser('other', 'org_a');
+    expect(list).toHaveLength(1);
+  });
+
+  it('rejects ownership-mismatched suggestion modifications with 403', async () => {
+    const { app, repo } = makeApp([]);
+    const otherRow = await repo.create({
+      orgId: 'org_a', userId: 'other', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k',
+    });
+    const res = await request(app).post(`/api/suggestions/${otherRow.id}/dismiss`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects invalid snooze days', async () => {
+    const { app, repo } = makeApp([]);
+    const s = await repo.create({
+      orgId: 'org_a', userId: 'user_a', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k',
+    });
+    const res = await request(app)
+      .post(`/api/suggestions/${s.id}/snooze`)
+      .send({ days: 3 });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api-gateway/src/routes/suggestions.ts
+++ b/packages/api-gateway/src/routes/suggestions.ts
@@ -1,0 +1,226 @@
+/**
+ * /api/suggestions — AI Suggestions inbox (Wave 2 / step 3).
+ *
+ * REST surface:
+ *   GET    /api/suggestions
+ *   POST   /api/suggestions/:id/accept
+ *   POST   /api/suggestions/:id/snooze    body: { days: 1 | 7 }
+ *   POST   /api/suggestions/:id/dismiss
+ *   POST   /api/suggestions/snooze-all    body: { days: 7 }
+ *
+ * On GET, every registered SuggestionGenerator runs and upserts its
+ * proposals via the repository (dedup_key idempotent). The response is
+ * then the user's currently-visible inbox (open + resurfaced-snoozed).
+ *
+ * Auth: every endpoint is gated by authMiddleware. Suggestions are
+ * per-user — the repository scopes by (userId, orgId).
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import {
+  AuditAction,
+  type IAiSuggestionRepository,
+  type AiSuggestion,
+  type Identity,
+} from '@agentic-obs/common';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+import type { SuggestionGenerator, GeneratorCtx } from '../services/suggestion-generators.js';
+import {
+  dispatchSuggestionAction,
+  type ActionHandlerDeps,
+  type ActionResult,
+} from '../services/suggestion-action-handlers.js';
+
+export interface SuggestionsRouterDeps {
+  repo: IAiSuggestionRepository;
+  generators: SuggestionGenerator[];
+  generatorDeps: Omit<GeneratorCtx, 'orgId' | 'userId'>;
+  actionDeps: ActionHandlerDeps;
+  audit: AuditWriter;
+}
+
+function snoozeUntilFromDays(days: number, now: number = Date.now()): string {
+  return new Date(now + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function getIdentity(req: Request): Identity | null {
+  const auth = (req as AuthenticatedRequest).auth;
+  return auth ?? null;
+}
+
+function bad(res: Response, message: string, code = 'VALIDATION'): void {
+  res.status(400).json({ error: { code, message } });
+}
+
+function notFound(res: Response): void {
+  res.status(404).json({ error: { code: 'NOT_FOUND', message: 'suggestion not found' } });
+}
+
+function forbidden(res: Response): void {
+  res.status(403).json({ error: { code: 'FORBIDDEN', message: 'not your suggestion' } });
+}
+
+async function loadOwned(
+  repo: IAiSuggestionRepository,
+  id: string,
+  identity: Identity,
+): Promise<AiSuggestion | null | 'forbidden'> {
+  const row = await repo.findById(id);
+  if (!row) return null;
+  if (row.userId !== identity.userId || row.orgId !== identity.orgId) {
+    return 'forbidden';
+  }
+  return row;
+}
+
+export function createSuggestionsRouter(deps: SuggestionsRouterDeps): Router {
+  const router = Router();
+  router.use(authMiddleware);
+
+  // GET /api/suggestions — runs generators (idempotent via dedup_key),
+  // then returns the user's currently-visible inbox.
+  router.get('/', async (req, res) => {
+    const id = getIdentity(req);
+    if (!id) return bad(res, 'unauthenticated', 'UNAUTHENTICATED');
+
+    const ctx: GeneratorCtx = {
+      orgId: id.orgId,
+      userId: id.userId,
+      ...deps.generatorDeps,
+    };
+    // Run generators sequentially — they query the same repos and the
+    // total volume is tiny. Errors in one generator must not blow up the
+    // whole inbox.
+    for (const g of deps.generators) {
+      try {
+        const proposals = await g.generate(ctx);
+        for (const p of proposals) {
+          await deps.repo.create(p);
+        }
+      } catch {
+        // Swallow — the inbox should still render with whatever ran.
+      }
+    }
+
+    const list = await deps.repo.findOpenForUser(id.userId, id.orgId);
+    res.json({ data: { suggestions: list } });
+    return;
+  });
+
+  // POST /api/suggestions/:id/accept
+  router.post('/:id/accept', async (req, res) => {
+    const id = getIdentity(req);
+    if (!id) return bad(res, 'unauthenticated', 'UNAUTHENTICATED');
+    const rowId = req.params['id'] ?? '';
+    const row = await loadOwned(deps.repo, rowId, id);
+    if (row === null) return notFound(res);
+    if (row === 'forbidden') return forbidden(res);
+
+    let actionResult: ActionResult | null = null;
+    if (row.actionKind) {
+      actionResult = await dispatchSuggestionAction(
+        row.actionKind,
+        row.actionPayload ?? {},
+        deps.actionDeps,
+      );
+    }
+    const updated = await deps.repo.updateState(row.id, 'accepted');
+    void deps.audit.log({
+      action: AuditAction.SuggestionAccepted,
+      actorType: 'user',
+      actorId: id.userId,
+      orgId: id.orgId,
+      targetType: 'ai_suggestion',
+      targetId: row.id,
+      targetName: row.kind,
+      outcome: 'success',
+      metadata: { actionKind: row.actionKind, result: actionResult },
+    });
+    res.json({ data: { suggestion: updated, action: actionResult } });
+    return;
+  });
+
+  // POST /api/suggestions/:id/snooze  body: { days: 1 | 7 }
+  router.post('/:id/snooze', async (req, res) => {
+    const id = getIdentity(req);
+    if (!id) return bad(res, 'unauthenticated', 'UNAUTHENTICATED');
+    const days = Number((req.body ?? {}).days);
+    if (days !== 1 && days !== 7) {
+      return bad(res, 'days must be 1 or 7');
+    }
+    const rowId = req.params['id'] ?? '';
+    const row = await loadOwned(deps.repo, rowId, id);
+    if (row === null) return notFound(res);
+    if (row === 'forbidden') return forbidden(res);
+
+    const snoozedUntil = snoozeUntilFromDays(days);
+    const updated = await deps.repo.updateState(row.id, 'snoozed', snoozedUntil);
+    void deps.audit.log({
+      action: AuditAction.SuggestionSnoozed,
+      actorType: 'user',
+      actorId: id.userId,
+      orgId: id.orgId,
+      targetType: 'ai_suggestion',
+      targetId: row.id,
+      targetName: row.kind,
+      outcome: 'success',
+      metadata: { days, snoozedUntil },
+    });
+    res.json({ data: { suggestion: updated } });
+    return;
+  });
+
+  // POST /api/suggestions/:id/dismiss
+  router.post('/:id/dismiss', async (req, res) => {
+    const id = getIdentity(req);
+    if (!id) return bad(res, 'unauthenticated', 'UNAUTHENTICATED');
+    const rowId = req.params['id'] ?? '';
+    const row = await loadOwned(deps.repo, rowId, id);
+    if (row === null) return notFound(res);
+    if (row === 'forbidden') return forbidden(res);
+
+    const updated = await deps.repo.updateState(row.id, 'dismissed');
+    void deps.audit.log({
+      action: AuditAction.SuggestionDismissed,
+      actorType: 'user',
+      actorId: id.userId,
+      orgId: id.orgId,
+      targetType: 'ai_suggestion',
+      targetId: row.id,
+      targetName: row.kind,
+      outcome: 'success',
+    });
+    res.json({ data: { suggestion: updated } });
+    return;
+  });
+
+  // POST /api/suggestions/snooze-all  body: { days: 7 }
+  router.post('/snooze-all', async (req, res) => {
+    const id = getIdentity(req);
+    if (!id) return bad(res, 'unauthenticated', 'UNAUTHENTICATED');
+    const days = Number((req.body ?? {}).days ?? 7);
+    if (days !== 1 && days !== 7) {
+      return bad(res, 'days must be 1 or 7');
+    }
+    const snoozedUntil = snoozeUntilFromDays(days);
+    const count = await deps.repo.snoozeAllForUser(id.userId, id.orgId, snoozedUntil);
+    void deps.audit.log({
+      action: AuditAction.SuggestionSnoozed,
+      actorType: 'user',
+      actorId: id.userId,
+      orgId: id.orgId,
+      targetType: 'ai_suggestion',
+      targetId: null,
+      targetName: 'all',
+      outcome: 'success',
+      metadata: { bulk: true, count, days, snoozedUntil },
+    });
+    res.json({ data: { count, snoozedUntil } });
+    return;
+  });
+
+  return router;
+}

--- a/packages/api-gateway/src/services/suggestion-action-handlers.test.ts
+++ b/packages/api-gateway/src/services/suggestion-action-handlers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { dispatchSuggestionAction } from './suggestion-action-handlers.js';
+
+describe('suggestion action handlers', () => {
+  it('create_dashboard returns a navigate URL with prefill query', async () => {
+    const r = await dispatchSuggestionAction(
+      'create_dashboard',
+      { prefill: { title: 'ingress-gateway overview', prompt: 'p' } },
+      {},
+    );
+    expect(r.kind).toBe('navigate');
+    if (r.kind === 'navigate') {
+      expect(r.url.startsWith('/dashboards/new?')).toBe(true);
+      expect(r.url).toContain('title=');
+      expect(r.url).toContain('prompt=');
+    }
+  });
+
+  it('archive_resources is STUBBED — navigates to list view with preselected IDs', async () => {
+    const r = await dispatchSuggestionAction(
+      'archive_resources',
+      { resourceIds: ['d1', 'd2'] },
+      {},
+    );
+    expect(r.kind).toBe('navigate');
+    if (r.kind === 'navigate') {
+      expect(r.url).toBe('/dashboards?preselect=d1%2Cd2');
+    }
+  });
+
+  it('merge_dashboards navigates to compare view', async () => {
+    const r = await dispatchSuggestionAction(
+      'merge_dashboards',
+      { dashboardIds: ['a', 'b'] },
+      {},
+    );
+    expect(r.kind).toBe('navigate');
+    if (r.kind === 'navigate') {
+      expect(r.url).toBe('/dashboards/compare?a=a&b=b');
+    }
+  });
+
+  it('merge_dashboards with <2 ids returns a message', async () => {
+    const r = await dispatchSuggestionAction(
+      'merge_dashboards',
+      { dashboardIds: ['only-one'] },
+      {},
+    );
+    expect(r.kind).toBe('message');
+  });
+});

--- a/packages/api-gateway/src/services/suggestion-action-handlers.ts
+++ b/packages/api-gateway/src/services/suggestion-action-handlers.ts
@@ -1,0 +1,95 @@
+/**
+ * Action handlers for the AI Suggestions inbox — Wave 2 / step 3.
+ *
+ * When the user clicks "Accept" on a suggestion, the route layer looks up
+ * the handler by `actionKind` and invokes it. The handler returns either:
+ *
+ *   { kind: 'navigate', url }        — the UI should open this URL.
+ *   { kind: 'message', message }     — the UI shows a toast/banner.
+ *
+ * `archive_resources` is STUBBED in this wave: the dashboard lifecycle
+ * archive column doesn't exist yet (Wave 1 PR-C deferred this — see Open
+ * Risks in docs/wave1/). Instead of silently failing or fabricating a
+ * delete, we route the user to a list view with the candidate IDs
+ * preselected so they can decide what to do manually. This matches the
+ * "no auto-archive" decision in the design.
+ *
+ * `merge_dashboards` is also stub-shaped (no real merge UI yet) — we
+ * route the user to a compare view rendered by the web app.
+ */
+
+import type { AiSuggestionActionKind } from '@agentic-obs/common';
+
+export type ActionResult =
+  | { kind: 'navigate'; url: string }
+  | { kind: 'message'; message: string };
+
+export interface ActionHandlerDeps {
+  // No real services needed yet — the handlers compute URLs only.
+  // Keeping the dep object reserves a hook for future handlers (e.g.
+  // create_dashboard could call the dashboard service directly).
+  _reserved?: never;
+}
+
+export type ActionHandler = (
+  payload: Record<string, unknown>,
+  deps: ActionHandlerDeps,
+) => Promise<ActionResult>;
+
+const handlers: Record<AiSuggestionActionKind, ActionHandler> = {
+  create_dashboard: async (payload) => {
+    const prefill = (payload['prefill'] ?? {}) as { title?: string; prompt?: string };
+    const params = new URLSearchParams();
+    if (prefill.title) params.set('title', prefill.title);
+    if (prefill.prompt) params.set('prompt', prefill.prompt);
+    return {
+      kind: 'navigate',
+      url: `/dashboards/new${params.toString() ? `?${params.toString()}` : ''}`,
+    };
+  },
+  archive_resources: async (payload) => {
+    // Stubbed: lifecycle archive column isn't built. Navigate to the
+    // dashboards list with the candidate IDs preselected. The web app
+    // reads `?preselect=...` to highlight rows.
+    const ids = Array.isArray(payload['resourceIds'])
+      ? (payload['resourceIds'] as string[])
+      : [];
+    const params = new URLSearchParams();
+    if (ids.length > 0) params.set('preselect', ids.join(','));
+    return {
+      kind: 'navigate',
+      url: `/dashboards${params.toString() ? `?${params.toString()}` : ''}`,
+    };
+  },
+  merge_dashboards: async (payload) => {
+    const ids = Array.isArray(payload['dashboardIds'])
+      ? (payload['dashboardIds'] as string[])
+      : [];
+    if (ids.length < 2) {
+      return { kind: 'message', message: 'Need two dashboards to compare.' };
+    }
+    return {
+      kind: 'navigate',
+      url: `/dashboards/compare?a=${encodeURIComponent(ids[0]!)}&b=${encodeURIComponent(ids[1]!)}`,
+    };
+  },
+};
+
+export function dispatchSuggestionAction(
+  kind: AiSuggestionActionKind,
+  payload: Record<string, unknown>,
+  deps: ActionHandlerDeps,
+): Promise<ActionResult> {
+  const handler = handlers[kind];
+  if (!handler) {
+    return Promise.resolve({
+      kind: 'message',
+      message: `Unknown action: ${kind}`,
+    });
+  }
+  return handler(payload, deps);
+}
+
+/** Exposed for tests + the docstring of suggestions.ts. */
+export const SUGGESTION_ACTION_HANDLERS: ReadonlyArray<AiSuggestionActionKind> =
+  Object.keys(handlers) as AiSuggestionActionKind[];

--- a/packages/api-gateway/src/services/suggestion-generators.test.ts
+++ b/packages/api-gateway/src/services/suggestion-generators.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Generator unit tests — seeded fakes for IDashboardRepository and
+ * IAlertRuleRepository. We only stub the methods each generator actually
+ * calls.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DuplicateDashboardSuggestionGenerator,
+  MissingDashboardSuggestionGenerator,
+  StaleDraftSuggestionGenerator,
+  type GeneratorCtx,
+} from './suggestion-generators.js';
+
+// -- Minimal fake repos (typed loosely on purpose — the generator only
+//    touches a tiny part of each surface). -------------------------------
+
+function fakeDashboards(rows: any[]) {
+  return {
+    findAll: async (userId?: string) =>
+      userId ? rows.filter((r) => r.userId === userId) : rows,
+  } as any;
+}
+
+function fakeAlertRules(list: any[]) {
+  return {
+    findAll: async () => ({ list, total: list.length }),
+  } as any;
+}
+
+function ctx(over: Partial<GeneratorCtx>): GeneratorCtx {
+  return {
+    orgId: 'org_a',
+    userId: 'user_a',
+    dashboards: fakeDashboards([]),
+    alertRules: fakeAlertRules([]),
+    ...over,
+  };
+}
+
+// -- MissingDashboardSuggestionGenerator --------------------------------
+
+describe('MissingDashboardSuggestionGenerator', () => {
+  const gen = new MissingDashboardSuggestionGenerator();
+
+  it('proposes when an alert exists but no dashboard mentions it', async () => {
+    const out = await gen.generate(
+      ctx({
+        alertRules: fakeAlertRules([
+          { id: 'rule1', name: 'ingress-gateway', originalPrompt: 'prompt' },
+        ]),
+        dashboards: fakeDashboards([
+          { id: 'd1', title: 'Unrelated', panels: [] },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('missing_dashboard');
+    expect(out[0]?.actionKind).toBe('create_dashboard');
+    expect(out[0]?.dedupKey).toBe('missing_dashboard:rule1');
+    expect(out[0]?.title).toContain('ingress-gateway');
+  });
+
+  it('skips when a dashboard already mentions the alert name', async () => {
+    const out = await gen.generate(
+      ctx({
+        alertRules: fakeAlertRules([{ id: 'rule1', name: 'ingress-gateway' }]),
+        dashboards: fakeDashboards([
+          { id: 'd1', title: 'Ingress-Gateway Overview', panels: [] },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(0);
+  });
+});
+
+// -- StaleDraftSuggestionGenerator --------------------------------------
+
+describe('StaleDraftSuggestionGenerator', () => {
+  const gen = new StaleDraftSuggestionGenerator();
+  const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  const recent = new Date().toISOString();
+
+  it('proposes when personal-folder dashboards are stale', async () => {
+    const out = await gen.generate(
+      ctx({
+        dashboards: fakeDashboards([
+          { id: 'd1', userId: 'user_a', folder: undefined, updatedAt: old, createdAt: old, panels: [] },
+          { id: 'd2', userId: 'user_a', folder: undefined, updatedAt: old, createdAt: old, panels: [] },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('stale_draft');
+    expect(out[0]?.actionKind).toBe('archive_resources');
+    const ids = (out[0]?.actionPayload as { resourceIds: string[] }).resourceIds;
+    expect(ids.sort()).toEqual(['d1', 'd2']);
+    expect(out[0]?.dedupKey).toBe('stale_draft:user_a');
+  });
+
+  it('skips when nothing is stale enough', async () => {
+    const out = await gen.generate(
+      ctx({
+        dashboards: fakeDashboards([
+          { id: 'd1', userId: 'user_a', folder: undefined, updatedAt: recent, createdAt: recent, panels: [] },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('ignores dashboards in shared folders', async () => {
+    const out = await gen.generate(
+      ctx({
+        dashboards: fakeDashboards([
+          { id: 'd1', userId: 'user_a', folder: 'team-x', updatedAt: old, createdAt: old, panels: [] },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(0);
+  });
+});
+
+// -- DuplicateDashboardSuggestionGenerator -----------------------------
+
+describe('DuplicateDashboardSuggestionGenerator', () => {
+  const gen = new DuplicateDashboardSuggestionGenerator();
+  const panel = (expr: string) => [
+    { id: 'p', title: '', description: '', queries: [{ refId: 'A', expr }], visualization: {} as any, row: 0, col: 0, width: 6, height: 4 },
+  ];
+
+  it('proposes one suggestion for a duplicate pair', async () => {
+    const out = await gen.generate(
+      ctx({
+        dashboards: fakeDashboards([
+          { id: 'b', title: 'B', panels: panel('rate(http_requests_total[5m])') },
+          { id: 'a', title: 'A', panels: panel('rate(http_requests_total[5m])') },
+          { id: 'c', title: 'C', panels: panel('other_metric') },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('duplicate_dashboard');
+    expect(out[0]?.actionKind).toBe('merge_dashboards');
+    const ids = (out[0]?.actionPayload as { dashboardIds: string[] }).dashboardIds;
+    expect(ids).toEqual(['a', 'b']);
+    // Deterministic dedup_key regardless of input order
+    expect(out[0]?.dedupKey).toBe('duplicate_dashboard:a:b');
+  });
+
+  it('emits no suggestion when no duplicates exist', async () => {
+    const out = await gen.generate(
+      ctx({
+        dashboards: fakeDashboards([
+          { id: 'a', title: 'A', panels: panel('m1') },
+          { id: 'b', title: 'B', panels: panel('m2') },
+        ]),
+      }),
+    );
+    expect(out).toHaveLength(0);
+  });
+});

--- a/packages/api-gateway/src/services/suggestion-generators.ts
+++ b/packages/api-gateway/src/services/suggestion-generators.ts
@@ -1,0 +1,202 @@
+/**
+ * Suggestion generators — Wave 2 / step 3.
+ *
+ * Each generator inspects user-visible resources and proposes a row for the
+ * AI Suggestions inbox. Generators are pure (no side effects) — the route
+ * layer upserts the returned `NewAiSuggestion[]` through the repository,
+ * which is responsible for dedup (UNIQUE(user_id, dedup_key)).
+ *
+ * Why these 3 to start:
+ *   - MissingDashboard: "alert fired but no dashboard to look at" is the
+ *     canonical post-pageout moment.
+ *   - StaleDraft: surfaces personal-folder drafts the user has forgotten
+ *     about (the equivalent of a "drafts" cleanup nag).
+ *   - DuplicateDashboard: top-1 only — duplicate detection is heuristic
+ *     and we don't want to spam the inbox if many dashboards share queries.
+ */
+
+import type {
+  Dashboard,
+  IDashboardRepository,
+  NewAiSuggestion,
+  PanelConfig,
+  PanelQuery,
+} from '@agentic-obs/common';
+import type { IAlertRuleRepository } from '@agentic-obs/data-layer';
+
+export interface GeneratorCtx {
+  orgId: string;
+  userId: string;
+  dashboards: IDashboardRepository;
+  alertRules: IAlertRuleRepository;
+}
+
+export interface SuggestionGenerator {
+  kind: string;
+  generate(ctx: GeneratorCtx): Promise<NewAiSuggestion[]>;
+}
+
+/**
+ * Cap the per-generator output. The inbox is a glance-surface — too many
+ * rows defeats the purpose of one inbox.
+ */
+const MAX_ALERTS_SCANNED = 5;
+
+function firstPanelQuery(panels: PanelConfig[] | undefined): string | null {
+  if (!panels || panels.length === 0) return null;
+  const p = panels[0];
+  if (!p) return null;
+  const q: PanelQuery | undefined = p.queries?.[0];
+  const expr = q?.expr;
+  return expr && expr.trim() !== '' ? expr.trim() : null;
+}
+
+/**
+ * MissingDashboardSuggestionGenerator
+ *
+ * Scans up to MAX_ALERTS_SCANNED of the most recent alert rules. For each
+ * rule that has no dashboard mentioning its name or matching its first
+ * label value, propose a `create_dashboard` action prefilled with the
+ * alert's prompt.
+ *
+ * Heuristic: match by case-insensitive dashboard title containing the
+ * alert name. Cheap, not semantic — false negatives are fine because the
+ * dedup_key includes the alert id so we don't re-propose if the user
+ * already accepted/dismissed.
+ */
+export class MissingDashboardSuggestionGenerator implements SuggestionGenerator {
+  kind = 'missing_dashboard';
+
+  async generate(ctx: GeneratorCtx): Promise<NewAiSuggestion[]> {
+    const { list } = await ctx.alertRules.findAll({ limit: MAX_ALERTS_SCANNED });
+    const dashboards = await ctx.dashboards.findAll();
+    const titles = dashboards.map((d) => d.title.toLowerCase());
+
+    const out: NewAiSuggestion[] = [];
+    for (const rule of list) {
+      const needle = rule.name.toLowerCase();
+      const hasDashboard = titles.some((t) => t.includes(needle));
+      if (hasDashboard) continue;
+      out.push({
+        orgId: ctx.orgId,
+        userId: ctx.userId,
+        kind: 'missing_dashboard',
+        title: `${rule.name} has alerts but no dashboard. Create one?`,
+        body: `Alert rule **${rule.name}** is configured but no dashboard contains "${rule.name}" in its title. Create a dashboard so the next page-out has a place to land.`,
+        actionKind: 'create_dashboard',
+        actionPayload: {
+          prefill: {
+            title: `${rule.name} overview`,
+            prompt: rule.originalPrompt ?? `Dashboard for ${rule.name}`,
+          },
+          sourceAlertRuleId: rule.id,
+        },
+        dedupKey: `missing_dashboard:${rule.id}`,
+      });
+    }
+    return out;
+  }
+}
+
+/**
+ * StaleDraftSuggestionGenerator
+ *
+ * Counts the user's personal-folder dashboards/alerts not opened in 30
+ * days. We use `updatedAt` as the proxy because `last_opened_at` isn't a
+ * column yet (Wave 1 / Open Risks — lifecycle archive deferred). The
+ * action is `archive_resources` but the real-world handler navigates the
+ * user to the list view with archivable items preselected (no auto
+ * archive — see action-handlers.ts).
+ */
+export class StaleDraftSuggestionGenerator implements SuggestionGenerator {
+  kind = 'stale_draft';
+
+  async generate(ctx: GeneratorCtx): Promise<NewAiSuggestion[]> {
+    const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const cutoff = new Date(cutoffMs).toISOString();
+
+    const dashboards = await ctx.dashboards.findAll(ctx.userId);
+    // "personal folder" proxy: no folder set (Wave 1 personal-vs-shared
+    // distinction). Anything in a shared folder is presumed intentional.
+    const stale = dashboards.filter(
+      (d: Dashboard) => !d.folder && (d.updatedAt ?? d.createdAt) <= cutoff,
+    );
+    if (stale.length === 0) return [];
+
+    return [
+      {
+        orgId: ctx.orgId,
+        userId: ctx.userId,
+        kind: 'stale_draft',
+        title: `You have ${stale.length} untouched drafts in My Workspace. Review?`,
+        body: `${stale.length} dashboards in your personal workspace haven't been updated in 30 days. Open the review queue to archive what you don't need.`,
+        actionKind: 'archive_resources',
+        actionPayload: {
+          resourceIds: stale.map((d) => d.id),
+          resourceKind: 'dashboard',
+        },
+        // Dedup by user only — we want one rolling stale-draft suggestion,
+        // not one per stale dashboard. State transitions on the row reset
+        // the visibility window.
+        dedupKey: `stale_draft:${ctx.userId}`,
+      },
+    ];
+  }
+}
+
+/**
+ * DuplicateDashboardSuggestionGenerator
+ *
+ * Naive: bucket dashboards by their first panel's first query expression
+ * (after trim). If any bucket has >= 2 dashboards, emit ONE suggestion
+ * pointing at the first pair we found. We deliberately do not emit a
+ * suggestion per pair — duplicate-detection is fuzzy enough that flooding
+ * the inbox would be worse than under-reporting.
+ */
+export class DuplicateDashboardSuggestionGenerator implements SuggestionGenerator {
+  kind = 'duplicate_dashboard';
+
+  async generate(ctx: GeneratorCtx): Promise<NewAiSuggestion[]> {
+    const dashboards = await ctx.dashboards.findAll();
+    const buckets = new Map<string, Dashboard[]>();
+    for (const d of dashboards) {
+      const q = firstPanelQuery(d.panels);
+      if (!q) continue;
+      const bucket = buckets.get(q) ?? [];
+      bucket.push(d);
+      buckets.set(q, bucket);
+    }
+
+    for (const [, bucket] of buckets) {
+      if (bucket.length >= 2) {
+        const [a, b] = bucket;
+        if (!a || !b) continue;
+        // Stable order so the dedup_key is deterministic.
+        const [first, second] = a.id < b.id ? [a, b] : [b, a];
+        return [
+          {
+            orgId: ctx.orgId,
+            userId: ctx.userId,
+            kind: 'duplicate_dashboard',
+            title: `These 2 dashboards show the same metric. Merge?`,
+            body: `**${first.title}** and **${second.title}** both lead with the same query. Compare them side by side and decide if one should be archived.`,
+            actionKind: 'merge_dashboards',
+            actionPayload: {
+              dashboardIds: [first.id, second.id],
+            },
+            dedupKey: `duplicate_dashboard:${first.id}:${second.id}`,
+          },
+        ];
+      }
+    }
+    return [];
+  }
+}
+
+export function defaultGenerators(): SuggestionGenerator[] {
+  return [
+    new MissingDashboardSuggestionGenerator(),
+    new StaleDraftSuggestionGenerator(),
+    new DuplicateDashboardSuggestionGenerator(),
+  ];
+}

--- a/packages/common/src/audit/actions.ts
+++ b/packages/common/src/audit/actions.ts
@@ -112,6 +112,11 @@ export const AuditAction = {
   InvestigationCreate: 'investigation.create',
   InvestigationUpdate: 'investigation.update',
   ServiceAttributionConfirm: 'service.attribution_confirm',
+
+  // Wave 2 step 3 — AI Suggestions inbox (per-user proposals).
+  SuggestionAccepted: 'suggestion.accepted',
+  SuggestionDismissed: 'suggestion.dismissed',
+  SuggestionSnoozed: 'suggestion.snoozed',
 } as const;
 
 export type AuditActionValue = (typeof AuditAction)[keyof typeof AuditAction];

--- a/packages/common/src/models/ai-suggestion.ts
+++ b/packages/common/src/models/ai-suggestion.ts
@@ -1,0 +1,47 @@
+/**
+ * AI Suggestion model — Wave 2 step 3.
+ *
+ * One inbox on Home (not 6 notification channels). Each suggestion is an
+ * AI-generated proposal: create-dashboard, archive-stale, merge-duplicate.
+ * Per-user, not org-wide.
+ */
+
+export type AiSuggestionKind =
+  | 'missing_dashboard'
+  | 'stale_draft'
+  | 'duplicate_dashboard';
+
+export type AiSuggestionState = 'open' | 'accepted' | 'snoozed' | 'dismissed';
+
+export type AiSuggestionActionKind =
+  | 'create_dashboard'
+  | 'archive_resources'
+  | 'merge_dashboards';
+
+export interface AiSuggestion {
+  id: string;
+  orgId: string;
+  userId: string;
+  kind: AiSuggestionKind;
+  title: string;
+  body: string;
+  actionKind: AiSuggestionActionKind | null;
+  actionPayload: Record<string, unknown> | null;
+  state: AiSuggestionState;
+  snoozedUntil: string | null;
+  createdAt: string;
+  updatedAt: string;
+  dedupKey: string;
+}
+
+export interface NewAiSuggestion {
+  id?: string;
+  orgId: string;
+  userId: string;
+  kind: AiSuggestionKind;
+  title: string;
+  body: string;
+  actionKind?: AiSuggestionActionKind | null;
+  actionPayload?: Record<string, unknown> | null;
+  dedupKey: string;
+}

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -29,6 +29,9 @@ export * from './preferences.js';
 export * from './quota.js';
 export * from './audit-log.js';
 
+// — AI Suggestions inbox (Wave 2 / step 3) —
+export * from './ai-suggestion.js';
+
 // — Instance-scoped config (LLM / notification settings) —
 export * from './instance-config.js';
 // — HTTP wire-format types for instance config (W3 / T3.3) —

--- a/packages/common/src/repositories/ai-suggestion/index.ts
+++ b/packages/common/src/repositories/ai-suggestion/index.ts
@@ -1,0 +1,1 @@
+export * from './interfaces.js';

--- a/packages/common/src/repositories/ai-suggestion/interfaces.ts
+++ b/packages/common/src/repositories/ai-suggestion/interfaces.ts
@@ -1,0 +1,48 @@
+/**
+ * Repository interface for AI suggestions (Wave 2 / step 3).
+ *
+ * Per-user inbox of AI-generated proposals (one inbox, not 6 channels).
+ * The dedup_key uniqueness per (user_id, dedup_key) lets generators
+ * re-run idempotently — running the missing-dashboard generator twice
+ * does not create two rows.
+ *
+ * Implementations:
+ *   - packages/data-layer/src/repository/memory/ai-suggestion.ts
+ *   - packages/data-layer/src/repository/sqlite/ai-suggestion.ts
+ *   - packages/data-layer/src/repository/postgres/ai-suggestion.ts
+ */
+
+import type {
+  AiSuggestion,
+  AiSuggestionState,
+  NewAiSuggestion,
+} from '../../models/ai-suggestion.js';
+
+export interface IAiSuggestionRepository {
+  /** Upserts by (user_id, dedup_key). Returns the row whether inserted or no-op. */
+  create(input: NewAiSuggestion): Promise<AiSuggestion>;
+
+  findById(id: string): Promise<AiSuggestion | null>;
+
+  /**
+   * Returns rows that should currently be visible to the user. That is:
+   *   - state = 'open', OR
+   *   - state = 'snoozed' AND snoozed_until <= now()  (resurfaced)
+   */
+  findOpenForUser(userId: string, orgId: string, now?: string): Promise<AiSuggestion[]>;
+
+  /**
+   * State transitions. `snoozedUntil` only honored when state='snoozed'.
+   * Returns null when the row is missing.
+   */
+  updateState(
+    id: string,
+    state: AiSuggestionState,
+    snoozedUntil?: string | null,
+  ): Promise<AiSuggestion | null>;
+
+  /**
+   * Bulk-snooze all open suggestions for a user. Returns the count touched.
+   */
+  snoozeAllForUser(userId: string, orgId: string, snoozedUntil: string): Promise<number>;
+}

--- a/packages/common/src/repositories/index.ts
+++ b/packages/common/src/repositories/index.ts
@@ -4,3 +4,4 @@ export * from './dashboard/index.js';
 export * from './dashboard-variable-ack/index.js';
 export * from './investigation/index.js';
 export * from './alert-rule/index.js';
+export * from './ai-suggestion/index.js';

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -925,3 +925,28 @@ CREATE TABLE IF NOT EXISTS dashboard_variable_ack (
 
 CREATE INDEX IF NOT EXISTS idx_var_ack
   ON dashboard_variable_ack(user_id, dashboard_uid);
+
+-- ============================================================================
+-- AI Suggestions inbox (Wave 2 / step 3). Per-user inbox of AI-generated
+-- proposals that need user attention (one inbox, not 6 notification channels).
+-- See packages/common/src/models/ai-suggestion.ts for the canonical types.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS ai_suggestions (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL,
+  user_id         TEXT NOT NULL,
+  kind            TEXT NOT NULL,
+  title           TEXT NOT NULL,
+  body            TEXT NOT NULL,
+  action_kind     TEXT NULL,
+  action_payload  TEXT NULL,
+  state           TEXT NOT NULL DEFAULT 'open',
+  snoozed_until   TEXT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  dedup_key       TEXT NOT NULL,
+  UNIQUE(user_id, dedup_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_suggestions_user_state ON ai_suggestions(user_id, state);

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -23,6 +23,7 @@ import type {
   IDashboardVariableAckRepository,
   IInstanceConfigRepository,
   INotificationChannelRepository,
+  IAiSuggestionRepository,
 } from '@agentic-obs/common';
 import type { IConnectorRepository } from './types/connector.js';
 import type {
@@ -81,6 +82,8 @@ import { PostgresNotificationDispatchRepository } from './postgres/notification-
 import { SqliteLlmAuditRepository } from './sqlite/llm-audit-repository.js';
 import { PostgresLlmAuditRepository } from './postgres/llm-audit-repository.js';
 import type { ILlmAuditRepository } from './sqlite/llm-audit-repository.js';
+import { SqliteAiSuggestionRepository } from './sqlite/ai-suggestion.js';
+import { PostgresAiSuggestionRepository } from './postgres/ai-suggestion.js';
 
 /**
  * Complete repository bundle available behind every persistence backend.
@@ -116,6 +119,7 @@ export interface RepositoryBundle {
   remediationPlans: IRemediationPlanRepository;
   notificationDispatch: INotificationDispatchRepository;
   llmAudit: ILlmAuditRepository;
+  aiSuggestions: IAiSuggestionRepository;
 }
 
 export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
@@ -143,6 +147,7 @@ export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
     remediationPlans: new SqliteRemediationPlanRepository(db),
     notificationDispatch: new SqliteNotificationDispatchRepository(db),
     llmAudit: new SqliteLlmAuditRepository(db),
+    aiSuggestions: new SqliteAiSuggestionRepository(db),
   };
 }
 
@@ -172,6 +177,7 @@ export function createPostgresRepositories(db: DbClient): RepositoryBundle {
     remediationPlans: new PostgresRemediationPlanRepository(db),
     notificationDispatch: new PostgresNotificationDispatchRepository(db),
     llmAudit: new PostgresLlmAuditRepository(db),
+    aiSuggestions: new PostgresAiSuggestionRepository(db),
   };
 }
 

--- a/packages/data-layer/src/repository/memory/ai-suggestion.test.ts
+++ b/packages/data-layer/src/repository/memory/ai-suggestion.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryAiSuggestionRepository } from './ai-suggestion.js';
+
+describe('InMemoryAiSuggestionRepository', () => {
+  function makeRepo() {
+    return new InMemoryAiSuggestionRepository();
+  }
+
+  it('create() upserts by (userId, dedupKey) — running twice returns one row', async () => {
+    const repo = makeRepo();
+    const a = await repo.create({
+      orgId: 'org1',
+      userId: 'u1',
+      kind: 'missing_dashboard',
+      title: 't',
+      body: 'b',
+      dedupKey: 'k1',
+    });
+    const b = await repo.create({
+      orgId: 'org1',
+      userId: 'u1',
+      kind: 'missing_dashboard',
+      title: 't2', // different content shouldn't matter
+      body: 'b2',
+      dedupKey: 'k1',
+    });
+    expect(b.id).toBe(a.id);
+    // First-row wins; later create is a no-op
+    expect(b.title).toBe('t');
+    const list = await repo.findOpenForUser('u1', 'org1');
+    expect(list).toHaveLength(1);
+  });
+
+  it('findOpenForUser() includes resurfaced snoozed rows', async () => {
+    const repo = makeRepo();
+    const past = '2000-01-01T00:00:00.000Z';
+    const future = '9999-12-31T00:00:00.000Z';
+
+    const open = await repo.create({
+      orgId: 'org1', userId: 'u1', kind: 'stale_draft',
+      title: 'open', body: '', dedupKey: 'a',
+    });
+    const snoozedPast = await repo.create({
+      orgId: 'org1', userId: 'u1', kind: 'stale_draft',
+      title: 'past', body: '', dedupKey: 'b',
+    });
+    const snoozedFuture = await repo.create({
+      orgId: 'org1', userId: 'u1', kind: 'stale_draft',
+      title: 'future', body: '', dedupKey: 'c',
+    });
+    await repo.updateState(snoozedPast.id, 'snoozed', past);
+    await repo.updateState(snoozedFuture.id, 'snoozed', future);
+
+    const list = await repo.findOpenForUser('u1', 'org1');
+    const ids = list.map((r) => r.id).sort();
+    expect(ids).toEqual([open.id, snoozedPast.id].sort());
+  });
+
+  it('updateState() transitions open → dismissed (terminal)', async () => {
+    const repo = makeRepo();
+    const s = await repo.create({
+      orgId: 'o', userId: 'u', kind: 'duplicate_dashboard',
+      title: '', body: '', dedupKey: 'k',
+    });
+    const dismissed = await repo.updateState(s.id, 'dismissed');
+    expect(dismissed?.state).toBe('dismissed');
+    expect(dismissed?.snoozedUntil).toBeNull();
+    const visible = await repo.findOpenForUser('u', 'o');
+    expect(visible).toHaveLength(0);
+  });
+
+  it('updateState() transitions open → snoozed (sets snoozedUntil) → open after elapse', async () => {
+    const repo = makeRepo();
+    const s = await repo.create({
+      orgId: 'o', userId: 'u', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'k',
+    });
+    const until = '3000-01-01T00:00:00.000Z';
+    const snoozed = await repo.updateState(s.id, 'snoozed', until);
+    expect(snoozed?.state).toBe('snoozed');
+    expect(snoozed?.snoozedUntil).toBe(until);
+
+    // Snoozed to the future → not visible
+    let list = await repo.findOpenForUser('u', 'o', '2025-01-01T00:00:00.000Z');
+    expect(list).toHaveLength(0);
+
+    // After snoozedUntil passes → visible again (the inbox query resurfaces it)
+    list = await repo.findOpenForUser('u', 'o', '3001-01-01T00:00:00.000Z');
+    expect(list).toHaveLength(1);
+    expect(list[0]?.state).toBe('snoozed');
+  });
+
+  it('snoozeAllForUser() snoozes all open rows but not already-snoozed/dismissed ones', async () => {
+    const repo = makeRepo();
+    const a = await repo.create({
+      orgId: 'o', userId: 'u', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'a',
+    });
+    const b = await repo.create({
+      orgId: 'o', userId: 'u', kind: 'stale_draft',
+      title: '', body: '', dedupKey: 'b',
+    });
+    const c = await repo.create({
+      orgId: 'o', userId: 'u', kind: 'duplicate_dashboard',
+      title: '', body: '', dedupKey: 'c',
+    });
+    await repo.updateState(c.id, 'dismissed');
+
+    const count = await repo.snoozeAllForUser('u', 'o', '3000-01-01T00:00:00.000Z');
+    expect(count).toBe(2);
+
+    const aRow = await repo.findById(a.id);
+    const bRow = await repo.findById(b.id);
+    const cRow = await repo.findById(c.id);
+    expect(aRow?.state).toBe('snoozed');
+    expect(bRow?.state).toBe('snoozed');
+    expect(cRow?.state).toBe('dismissed');
+  });
+
+  it('scopes by userId + orgId', async () => {
+    const repo = makeRepo();
+    await repo.create({
+      orgId: 'o1', userId: 'u1', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'a',
+    });
+    await repo.create({
+      orgId: 'o2', userId: 'u1', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'a',
+    });
+    await repo.create({
+      orgId: 'o1', userId: 'u2', kind: 'missing_dashboard',
+      title: '', body: '', dedupKey: 'a',
+    });
+    const list = await repo.findOpenForUser('u1', 'o1');
+    expect(list).toHaveLength(1);
+  });
+});

--- a/packages/data-layer/src/repository/memory/ai-suggestion.ts
+++ b/packages/data-layer/src/repository/memory/ai-suggestion.ts
@@ -1,0 +1,102 @@
+/**
+ * In-memory IAiSuggestionRepository. Test-fixture only.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  AiSuggestion,
+  AiSuggestionState,
+  IAiSuggestionRepository,
+  NewAiSuggestion,
+} from '@agentic-obs/common';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export class InMemoryAiSuggestionRepository implements IAiSuggestionRepository {
+  private readonly rows = new Map<string, AiSuggestion>();
+
+  async create(input: NewAiSuggestion): Promise<AiSuggestion> {
+    for (const existing of this.rows.values()) {
+      if (existing.userId === input.userId && existing.dedupKey === input.dedupKey) {
+        return existing;
+      }
+    }
+    const id = input.id ?? randomUUID();
+    const now = nowIso();
+    const row: AiSuggestion = {
+      id,
+      orgId: input.orgId,
+      userId: input.userId,
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      actionKind: input.actionKind ?? null,
+      actionPayload: input.actionPayload ?? null,
+      state: 'open',
+      snoozedUntil: null,
+      createdAt: now,
+      updatedAt: now,
+      dedupKey: input.dedupKey,
+    };
+    this.rows.set(id, row);
+    return row;
+  }
+
+  async findById(id: string): Promise<AiSuggestion | null> {
+    return this.rows.get(id) ?? null;
+  }
+
+  async findOpenForUser(
+    userId: string,
+    orgId: string,
+    now: string = nowIso(),
+  ): Promise<AiSuggestion[]> {
+    const list = [...this.rows.values()].filter((r) => {
+      if (r.userId !== userId || r.orgId !== orgId) return false;
+      if (r.state === 'open') return true;
+      if (r.state === 'snoozed' && r.snoozedUntil !== null && r.snoozedUntil <= now) return true;
+      return false;
+    });
+    list.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+    return list;
+  }
+
+  async updateState(
+    id: string,
+    state: AiSuggestionState,
+    snoozedUntil?: string | null,
+  ): Promise<AiSuggestion | null> {
+    const r = this.rows.get(id);
+    if (!r) return null;
+    const updated: AiSuggestion = {
+      ...r,
+      state,
+      snoozedUntil: state === 'snoozed' ? (snoozedUntil ?? null) : null,
+      updatedAt: nowIso(),
+    };
+    this.rows.set(id, updated);
+    return updated;
+  }
+
+  async snoozeAllForUser(
+    userId: string,
+    orgId: string,
+    snoozedUntil: string,
+  ): Promise<number> {
+    let count = 0;
+    for (const [id, r] of this.rows.entries()) {
+      if (r.userId === userId && r.orgId === orgId && r.state === 'open') {
+        this.rows.set(id, {
+          ...r,
+          state: 'snoozed',
+          snoozedUntil,
+          updatedAt: nowIso(),
+        });
+        count += 1;
+      }
+    }
+    return count;
+  }
+}

--- a/packages/data-layer/src/repository/memory/index.ts
+++ b/packages/data-layer/src/repository/memory/index.ts
@@ -6,3 +6,4 @@
 export { InMemoryAlertRuleRepository } from './alert-rule.js';
 export { InMemoryDashboardRepository } from './dashboard.js';
 export { InMemoryDashboardVariableAckRepository } from './dashboard-variable-ack.js';
+export { InMemoryAiSuggestionRepository } from './ai-suggestion.js';

--- a/packages/data-layer/src/repository/postgres/ai-suggestion.ts
+++ b/packages/data-layer/src/repository/postgres/ai-suggestion.ts
@@ -1,0 +1,158 @@
+/**
+ * Postgres repository for `ai_suggestions` — Wave 2 / step 3.
+ * Mirrors the SQLite implementation in ../sqlite/ai-suggestion.ts.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import type {
+  AiSuggestion,
+  AiSuggestionActionKind,
+  AiSuggestionKind,
+  AiSuggestionState,
+  IAiSuggestionRepository,
+  NewAiSuggestion,
+} from '@agentic-obs/common';
+import type { DbClient } from '../../db/client.js';
+
+interface Row {
+  id: string;
+  org_id: string;
+  user_id: string;
+  kind: string;
+  title: string;
+  body: string;
+  action_kind: string | null;
+  action_payload: string | null;
+  state: string;
+  snoozed_until: string | null;
+  created_at: string;
+  updated_at: string;
+  dedup_key: string;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function rowTo(r: Row): AiSuggestion {
+  let payload: Record<string, unknown> | null = null;
+  if (r.action_payload) {
+    try {
+      const parsed = JSON.parse(r.action_payload);
+      if (parsed && typeof parsed === 'object') {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch {
+      payload = null;
+    }
+  }
+  return {
+    id: r.id,
+    orgId: r.org_id,
+    userId: r.user_id,
+    kind: r.kind as AiSuggestionKind,
+    title: r.title,
+    body: r.body,
+    actionKind: (r.action_kind as AiSuggestionActionKind | null) ?? null,
+    actionPayload: payload,
+    state: r.state as AiSuggestionState,
+    snoozedUntil: r.snoozed_until,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    dedupKey: r.dedup_key,
+  };
+}
+
+export class PostgresAiSuggestionRepository implements IAiSuggestionRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async create(input: NewAiSuggestion): Promise<AiSuggestion> {
+    const existing = await this.db.all<Row>(sql`
+      SELECT * FROM ai_suggestions
+      WHERE user_id = ${input.userId} AND dedup_key = ${input.dedupKey}
+      LIMIT 1
+    `);
+    if (existing[0]) return rowTo(existing[0]);
+
+    const id = input.id ?? randomUUID();
+    const now = nowIso();
+    const payload = input.actionPayload ? JSON.stringify(input.actionPayload) : null;
+    await this.db.run(sql`
+      INSERT INTO ai_suggestions (
+        id, org_id, user_id, kind, title, body,
+        action_kind, action_payload,
+        state, snoozed_until,
+        created_at, updated_at, dedup_key
+      ) VALUES (
+        ${id}, ${input.orgId}, ${input.userId}, ${input.kind}, ${input.title}, ${input.body},
+        ${input.actionKind ?? null}, ${payload},
+        'open', NULL,
+        ${now}, ${now}, ${input.dedupKey}
+      )
+    `);
+    const rows = await this.db.all<Row>(sql`SELECT * FROM ai_suggestions WHERE id = ${id}`);
+    return rowTo(rows[0]!);
+  }
+
+  async findById(id: string): Promise<AiSuggestion | null> {
+    const rows = await this.db.all<Row>(sql`SELECT * FROM ai_suggestions WHERE id = ${id}`);
+    return rows[0] ? rowTo(rows[0]) : null;
+  }
+
+  async findOpenForUser(
+    userId: string,
+    orgId: string,
+    now: string = nowIso(),
+  ): Promise<AiSuggestion[]> {
+    const rows = await this.db.all<Row>(sql`
+      SELECT * FROM ai_suggestions
+      WHERE user_id = ${userId}
+        AND org_id = ${orgId}
+        AND (
+          state = 'open'
+          OR (state = 'snoozed' AND snoozed_until IS NOT NULL AND snoozed_until <= ${now})
+        )
+      ORDER BY created_at DESC
+    `);
+    return rows.map(rowTo);
+  }
+
+  async updateState(
+    id: string,
+    state: AiSuggestionState,
+    snoozedUntil?: string | null,
+  ): Promise<AiSuggestion | null> {
+    const now = nowIso();
+    const effectiveSnooze = state === 'snoozed' ? (snoozedUntil ?? null) : null;
+    await this.db.run(sql`
+      UPDATE ai_suggestions
+      SET state = ${state},
+          snoozed_until = ${effectiveSnooze},
+          updated_at = ${now}
+      WHERE id = ${id}
+    `);
+    return this.findById(id);
+  }
+
+  async snoozeAllForUser(
+    userId: string,
+    orgId: string,
+    snoozedUntil: string,
+  ): Promise<number> {
+    const before = await this.db.all<{ n: number | string }>(sql`
+      SELECT COUNT(*) AS n FROM ai_suggestions
+      WHERE user_id = ${userId} AND org_id = ${orgId} AND state = 'open'
+    `);
+    const count = Number(before[0]?.n ?? 0);
+    const now = nowIso();
+    await this.db.run(sql`
+      UPDATE ai_suggestions
+      SET state = 'snoozed',
+          snoozed_until = ${snoozedUntil},
+          updated_at = ${now}
+      WHERE user_id = ${userId} AND org_id = ${orgId} AND state = 'open'
+    `);
+    return count;
+  }
+}

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -908,3 +908,26 @@ CREATE TABLE IF NOT EXISTS dashboard_variable_ack (
 
 CREATE INDEX IF NOT EXISTS idx_var_ack
   ON dashboard_variable_ack(user_id, dashboard_uid);
+
+-- ============================================================================
+-- AI Suggestions inbox (Wave 2 / step 3). Mirror of sqlite-schema.sql.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS ai_suggestions (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL,
+  user_id         TEXT NOT NULL,
+  kind            TEXT NOT NULL,
+  title           TEXT NOT NULL,
+  body            TEXT NOT NULL,
+  action_kind     TEXT NULL,
+  action_payload  TEXT NULL,
+  state           TEXT NOT NULL DEFAULT 'open',
+  snoozed_until   TEXT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  dedup_key       TEXT NOT NULL,
+  UNIQUE(user_id, dedup_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_suggestions_user_state ON ai_suggestions(user_id, state);

--- a/packages/data-layer/src/repository/sqlite/ai-suggestion.ts
+++ b/packages/data-layer/src/repository/sqlite/ai-suggestion.ts
@@ -1,0 +1,162 @@
+/**
+ * SQLite repository for `ai_suggestions` — Wave 2 / step 3.
+ *
+ * The unique `(user_id, dedup_key)` index drives idempotent generation:
+ * a generator can call `create()` on every run and the second call is a
+ * no-op (we keep the existing row).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import type {
+  AiSuggestion,
+  AiSuggestionActionKind,
+  AiSuggestionKind,
+  AiSuggestionState,
+  IAiSuggestionRepository,
+  NewAiSuggestion,
+} from '@agentic-obs/common';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+
+interface Row {
+  id: string;
+  org_id: string;
+  user_id: string;
+  kind: string;
+  title: string;
+  body: string;
+  action_kind: string | null;
+  action_payload: string | null;
+  state: string;
+  snoozed_until: string | null;
+  created_at: string;
+  updated_at: string;
+  dedup_key: string;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function rowTo(r: Row): AiSuggestion {
+  let payload: Record<string, unknown> | null = null;
+  if (r.action_payload) {
+    try {
+      const parsed = JSON.parse(r.action_payload);
+      if (parsed && typeof parsed === 'object') {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch {
+      payload = null;
+    }
+  }
+  return {
+    id: r.id,
+    orgId: r.org_id,
+    userId: r.user_id,
+    kind: r.kind as AiSuggestionKind,
+    title: r.title,
+    body: r.body,
+    actionKind: (r.action_kind as AiSuggestionActionKind | null) ?? null,
+    actionPayload: payload,
+    state: r.state as AiSuggestionState,
+    snoozedUntil: r.snoozed_until,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    dedupKey: r.dedup_key,
+  };
+}
+
+export class SqliteAiSuggestionRepository implements IAiSuggestionRepository {
+  constructor(private readonly db: SqliteClient) {}
+
+  async create(input: NewAiSuggestion): Promise<AiSuggestion> {
+    // Idempotent upsert by (user_id, dedup_key). Existing row is preserved.
+    const existing = this.db.all<Row>(sql`
+      SELECT * FROM ai_suggestions
+      WHERE user_id = ${input.userId} AND dedup_key = ${input.dedupKey}
+      LIMIT 1
+    `);
+    if (existing[0]) return rowTo(existing[0]);
+
+    const id = input.id ?? randomUUID();
+    const now = nowIso();
+    const payload = input.actionPayload ? JSON.stringify(input.actionPayload) : null;
+    this.db.run(sql`
+      INSERT INTO ai_suggestions (
+        id, org_id, user_id, kind, title, body,
+        action_kind, action_payload,
+        state, snoozed_until,
+        created_at, updated_at, dedup_key
+      ) VALUES (
+        ${id}, ${input.orgId}, ${input.userId}, ${input.kind}, ${input.title}, ${input.body},
+        ${input.actionKind ?? null}, ${payload},
+        'open', NULL,
+        ${now}, ${now}, ${input.dedupKey}
+      )
+    `);
+    const rows = this.db.all<Row>(sql`SELECT * FROM ai_suggestions WHERE id = ${id}`);
+    return rowTo(rows[0]!);
+  }
+
+  async findById(id: string): Promise<AiSuggestion | null> {
+    const rows = this.db.all<Row>(sql`SELECT * FROM ai_suggestions WHERE id = ${id}`);
+    return rows[0] ? rowTo(rows[0]) : null;
+  }
+
+  async findOpenForUser(
+    userId: string,
+    orgId: string,
+    now: string = nowIso(),
+  ): Promise<AiSuggestion[]> {
+    const rows = this.db.all<Row>(sql`
+      SELECT * FROM ai_suggestions
+      WHERE user_id = ${userId}
+        AND org_id = ${orgId}
+        AND (
+          state = 'open'
+          OR (state = 'snoozed' AND snoozed_until IS NOT NULL AND snoozed_until <= ${now})
+        )
+      ORDER BY created_at DESC
+    `);
+    return rows.map(rowTo);
+  }
+
+  async updateState(
+    id: string,
+    state: AiSuggestionState,
+    snoozedUntil?: string | null,
+  ): Promise<AiSuggestion | null> {
+    const now = nowIso();
+    const effectiveSnooze = state === 'snoozed' ? (snoozedUntil ?? null) : null;
+    this.db.run(sql`
+      UPDATE ai_suggestions
+      SET state = ${state},
+          snoozed_until = ${effectiveSnooze},
+          updated_at = ${now}
+      WHERE id = ${id}
+    `);
+    return this.findById(id);
+  }
+
+  async snoozeAllForUser(
+    userId: string,
+    orgId: string,
+    snoozedUntil: string,
+  ): Promise<number> {
+    const before = this.db.all<{ n: number }>(sql`
+      SELECT COUNT(*) AS n FROM ai_suggestions
+      WHERE user_id = ${userId} AND org_id = ${orgId} AND state = 'open'
+    `);
+    const count = Number(before[0]?.n ?? 0);
+    const now = nowIso();
+    this.db.run(sql`
+      UPDATE ai_suggestions
+      SET state = 'snoozed',
+          snoozed_until = ${snoozedUntil},
+          updated_at = ${now}
+      WHERE user_id = ${userId} AND org_id = ${orgId} AND state = 'open'
+    `);
+    return count;
+  }
+}

--- a/packages/web/src/components/AISuggestionsInbox.tsx
+++ b/packages/web/src/components/AISuggestionsInbox.tsx
@@ -1,0 +1,213 @@
+/**
+ * AISuggestionsInbox — Wave 2 / step 3.
+ *
+ * The single inbox on Home for AI-generated proposals. Why one inbox and
+ * not 6 notification channels: see the design doc — 6 channels become
+ * spam, one inbox stays glanceable.
+ *
+ * UI states:
+ *   - loading      → render nothing (we render alongside other Home cards,
+ *                    so a spinner would just flash)
+ *   - empty        → "Nothing to suggest right now. Rounds will check
+ *                    again later."
+ *   - has rows     → list rows with Accept / Snooze / Dismiss buttons
+ *
+ * Optimistic updates: clicking Accept/Snooze/Dismiss removes the row
+ * locally before the request resolves. If the server returns an error we
+ * refetch — we don't try to put the row back surgically because the inbox
+ * is small and a refetch is cheap.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '../api/client.js';
+
+interface AiSuggestion {
+  id: string;
+  kind: string;
+  title: string;
+  body: string;
+  actionKind: string | null;
+  state: string;
+}
+
+interface AcceptResult {
+  suggestion: AiSuggestion;
+  action: { kind: 'navigate'; url: string } | { kind: 'message'; message: string } | null;
+}
+
+function actionLabel(kind: string | null): string {
+  switch (kind) {
+    case 'create_dashboard':
+      return 'Yes, create';
+    case 'archive_resources':
+      return 'Review';
+    case 'merge_dashboards':
+      return 'Compare';
+    default:
+      return 'Accept';
+  }
+}
+
+export function AISuggestionsInbox(): JSX.Element | null {
+  const [items, setItems] = useState<AiSuggestion[] | null>(null);
+  const [snoozeOpenFor, setSnoozeOpenFor] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await apiClient.get<{ suggestions: AiSuggestion[] }>('/suggestions');
+    if (!res.error && res.data?.suggestions) {
+      setItems(res.data.suggestions);
+    } else if (!res.error) {
+      setItems([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const optimisticRemove = useCallback((id: string) => {
+    setItems((prev) => (prev ? prev.filter((s) => s.id !== id) : prev));
+  }, []);
+
+  const handleAccept = useCallback(
+    async (s: AiSuggestion) => {
+      optimisticRemove(s.id);
+      const res = await apiClient.post<AcceptResult>(`/suggestions/${s.id}/accept`, {});
+      if (res.error) {
+        void refresh();
+        return;
+      }
+      const action = res.data?.action;
+      if (action && action.kind === 'navigate') {
+        window.location.assign(action.url);
+      }
+    },
+    [optimisticRemove, refresh],
+  );
+
+  const handleSnooze = useCallback(
+    async (id: string, days: 1 | 7) => {
+      setSnoozeOpenFor(null);
+      optimisticRemove(id);
+      const res = await apiClient.post(`/suggestions/${id}/snooze`, { days });
+      if (res.error) void refresh();
+    },
+    [optimisticRemove, refresh],
+  );
+
+  const handleDismiss = useCallback(
+    async (id: string) => {
+      optimisticRemove(id);
+      const res = await apiClient.post(`/suggestions/${id}/dismiss`, {});
+      if (res.error) void refresh();
+    },
+    [optimisticRemove, refresh],
+  );
+
+  const handleSnoozeAll = useCallback(async () => {
+    setItems([]);
+    const res = await apiClient.post('/suggestions/snooze-all', { days: 7 });
+    if (res.error) void refresh();
+  }, [refresh]);
+
+  if (items === null) return null;
+
+  return (
+    <section
+      className="rounded-lg border border-outline-variant bg-surface-container/40 p-4"
+      aria-label="AI suggestions"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+          AI Suggestions {items.length > 0 ? `(${items.length})` : ''}
+        </h2>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm text-on-surface-variant">
+          Nothing to suggest right now. Rounds will check again later.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {items.map((s) => (
+            <li
+              key={s.id}
+              className="rounded-md border border-outline-variant/60 bg-surface-lowest p-3"
+            >
+              <div className="flex items-start gap-2">
+                <span aria-hidden className="text-base">
+                  💡
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-on-surface">{s.title}</p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                    <button
+                      type="button"
+                      onClick={() => void handleAccept(s)}
+                      className="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-primary hover:bg-primary/20"
+                    >
+                      {actionLabel(s.actionKind)}
+                    </button>
+
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setSnoozeOpenFor((cur) => (cur === s.id ? null : s.id))
+                        }
+                        className="rounded-full border border-outline-variant px-3 py-1 text-on-surface-variant hover:bg-surface-container"
+                      >
+                        Snooze
+                      </button>
+                      {snoozeOpenFor === s.id && (
+                        <div
+                          role="menu"
+                          className="absolute z-10 mt-1 flex flex-col gap-1 rounded-md border border-outline-variant bg-surface p-1 shadow"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => void handleSnooze(s.id, 1)}
+                            className="px-3 py-1 text-left text-xs text-on-surface hover:bg-surface-container"
+                          >
+                            1 day
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void handleSnooze(s.id, 7)}
+                            className="px-3 py-1 text-left text-xs text-on-surface hover:bg-surface-container"
+                          >
+                            1 week
+                          </button>
+                        </div>
+                      )}
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => void handleDismiss(s.id)}
+                      className="rounded-full border border-outline-variant px-3 py-1 text-on-surface-variant hover:bg-surface-container"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {items.length > 0 && (
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => void handleSnoozeAll()}
+            className="text-xs text-on-surface-variant hover:text-on-surface"
+          >
+            Snooze all for a week
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import {
 } from '../components/chat/MessageComponents.js';
 import AgentActivityBlock from '../components/chat/AgentActivityBlock.js';
 import { RoundsLogo } from '../components/RoundsLogo.js';
+import { AISuggestionsInbox } from '../components/AISuggestionsInbox.js';
 
 // Types
 
@@ -336,6 +337,16 @@ export default function Home() {
                   <span className="truncate">{action.label}</span>
                 </button>
               ))}
+            </motion.div>
+
+            <motion.div
+              className="mt-8"
+              variants={fadeIn}
+              initial="hidden"
+              animate="visible"
+              transition={{ delay: 0.23 }}
+            >
+              <AISuggestionsInbox />
             </motion.div>
 
             {sessions.length > 0 && (


### PR DESCRIPTION
Wave 2 Step 3 — one inbox on Home replaces 6 separate notification channels (which would become spam per the design doc).

## Changes

### Backend
- New table \`ai_suggestions\` (sqlite + postgres) — \`UNIQUE(user_id, dedup_key)\`
- \`IAiSuggestionRepository\` + sqlite/postgres/InMemory impls (ADR-001)
- 3 generators (run on-demand by GET /api/suggestions, deduped via dedup_key):
  - **MissingDashboardSuggestionGenerator** — top 5 recent alerts without matching dashboard
  - **StaleDraftSuggestionGenerator** — personal-folder dashboards not touched in 30d (uses \`updated\` as last-opened proxy)
  - **DuplicateDashboardSuggestionGenerator** — same first-query buckets, top 1 pair only
- REST:
  - \`GET /api/suggestions\` → open + resurfaced
  - \`POST /api/suggestions/:id/accept\` → dispatches action handler, returns navigation URL
  - \`POST /api/suggestions/:id/snooze\` body \`{ days: 1 | 7 }\`
  - \`POST /api/suggestions/:id/dismiss\` (terminal)
  - \`POST /api/suggestions/snooze-all\` body \`{ days: 7 }\`
- Action handler dispatch:
  - \`create_dashboard\` → navigate \`/dashboards/new?title=...&prompt=...\`
  - \`archive_resources\` → navigate \`/dashboards?preselect=<ids>\` (STUB — lifecycle archive not built)
  - \`merge_dashboards\` → navigate \`/dashboards/compare?a=<id>&b=<id>\` (compare page is a future surface)
- Audit: SUGGESTION_ACCEPTED / DISMISSED / SNOOZED added to enum

### Frontend
- AISuggestionsInbox component on Home page
- Snooze popover (1d / 1w)
- Snooze-all button
- Empty state copy

## Stubbed (intentional)

- **archive_resources** doesn't archive — lifecycle column deferred in Wave 1 PR-C. Navigates to a review queue instead. UI needs to honor \`?preselect=<ids>\` (read-side not in this PR).
- **merge_dashboards** comparison page itself isn't built.
- No real-time push — polling on Home.

## Test plan

- [x] 23/23 tests pass across 4 files
- [x] Repository: dedup, scoping, state transitions (open→snoozed→resurfaced, dismissed terminal)
- [x] Each generator's positive + negative path
- [x] Action handler URL shape
- [x] Route: GET excludes snoozed, snooze→resurface, 403 ownership, 400 invalid days
- [ ] CI green