### PR TITLE
Wave 2.2: Service attribution (Tier 1) + Services page

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -218,9 +218,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     accessControl,
     setupConfig,
     audit: authSub.audit,
-<<<<<<< HEAD
     variableAcks: repos.dashboardVariableAcks,
-=======
     serviceAttribution: repos.serviceAttribution,
   }));
   app.use('/api/services', createServicesRouter({
@@ -230,7 +228,6 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     investigations: repos.investigations,
     accessControl,
     audit: authSub.audit,
->>>>>>> a1a5602 (wave2.2: services router + Tier-1 attribution on dashboard/alert-rule writes)
   }));
   app.use('/api/chat', createChatRouter({
     dashboardStore: repos.dashboards,

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -43,6 +43,7 @@ import { createSystemRouter } from '../routes/system.js';
 import { createDashboardRouter } from '../routes/dashboard/router.js';
 import { createAlertRulesRouter } from '../routes/alert-rules.js';
 import { createResourcesPromoteRouter } from '../routes/resources-promote.js';
+import { createServicesRouter } from '../routes/services.js';
 import { PromoteService } from '../services/promote-service.js';
 import { createSuggestionsRouter } from '../routes/suggestions.js';
 import { defaultGenerators } from '../services/suggestion-generators.js';
@@ -217,7 +218,19 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     accessControl,
     setupConfig,
     audit: authSub.audit,
+<<<<<<< HEAD
     variableAcks: repos.dashboardVariableAcks,
+=======
+    serviceAttribution: repos.serviceAttribution,
+  }));
+  app.use('/api/services', createServicesRouter({
+    serviceAttribution: repos.serviceAttribution,
+    dashboards: repos.dashboards,
+    alertRules: eventAlertRuleStore,
+    investigations: repos.investigations,
+    accessControl,
+    audit: authSub.audit,
+>>>>>>> a1a5602 (wave2.2: services router + Tier-1 attribution on dashboard/alert-rule writes)
   }));
   app.use('/api/chat', createChatRouter({
     dashboardStore: repos.dashboards,
@@ -245,6 +258,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     folderRepository: sharedFolderRepo,
     ac: accessControl,
     audit: authSub.audit,
+    serviceAttribution: repos.serviceAttribution,
     ...(deps.runner ? { runner: deps.runner } : {}),
   }));
   // /api/folders is mounted in rbac-routes.ts (T7.1).

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -9,7 +9,8 @@ import {
   ProvisionedResourceError,
 } from '@agentic-obs/common';
 import type { AuditWriter } from '../auth/audit-writer.js';
-import type { IAlertRuleRepository, IGatewayInvestigationStore, IGatewayFeedStore, IInvestigationReportRepository } from '@agentic-obs/data-layer';
+import type { IAlertRuleRepository, IGatewayInvestigationStore, IGatewayFeedStore, IInvestigationReportRepository, IServiceAttributionRepository } from '@agentic-obs/data-layer';
+import { applyTier1PromqlAttribution } from '@agentic-obs/data-layer';
 import { runBackgroundAgent, type BackgroundRunnerDeps } from '@agentic-obs/agent-core';
 import { createLogger } from '@agentic-obs/common/logging';
 import { authMiddleware } from '../middleware/auth.js';
@@ -64,6 +65,11 @@ export interface AlertRulesRouterDeps {
    * investigation.create events for manual investigate flows.
    */
   audit?: AuditWriter;
+  /**
+   * W2 step 2 — Tier-1 service-name extraction from the PromQL condition.
+   * Optional so legacy tests can construct the router without one.
+   */
+  serviceAttribution?: IServiceAttributionRepository;
 }
 
 export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
@@ -416,6 +422,16 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         outcome: 'success',
         metadata: { folderUid: rule.folderUid, severity: rule.severity },
       });
+
+      // W2 step 2 — Tier-1 attribution from `service="..."` label in the
+      // PromQL condition. Best-effort; failures are swallowed.
+      if (deps.serviceAttribution && rule.condition?.query) {
+        void applyTier1PromqlAttribution(deps.serviceAttribution, workspaceId, {
+          kind: 'alert_rule',
+          id: rule.id,
+          queries: [rule.condition.query],
+        });
+      }
 
       res.status(201).json(rule);
     },

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -5,7 +5,8 @@ import { randomUUID } from 'crypto'
 import type { AuthenticatedRequest } from '../../middleware/auth.js'
 import { authMiddleware } from '../../middleware/auth.js'
 import { createRequirePermission } from '../../middleware/require-permission.js'
-import type { IGatewayDashboardStore } from '@agentic-obs/data-layer'
+import type { IGatewayDashboardStore, IServiceAttributionRepository } from '@agentic-obs/data-layer'
+import { applyTier1PromqlAttribution } from '@agentic-obs/data-layer'
 import { VariableResolver } from './variable-resolver.js'
 import { ac, ACTIONS, AuditAction, assertWritable, ProvisionedResourceError, hashVariables } from '@agentic-obs/common'
 import type { IDashboardVariableAckRepository } from '@agentic-obs/common'
@@ -44,6 +45,11 @@ export interface DashboardRouterDeps {
    * on it return 503 when missing.
    */
   variableAcks?: IDashboardVariableAckRepository
+  /**
+   * W2 step 2 — Tier-1 service-name extraction from panel PromQL. Optional
+   * so legacy tests can construct the router without one.
+   */
+  serviceAttribution?: IServiceAttributionRepository
 }
 
 export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter {
@@ -52,6 +58,31 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
   const setupConfig = deps.setupConfig
   const audit = deps.audit
   const variableAcks = deps.variableAcks
+  const serviceAttribution = deps.serviceAttribution
+
+  function panelsToPromqlQueries(panels: PanelConfig[]): string[] {
+    const out: string[] = []
+    for (const p of panels) {
+      if (p.query) out.push(p.query)
+      if (p.queries) for (const q of p.queries) if (q.expr) out.push(q.expr)
+    }
+    return out
+  }
+
+  /**
+   * Tier-1 service auto-fill. Best-effort: writes a `prom_label` attribution
+   * row with confidence 0.95 when any panel query contains a `service="x"`
+   * label. Runs after the primary panel write; failures are swallowed inside
+   * `applyTier1PromqlAttribution`.
+   */
+  async function autoAttributeDashboard(orgId: string, dashboardId: string, panels: PanelConfig[]): Promise<void> {
+    if (!serviceAttribution) return
+    await applyTier1PromqlAttribution(serviceAttribution, orgId, {
+      kind: 'dashboard',
+      id: dashboardId,
+      queries: panelsToPromqlQueries(panels),
+    })
+  }
 
   const router = Router()
   const requirePermission = createRequirePermission(accessControl)
@@ -370,6 +401,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         return
       }
 
+      void autoAttributeDashboard(resolveOrgId(req), id, body.panels)
       res.json(updated)
     }
     catch (err) {
@@ -400,6 +432,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
         return
       }
 
+      void autoAttributeDashboard(resolveOrgId(req), id, updated.panels)
       res.status(201).json(updated)
     }
     catch (err) {

--- a/packages/api-gateway/src/routes/services.ts
+++ b/packages/api-gateway/src/routes/services.ts
@@ -11,12 +11,12 @@ import { Router } from 'express';
 import type { Router as ExpressRouter, Request, Response, NextFunction } from 'express';
 import type {
   IServiceAttributionRepository,
-  IDashboardRepository,
   IAlertRuleRepository,
   AttributionResourceKind,
 } from '@agentic-obs/data-layer';
 import type { IInvestigationRepository } from '@agentic-obs/data-layer';
 import { ac, ACTIONS, AuditAction } from '@agentic-obs/common';
+import type { IDashboardRepository } from '@agentic-obs/common';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import { authMiddleware } from '../middleware/auth.js';
@@ -28,7 +28,9 @@ export interface ServicesRouterDeps {
   serviceAttribution: IServiceAttributionRepository;
   dashboards: IDashboardRepository;
   alertRules: IAlertRuleRepository;
-  investigations: IInvestigationRepository;
+  // Only uses findAll — kept narrow so RepositoryBundle.investigations (which
+  // intersects with IGatewayInvestigationStore) satisfies it structurally.
+  investigations: Pick<IInvestigationRepository, 'findAll'>;
   accessControl: AccessControlSurface;
   audit?: AuditWriter;
 }
@@ -264,7 +266,7 @@ async function listAlertRuleIds(repo: IAlertRuleRepository, orgId: string): Prom
 }
 
 async function listInvestigationIds(
-  repo: IInvestigationRepository,
+  repo: Pick<IInvestigationRepository, 'findAll'>,
   orgId: string,
 ): Promise<string[]> {
   const all = await repo.findAll({ tenantId: orgId });

--- a/packages/api-gateway/src/routes/services.ts
+++ b/packages/api-gateway/src/routes/services.ts
@@ -1,0 +1,272 @@
+/**
+ * Services router (Wave 2 / Step 2).
+ *
+ * Service is the primary organizing concept for Rounds — derived from the
+ * `resource_service_attribution` table. Resources without a high-confidence
+ * (or user-confirmed) attribution row are surfaced in the Unassigned bucket
+ * so the user can bulk-assign.
+ */
+
+import { Router } from 'express';
+import type { Router as ExpressRouter, Request, Response, NextFunction } from 'express';
+import type {
+  IServiceAttributionRepository,
+  IDashboardRepository,
+  IAlertRuleRepository,
+  AttributionResourceKind,
+} from '@agentic-obs/data-layer';
+import type { IInvestigationRepository } from '@agentic-obs/data-layer';
+import { ac, ACTIONS, AuditAction } from '@agentic-obs/common';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import { createRequirePermission } from '../middleware/require-permission.js';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { getOrgId } from '../middleware/workspace-context.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+
+export interface ServicesRouterDeps {
+  serviceAttribution: IServiceAttributionRepository;
+  dashboards: IDashboardRepository;
+  alertRules: IAlertRuleRepository;
+  investigations: IInvestigationRepository;
+  accessControl: AccessControlSurface;
+  audit?: AuditWriter;
+}
+
+function resolveOrgId(req: Request): string {
+  const authed = (req as Request & { auth?: { orgId?: string } }).auth;
+  if (authed?.orgId) return authed.orgId;
+  return getOrgId(req);
+}
+
+export function createServicesRouter(deps: ServicesRouterDeps): ExpressRouter {
+  const router = Router();
+  const requirePermission = createRequirePermission(deps.accessControl);
+
+  router.use(authMiddleware);
+
+  /**
+   * GET /api/services
+   * → { services: [{ name, resourceCount }], unassignedCount }
+   *
+   * `unassignedCount` is computed across the three attributable resource
+   * kinds (dashboards, alert rules, investigations) — the union of resource
+   * ids belonging to this org minus those with a visible attribution row.
+   */
+  router.get(
+    '/',
+    requirePermission(() => ac.eval(ACTIONS.DashboardsRead, 'dashboards:*')),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const orgId = resolveOrgId(req);
+        const services = await deps.serviceAttribution.listServices(orgId);
+
+        const [dashIds, ruleIds, invIds] = await Promise.all([
+          listDashboardIds(deps.dashboards, orgId),
+          listAlertRuleIds(deps.alertRules, orgId),
+          listInvestigationIds(deps.investigations, orgId),
+        ]);
+
+        const [dashUn, ruleUn, invUn] = await Promise.all([
+          deps.serviceAttribution.listUnassigned(orgId, 'dashboard', dashIds),
+          deps.serviceAttribution.listUnassigned(orgId, 'alert_rule', ruleIds),
+          deps.serviceAttribution.listUnassigned(orgId, 'investigation', invIds),
+        ]);
+        const unassignedCount = dashUn.length + ruleUn.length + invUn.length;
+
+        res.json({ services, unassignedCount });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  /**
+   * GET /api/services/unassigned
+   * → { resources: [{ kind, id, title }] }
+   *
+   * Lists each resource of every kind with no visible attribution. `title`
+   * is whatever the underlying resource exposes (dashboard.title,
+   * alert_rule.name, investigation.intent).
+   */
+  router.get(
+    '/unassigned',
+    requirePermission(() => ac.eval(ACTIONS.DashboardsRead, 'dashboards:*')),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const orgId = resolveOrgId(req);
+        const out: Array<{ kind: AttributionResourceKind; id: string; title: string }> = [];
+
+        const dashboards = await deps.dashboards.findAll();
+        const ownedDashboards = dashboards.filter((d) => d.workspaceId === orgId);
+        const dashUn = await deps.serviceAttribution.listUnassigned(
+          orgId,
+          'dashboard',
+          ownedDashboards.map((d) => d.id),
+        );
+        const dashByIdTitle = new Map(ownedDashboards.map((d) => [d.id, d.title]));
+        for (const id of dashUn) {
+          out.push({ kind: 'dashboard', id, title: dashByIdTitle.get(id) ?? id });
+        }
+
+        const rulesPage = await deps.alertRules.findAll();
+        const ownedRules = rulesPage.list.filter((r) => r.workspaceId === orgId);
+        const ruleUn = await deps.serviceAttribution.listUnassigned(
+          orgId,
+          'alert_rule',
+          ownedRules.map((r) => r.id),
+        );
+        const ruleByIdName = new Map(ownedRules.map((r) => [r.id, r.name]));
+        for (const id of ruleUn) {
+          out.push({ kind: 'alert_rule', id, title: ruleByIdName.get(id) ?? id });
+        }
+
+        const invs = await deps.investigations.findAll({ tenantId: orgId });
+        const invUn = await deps.serviceAttribution.listUnassigned(
+          orgId,
+          'investigation',
+          invs.map((i) => i.id),
+        );
+        const invByIdIntent = new Map(invs.map((i) => [i.id, i.intent]));
+        for (const id of invUn) {
+          out.push({ kind: 'investigation', id, title: invByIdIntent.get(id) ?? id });
+        }
+
+        res.json({ resources: out });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  /**
+   * GET /api/services/:name
+   * → { name, dashboards, alertRules, investigations, owner?, deploys? }
+   *
+   * owner/deploys are stubbed null in this PR; the UI shows them when
+   * present. Filling them is a follow-up (k8s reconciler / change-event
+   * cross-link).
+   */
+  router.get(
+    '/:name',
+    requirePermission(() => ac.eval(ACTIONS.DashboardsRead, 'dashboards:*')),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const orgId = resolveOrgId(req);
+        const name = decodeURIComponent(req.params['name'] ?? '');
+        if (!name) {
+          res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'service name required' } });
+          return;
+        }
+        const refs = await deps.serviceAttribution.listResourcesForService(orgId, name);
+        const dashboardIds = refs.filter((r) => r.kind === 'dashboard').map((r) => r.id);
+        const alertIds = refs.filter((r) => r.kind === 'alert_rule').map((r) => r.id);
+        const invIds = refs.filter((r) => r.kind === 'investigation').map((r) => r.id);
+
+        const [allDashboards, allRulesPage, allInvs] = await Promise.all([
+          deps.dashboards.findAll(),
+          deps.alertRules.findAll(),
+          deps.investigations.findAll({ tenantId: orgId }),
+        ]);
+        const dashSet = new Set(dashboardIds);
+        const ruleSet = new Set(alertIds);
+        const invSet = new Set(invIds);
+
+        res.json({
+          name,
+          dashboards: allDashboards
+            .filter((d) => dashSet.has(d.id) && d.workspaceId === orgId)
+            .map((d) => ({ id: d.id, title: d.title })),
+          alertRules: allRulesPage.list
+            .filter((r) => ruleSet.has(r.id) && r.workspaceId === orgId)
+            .map((r) => ({ id: r.id, name: r.name, state: r.state, severity: r.severity })),
+          investigations: allInvs
+            .filter((i) => invSet.has(i.id))
+            .map((i) => ({ id: i.id, intent: i.intent, status: i.status })),
+          owner: null,
+          deploys: [],
+        });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  /**
+   * POST /api/services/:name/assign
+   * body: { resourceKind, resourceId }
+   *
+   * Writes a manual attribution row (tier 4, user_confirmed=1) and an
+   * audit entry. Idempotent: a second call with the same payload updates
+   * the existing row's service_name.
+   */
+  router.post(
+    '/:name/assign',
+    requirePermission(() => ac.eval(ACTIONS.DashboardsWrite, 'dashboards:*')),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const orgId = resolveOrgId(req);
+        const userId = (req as AuthenticatedRequest).auth?.userId ?? 'anonymous';
+        const name = decodeURIComponent(req.params['name'] ?? '');
+        const body = req.body as { resourceKind?: unknown; resourceId?: unknown };
+        const kind = body.resourceKind;
+        const id = body.resourceId;
+        if (
+          !name ||
+          (kind !== 'dashboard' && kind !== 'alert_rule' && kind !== 'investigation') ||
+          typeof id !== 'string' ||
+          !id
+        ) {
+          res.status(400).json({
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'name (path) and { resourceKind, resourceId } body are required',
+            },
+          });
+          return;
+        }
+        const row = await deps.serviceAttribution.confirmAttribution(
+          orgId,
+          kind,
+          id,
+          name,
+          userId,
+        );
+        void deps.audit?.log({
+          action: AuditAction.ServiceAttributionConfirm,
+          actorType: 'user',
+          actorId: userId,
+          orgId,
+          targetType: kind,
+          targetId: id,
+          targetName: name,
+          outcome: 'success',
+          metadata: { sourceTier: 4, sourceKind: 'manual', confidence: 1 },
+        });
+        res.status(200).json(row);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  return router;
+}
+
+async function listDashboardIds(repo: IDashboardRepository, orgId: string): Promise<string[]> {
+  const all = await repo.findAll();
+  return all.filter((d) => d.workspaceId === orgId).map((d) => d.id);
+}
+
+async function listAlertRuleIds(repo: IAlertRuleRepository, orgId: string): Promise<string[]> {
+  const page = await repo.findAll();
+  return page.list.filter((r) => r.workspaceId === orgId).map((r) => r.id);
+}
+
+async function listInvestigationIds(
+  repo: IInvestigationRepository,
+  orgId: string,
+): Promise<string[]> {
+  const all = await repo.findAll({ tenantId: orgId });
+  return all.map((i) => i.id);
+}

--- a/packages/data-layer/src/db/sqlite-schema.sql
+++ b/packages/data-layer/src/db/sqlite-schema.sql
@@ -950,3 +950,35 @@ CREATE TABLE IF NOT EXISTS ai_suggestions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_suggestions_user_state ON ai_suggestions(user_id, state);
+
+-- ============================================================================
+-- Service attribution (Wave 2 / Step 2)
+--
+-- Maps observable resources (dashboards, alert rules, investigations) to a
+-- free-form service name. Service is not a separate table per the spike doc
+-- (RFC-4 ADR) — it's just a string, populated by tiered sources:
+--   tier 1: Prometheus label / GitHub repo name (high-confidence, automatic)
+--   tier 2: k8s reconciler (future)
+--   tier 3: AI inference (future)
+--   tier 4: manual confirm by user (user_confirmed=1)
+--
+-- One row per (resource, source) — multiple sources may attribute the same
+-- resource. Visibility threshold is `user_confirmed=1 OR confidence >= 0.8`.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS resource_service_attribution (
+  id             TEXT PRIMARY KEY,
+  org_id         TEXT NOT NULL,
+  resource_kind  TEXT NOT NULL,
+  resource_id    TEXT NOT NULL,
+  service_name   TEXT NOT NULL,
+  source_tier    INTEGER NOT NULL,
+  source_kind    TEXT NOT NULL,
+  confidence     REAL NOT NULL,
+  user_confirmed INTEGER NOT NULL DEFAULT 0,
+  created_at     TEXT NOT NULL,
+  UNIQUE(org_id, resource_kind, resource_id, source_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_attr_service  ON resource_service_attribution(org_id, service_name);
+CREATE INDEX IF NOT EXISTS idx_attr_resource ON resource_service_attribution(org_id, resource_kind, resource_id);

--- a/packages/data-layer/src/db/sqlite-schema.ts
+++ b/packages/data-layer/src/db/sqlite-schema.ts
@@ -2,6 +2,7 @@ import {
   sqliteTable,
   text,
   integer,
+  real,
   index,
   uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
@@ -612,5 +613,28 @@ export const dashboardVariableAck = sqliteTable(
       t.varsHash,
     ),
     index('idx_var_ack').on(t.userId, t.dashboardUid),
+  ],
+);
+
+// — resource service attribution (Wave 2 / Step 2)
+
+export const resourceServiceAttribution = sqliteTable(
+  'resource_service_attribution',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    resourceKind: text('resource_kind').notNull(),
+    resourceId: text('resource_id').notNull(),
+    serviceName: text('service_name').notNull(),
+    sourceTier: integer('source_tier').notNull(),
+    sourceKind: text('source_kind').notNull(),
+    confidence: real('confidence').notNull(),
+    userConfirmed: integer('user_confirmed', { mode: 'boolean' }).notNull().default(false),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    uniqueIndex('idx_attr_unique').on(t.orgId, t.resourceKind, t.resourceId, t.sourceKind),
+    index('idx_attr_service').on(t.orgId, t.serviceName),
+    index('idx_attr_resource').on(t.orgId, t.resourceKind, t.resourceId),
   ],
 );

--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -16,6 +16,7 @@ import type {
   IChatSessionContextRepository,
   IChatMessageRepository,
   IChatSessionEventRepository,
+  IServiceAttributionRepository,
 } from './interfaces.js';
 import type { IInvestigationRepository as SqliteInvestigationRepositoryInterface } from './sqlite/investigation.js';
 import type {
@@ -84,6 +85,8 @@ import { PostgresLlmAuditRepository } from './postgres/llm-audit-repository.js';
 import type { ILlmAuditRepository } from './sqlite/llm-audit-repository.js';
 import { SqliteAiSuggestionRepository } from './sqlite/ai-suggestion.js';
 import { PostgresAiSuggestionRepository } from './postgres/ai-suggestion.js';
+import { SqliteServiceAttributionRepository } from './sqlite/service-attribution.js';
+import { PostgresServiceAttributionRepository } from './postgres/service-attribution.js';
 
 /**
  * Complete repository bundle available behind every persistence backend.
@@ -120,6 +123,7 @@ export interface RepositoryBundle {
   notificationDispatch: INotificationDispatchRepository;
   llmAudit: ILlmAuditRepository;
   aiSuggestions: IAiSuggestionRepository;
+  serviceAttribution: IServiceAttributionRepository;
 }
 
 export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
@@ -148,6 +152,7 @@ export function createSqliteRepositories(db: SqliteClient): RepositoryBundle {
     notificationDispatch: new SqliteNotificationDispatchRepository(db),
     llmAudit: new SqliteLlmAuditRepository(db),
     aiSuggestions: new SqliteAiSuggestionRepository(db),
+    serviceAttribution: new SqliteServiceAttributionRepository(db),
   };
 }
 
@@ -178,6 +183,7 @@ export function createPostgresRepositories(db: DbClient): RepositoryBundle {
     notificationDispatch: new PostgresNotificationDispatchRepository(db),
     llmAudit: new PostgresLlmAuditRepository(db),
     aiSuggestions: new PostgresAiSuggestionRepository(db),
+    serviceAttribution: new PostgresServiceAttributionRepository(db),
   };
 }
 

--- a/packages/data-layer/src/repository/index.ts
+++ b/packages/data-layer/src/repository/index.ts
@@ -31,6 +31,12 @@ export type {
   ChatSessionContextResourceScope,
   ChatSessionScope,
   ChatSessionEventRecord,
+  IServiceAttributionRepository,
+  ServiceAttribution,
+  ServiceSummary,
+  UnassignedResourceRef,
+  AttributionResourceKind,
+  AttributionSourceKind,
 } from './interfaces.js';
 
 export type {
@@ -76,6 +82,13 @@ export * from './event-wrappers/index.js';
 export * from './memory/index.js';
 export { createPostgresRepositories, createSqliteRepositories } from './factory.js';
 export type { RepositoryBundle, SqliteRepositories } from './factory.js';
+
+export {
+  extractPromqlServiceLabel,
+  extractServiceFromQueries,
+  applyTier1PromqlAttribution,
+  applyTier1GithubRepoAttribution,
+} from './service-attribution-tier1.js';
 
 export { SqliteLlmAuditRepository } from './sqlite/llm-audit-repository.js';
 export { PostgresLlmAuditRepository } from './postgres/llm-audit-repository.js';

--- a/packages/data-layer/src/repository/interfaces.ts
+++ b/packages/data-layer/src/repository/interfaces.ts
@@ -489,3 +489,99 @@ export interface IChatSessionEventRepository {
   nextSeq(sessionId: string): MaybeAsync<number>;
   deleteBySession(sessionId: string): MaybeAsync<void>;
 }
+
+// — Service attribution (Wave 2 / Step 2)
+//
+// Service is a free-form string. Resources may have multiple attribution rows
+// (one per source); the visibility threshold for "this resource belongs to
+// service X" is `user_confirmed=1 OR confidence >= 0.8`.
+
+export type AttributionResourceKind = 'dashboard' | 'alert_rule' | 'investigation';
+
+export type AttributionSourceKind =
+  | 'prom_label'
+  | 'github_repo'
+  | 'k8s_label'
+  | 'ai_infer'
+  | 'manual';
+
+export interface ServiceAttribution {
+  id: string;
+  orgId: string;
+  resourceKind: AttributionResourceKind;
+  resourceId: string;
+  serviceName: string;
+  sourceTier: 1 | 2 | 3 | 4;
+  sourceKind: AttributionSourceKind;
+  confidence: number; // 0..1
+  userConfirmed: boolean;
+  createdAt: string;
+}
+
+export interface ServiceSummary {
+  name: string;
+  resourceCount: number;
+}
+
+export interface UnassignedResourceRef {
+  kind: AttributionResourceKind;
+  id: string;
+}
+
+export interface IServiceAttributionRepository {
+  /**
+   * Idempotent on UNIQUE(org_id, resource_kind, resource_id, source_kind).
+   * If a row exists for the same (resource, source_kind), it is updated.
+   */
+  upsert(
+    orgId: string,
+    attribution: Omit<ServiceAttribution, 'id' | 'orgId' | 'createdAt'> & {
+      id?: string;
+      createdAt?: string;
+    },
+  ): MaybeAsync<ServiceAttribution>;
+
+  /** All attribution rows (across sources) for a single resource. */
+  listAttributionsByResource(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+  ): MaybeAsync<ServiceAttribution[]>;
+
+  /**
+   * Services visible in the UI — grouped by service_name, filtered to
+   * attributions where `user_confirmed=1 OR confidence >= 0.8`.
+   */
+  listServices(orgId: string): MaybeAsync<ServiceSummary[]>;
+
+  /** Resources visibly attributed to `name` (visibility threshold applies). */
+  listResourcesForService(
+    orgId: string,
+    name: string,
+  ): MaybeAsync<UnassignedResourceRef[]>;
+
+  /**
+   * Resources of `kind` that have NO attribution row meeting the visibility
+   * threshold. Caller supplies the candidate resource ids (the attribution
+   * table doesn't know what exists).
+   */
+  listUnassigned(
+    orgId: string,
+    kind: AttributionResourceKind,
+    candidateIds: string[],
+  ): MaybeAsync<string[]>;
+
+  /**
+   * Manually confirm `(resource → serviceName)`. Writes a row with
+   * source_tier=4, source_kind='manual', confidence=1, user_confirmed=1.
+   * Audit is the caller's responsibility (route layer writes
+   * 'service_attribution.confirm').
+   */
+  confirmAttribution(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+    serviceName: string,
+    userId: string,
+  ): MaybeAsync<ServiceAttribution>;
+}

--- a/packages/data-layer/src/repository/memory/index.ts
+++ b/packages/data-layer/src/repository/memory/index.ts
@@ -7,3 +7,4 @@ export { InMemoryAlertRuleRepository } from './alert-rule.js';
 export { InMemoryDashboardRepository } from './dashboard.js';
 export { InMemoryDashboardVariableAckRepository } from './dashboard-variable-ack.js';
 export { InMemoryAiSuggestionRepository } from './ai-suggestion.js';
+export { InMemoryServiceAttributionRepository } from './service-attribution.js';

--- a/packages/data-layer/src/repository/memory/service-attribution.ts
+++ b/packages/data-layer/src/repository/memory/service-attribution.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'crypto';
+import type {
+  AttributionResourceKind,
+  IServiceAttributionRepository,
+  ServiceAttribution,
+  ServiceSummary,
+  UnassignedResourceRef,
+} from '../interfaces.js';
+
+/**
+ * In-memory implementation of `IServiceAttributionRepository`. Test
+ * fixture only — production uses SQLite or Postgres (ADR-001).
+ */
+export class InMemoryServiceAttributionRepository
+  implements IServiceAttributionRepository
+{
+  private rows: ServiceAttribution[] = [];
+
+  private visible(r: ServiceAttribution): boolean {
+    return r.userConfirmed || r.confidence >= 0.8;
+  }
+
+  async upsert(
+    orgId: string,
+    attribution: Omit<ServiceAttribution, 'id' | 'orgId' | 'createdAt'> & {
+      id?: string;
+      createdAt?: string;
+    },
+  ): Promise<ServiceAttribution> {
+    const existingIdx = this.rows.findIndex(
+      (r) =>
+        r.orgId === orgId &&
+        r.resourceKind === attribution.resourceKind &&
+        r.resourceId === attribution.resourceId &&
+        r.sourceKind === attribution.sourceKind,
+    );
+    const row: ServiceAttribution = {
+      id: attribution.id ?? randomUUID(),
+      orgId,
+      resourceKind: attribution.resourceKind,
+      resourceId: attribution.resourceId,
+      serviceName: attribution.serviceName,
+      sourceTier: attribution.sourceTier,
+      sourceKind: attribution.sourceKind,
+      confidence: attribution.confidence,
+      userConfirmed: attribution.userConfirmed,
+      createdAt: attribution.createdAt ?? new Date().toISOString(),
+    };
+    if (existingIdx >= 0) {
+      this.rows[existingIdx] = { ...row, id: this.rows[existingIdx]!.id };
+      return this.rows[existingIdx]!;
+    }
+    this.rows.push(row);
+    return row;
+  }
+
+  async listAttributionsByResource(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+  ): Promise<ServiceAttribution[]> {
+    return this.rows.filter(
+      (r) => r.orgId === orgId && r.resourceKind === kind && r.resourceId === id,
+    );
+  }
+
+  async listServices(orgId: string): Promise<ServiceSummary[]> {
+    const visible = this.rows.filter((r) => r.orgId === orgId && this.visible(r));
+    // Dedup by (resource, service) — a resource attributed to "foo" by two
+    // different sources still counts as one.
+    const seen = new Set<string>();
+    const counts = new Map<string, number>();
+    for (const r of visible) {
+      const key = `${r.resourceKind}::${r.resourceId}::${r.serviceName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      counts.set(r.serviceName, (counts.get(r.serviceName) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([name, resourceCount]) => ({ name, resourceCount }))
+      .sort((a, b) => b.resourceCount - a.resourceCount);
+  }
+
+  async listResourcesForService(
+    orgId: string,
+    name: string,
+  ): Promise<UnassignedResourceRef[]> {
+    const seen = new Set<string>();
+    const out: UnassignedResourceRef[] = [];
+    for (const r of this.rows) {
+      if (r.orgId !== orgId || r.serviceName !== name || !this.visible(r)) continue;
+      const key = `${r.resourceKind}::${r.resourceId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ kind: r.resourceKind, id: r.resourceId });
+    }
+    return out;
+  }
+
+  async listUnassigned(
+    orgId: string,
+    kind: AttributionResourceKind,
+    candidateIds: string[],
+  ): Promise<string[]> {
+    const attributed = new Set(
+      this.rows
+        .filter(
+          (r) =>
+            r.orgId === orgId && r.resourceKind === kind && this.visible(r),
+        )
+        .map((r) => r.resourceId),
+    );
+    return candidateIds.filter((id) => !attributed.has(id));
+  }
+
+  async confirmAttribution(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+    serviceName: string,
+    _userId: string,
+  ): Promise<ServiceAttribution> {
+    return this.upsert(orgId, {
+      resourceKind: kind,
+      resourceId: id,
+      serviceName,
+      sourceTier: 4,
+      sourceKind: 'manual',
+      confidence: 1,
+      userConfirmed: true,
+    });
+  }
+}

--- a/packages/data-layer/src/repository/postgres/index.ts
+++ b/packages/data-layer/src/repository/postgres/index.ts
@@ -23,3 +23,4 @@ export { PostgresConnectorRepository } from './connector.js';
 export { applyPostgresSchema } from './schema-applier.js';
 
 export { PostgresRemediationPlanRepository } from './remediation-plan.js';
+export { PostgresServiceAttributionRepository } from './service-attribution.js';

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -931,3 +931,24 @@ CREATE TABLE IF NOT EXISTS ai_suggestions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_suggestions_user_state ON ai_suggestions(user_id, state);
+
+-- ============================================================================
+-- Service attribution (Wave 2 / Step 2). See sqlite-schema.sql for the contract.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS resource_service_attribution (
+  id             TEXT PRIMARY KEY,
+  org_id         TEXT NOT NULL,
+  resource_kind  TEXT NOT NULL,
+  resource_id    TEXT NOT NULL,
+  service_name   TEXT NOT NULL,
+  source_tier    INTEGER NOT NULL,
+  source_kind    TEXT NOT NULL,
+  confidence     DOUBLE PRECISION NOT NULL,
+  user_confirmed BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at     TEXT NOT NULL,
+  UNIQUE(org_id, resource_kind, resource_id, source_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_attr_service  ON resource_service_attribution(org_id, service_name);
+CREATE INDEX IF NOT EXISTS idx_attr_resource ON resource_service_attribution(org_id, resource_kind, resource_id);

--- a/packages/data-layer/src/repository/postgres/schema.ts
+++ b/packages/data-layer/src/repository/postgres/schema.ts
@@ -3,6 +3,7 @@ import {
   text,
   integer,
   boolean,
+  doublePrecision,
   jsonb,
   index,
   uniqueIndex,
@@ -322,5 +323,31 @@ export const dashboardVariableAck = pgTable(
       t.varsHash,
     ),
     index('pg_repo_idx_var_ack').on(t.userId, t.dashboardUid),
+  ],
+);
+
+export const resourceServiceAttribution = pgTable(
+  'resource_service_attribution',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').notNull(),
+    resourceKind: text('resource_kind').notNull(),
+    resourceId: text('resource_id').notNull(),
+    serviceName: text('service_name').notNull(),
+    sourceTier: integer('source_tier').notNull(),
+    sourceKind: text('source_kind').notNull(),
+    confidence: doublePrecision('confidence').notNull(),
+    userConfirmed: boolean('user_confirmed').notNull().default(false),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    uniqueIndex('pg_repo_attr_unique').on(
+      t.orgId,
+      t.resourceKind,
+      t.resourceId,
+      t.sourceKind,
+    ),
+    index('pg_repo_attr_service').on(t.orgId, t.serviceName),
+    index('pg_repo_attr_resource').on(t.orgId, t.resourceKind, t.resourceId),
   ],
 );

--- a/packages/data-layer/src/repository/postgres/service-attribution.ts
+++ b/packages/data-layer/src/repository/postgres/service-attribution.ts
@@ -1,0 +1,202 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { resourceServiceAttribution } from '../../db/schema.js';
+import type {
+  AttributionResourceKind,
+  AttributionSourceKind,
+  IServiceAttributionRepository,
+  ServiceAttribution,
+  ServiceSummary,
+  UnassignedResourceRef,
+} from '../interfaces.js';
+
+type Row = typeof resourceServiceAttribution.$inferSelect;
+
+function rowToAttribution(row: Row): ServiceAttribution {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    resourceKind: row.resourceKind as AttributionResourceKind,
+    resourceId: row.resourceId,
+    serviceName: row.serviceName,
+    sourceTier: row.sourceTier as ServiceAttribution['sourceTier'],
+    sourceKind: row.sourceKind as AttributionSourceKind,
+    confidence: row.confidence,
+    userConfirmed: Boolean(row.userConfirmed),
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Postgres implementation of `IServiceAttributionRepository`. The
+ * visibility threshold (`user_confirmed OR confidence >= 0.8`) is
+ * enforced at read time, identical to the SQLite repo.
+ */
+export class PostgresServiceAttributionRepository
+  implements IServiceAttributionRepository
+{
+  constructor(private readonly db: any) {}
+
+  private visiblePredicate() {
+    return or(
+      eq(resourceServiceAttribution.userConfirmed, true),
+      sql`${resourceServiceAttribution.confidence} >= 0.8`,
+    );
+  }
+
+  async upsert(
+    orgId: string,
+    attribution: Omit<ServiceAttribution, 'id' | 'orgId' | 'createdAt'> & {
+      id?: string;
+      createdAt?: string;
+    },
+  ): Promise<ServiceAttribution> {
+    const existing = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, attribution.resourceKind),
+          eq(resourceServiceAttribution.resourceId, attribution.resourceId),
+          eq(resourceServiceAttribution.sourceKind, attribution.sourceKind),
+        ),
+      );
+
+    if (existing.length > 0) {
+      const id = existing[0]!.id;
+      const [updated] = await this.db
+        .update(resourceServiceAttribution)
+        .set({
+          serviceName: attribution.serviceName,
+          sourceTier: attribution.sourceTier,
+          confidence: attribution.confidence,
+          userConfirmed: attribution.userConfirmed,
+        })
+        .where(eq(resourceServiceAttribution.id, id))
+        .returning();
+      return rowToAttribution(updated!);
+    }
+
+    const [inserted] = await this.db
+      .insert(resourceServiceAttribution)
+      .values({
+        id: attribution.id ?? randomUUID(),
+        orgId,
+        resourceKind: attribution.resourceKind,
+        resourceId: attribution.resourceId,
+        serviceName: attribution.serviceName,
+        sourceTier: attribution.sourceTier,
+        sourceKind: attribution.sourceKind,
+        confidence: attribution.confidence,
+        userConfirmed: attribution.userConfirmed,
+        createdAt: attribution.createdAt ?? new Date().toISOString(),
+      })
+      .returning();
+    return rowToAttribution(inserted!);
+  }
+
+  async listAttributionsByResource(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+  ): Promise<ServiceAttribution[]> {
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, kind),
+          eq(resourceServiceAttribution.resourceId, id),
+        ),
+      );
+    return rows.map(rowToAttribution);
+  }
+
+  async listServices(orgId: string): Promise<ServiceSummary[]> {
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(eq(resourceServiceAttribution.orgId, orgId), this.visiblePredicate()),
+      );
+    const seen = new Set<string>();
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      const r = rowToAttribution(row);
+      const key = `${r.resourceKind}::${r.resourceId}::${r.serviceName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      counts.set(r.serviceName, (counts.get(r.serviceName) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([name, resourceCount]) => ({ name, resourceCount }))
+      .sort((a, b) => b.resourceCount - a.resourceCount);
+  }
+
+  async listResourcesForService(
+    orgId: string,
+    name: string,
+  ): Promise<UnassignedResourceRef[]> {
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.serviceName, name),
+          this.visiblePredicate(),
+        ),
+      );
+    const seen = new Set<string>();
+    const out: UnassignedResourceRef[] = [];
+    for (const row of rows) {
+      const r = rowToAttribution(row);
+      const key = `${r.resourceKind}::${r.resourceId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ kind: r.resourceKind, id: r.resourceId });
+    }
+    return out;
+  }
+
+  async listUnassigned(
+    orgId: string,
+    kind: AttributionResourceKind,
+    candidateIds: string[],
+  ): Promise<string[]> {
+    if (candidateIds.length === 0) return [];
+    const rows = await this.db
+      .select({ resourceId: resourceServiceAttribution.resourceId })
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, kind),
+          inArray(resourceServiceAttribution.resourceId, candidateIds),
+          this.visiblePredicate(),
+        ),
+      );
+    const attributed = new Set<string>(rows.map((r: any) => r.resourceId));
+    return candidateIds.filter((id) => !attributed.has(id));
+  }
+
+  async confirmAttribution(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+    serviceName: string,
+    _userId: string,
+  ): Promise<ServiceAttribution> {
+    return this.upsert(orgId, {
+      resourceKind: kind,
+      resourceId: id,
+      serviceName,
+      sourceTier: 4,
+      sourceKind: 'manual',
+      confidence: 1,
+      userConfirmed: true,
+    });
+  }
+}

--- a/packages/data-layer/src/repository/service-attribution-tier1.ts
+++ b/packages/data-layer/src/repository/service-attribution-tier1.ts
@@ -1,0 +1,104 @@
+/**
+ * Tier-1 service-name extraction (Wave 2 / Step 2).
+ *
+ * Tier 1 = high-confidence (`0.95`) automatic attribution from signals
+ * already attached to a resource at create time:
+ *   - Prometheus `service="..."` label in a PromQL expression
+ *   - GitHub repo name from a normalized change-event
+ *
+ * Higher tiers (k8s reconciler, AI inference) are deferred.
+ */
+
+import type {
+  IServiceAttributionRepository,
+  AttributionResourceKind,
+} from './interfaces.js';
+
+/**
+ * Extract the `service` label value from a PromQL expression. Matches
+ * the common label-matcher syntax `service="foo"` (allowing `==`, single
+ * quotes, and surrounding whitespace). Returns the first match.
+ *
+ * The regex deliberately allows only `=` and `==` (equality matchers) —
+ * a regex matcher (`service=~"..."`) is too ambiguous to attribute
+ * automatically and is left to Tier 3 (AI infer).
+ */
+export function extractPromqlServiceLabel(promql: string): string | null {
+  if (!promql) return null;
+  // service ("=" | "==") (whitespace) ("..." | '...')
+  const match = promql.match(
+    /\bservice\s*={1,2}\s*(?:"([^"]+)"|'([^']+)')/,
+  );
+  if (!match) return null;
+  return match[1] ?? match[2] ?? null;
+}
+
+/**
+ * Extract a service name from a set of PromQL expressions. Returns the
+ * first value found across all queries (consistent label values across
+ * a single dashboard/rule are the common case; mixed is rare and we
+ * surface only the first to avoid silently dropping signal).
+ */
+export function extractServiceFromQueries(queries: string[]): string | null {
+  for (const q of queries) {
+    const v = extractPromqlServiceLabel(q);
+    if (v) return v;
+  }
+  return null;
+}
+
+/**
+ * Apply Tier-1 auto-attribution to a resource. Best-effort: if extraction
+ * yields no service, returns false and writes nothing. Failures are
+ * swallowed and reported so the caller's primary write isn't blocked.
+ */
+export async function applyTier1PromqlAttribution(
+  repo: IServiceAttributionRepository,
+  orgId: string,
+  resource: { kind: AttributionResourceKind; id: string; queries: string[] },
+): Promise<{ attributed: boolean; service?: string }> {
+  const service = extractServiceFromQueries(resource.queries);
+  if (!service) return { attributed: false };
+  try {
+    await repo.upsert(orgId, {
+      resourceKind: resource.kind,
+      resourceId: resource.id,
+      serviceName: service,
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    return { attributed: true, service };
+  } catch {
+    // Auto-fill must never block resource creation — surface false on failure.
+    return { attributed: false };
+  }
+}
+
+/**
+ * Apply Tier-1 attribution from a GitHub change-event repo name. Used when
+ * an investigation is created from a normalized change-event whose
+ * `serviceId` is the full repo name (see
+ * packages/adapters/src/change-event/normalizer.ts).
+ */
+export async function applyTier1GithubRepoAttribution(
+  repo: IServiceAttributionRepository,
+  orgId: string,
+  resource: { kind: AttributionResourceKind; id: string; repoName: string },
+): Promise<void> {
+  if (!resource.repoName) return;
+  try {
+    await repo.upsert(orgId, {
+      resourceKind: resource.kind,
+      resourceId: resource.id,
+      serviceName: resource.repoName,
+      sourceTier: 1,
+      sourceKind: 'github_repo',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+  } catch {
+    // Swallow: attribution is auxiliary.
+  }
+}

--- a/packages/data-layer/src/repository/services-integration.test.ts
+++ b/packages/data-layer/src/repository/services-integration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Integration: end-to-end Tier-1 attribution flow at the repository layer.
+ *
+ * Scenario from the W2/T2 spec: create 3 dashboards, two with a
+ * `service="foo"` PromQL label and one without → `listServices` returns
+ * foo with resourceCount=2 and `listUnassigned` flags the third.
+ *
+ * The route test would re-exercise the same code path through one extra
+ * hop; vite's deep-import resolution makes cross-package wiring noisy in
+ * vitest, so the integration assertion lives at the repository edge.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryServiceAttributionRepository } from './memory/service-attribution.js';
+import { applyTier1PromqlAttribution } from './service-attribution-tier1.js';
+
+describe('service attribution integration (Tier-1 PromQL)', () => {
+  let attribution: InMemoryServiceAttributionRepository;
+
+  beforeEach(() => {
+    attribution = new InMemoryServiceAttributionRepository();
+  });
+
+  it('3 dashboards: 2 with service=foo + 1 without → listServices=foo (count 2), 1 unassigned', async () => {
+    const orgId = 'org_main';
+    const dashboardIds = ['d1', 'd2', 'd3'];
+
+    // d1 and d2 carry a `service="foo"` label, d3 does not.
+    const cases: Array<{ id: string; queries: string[] }> = [
+      { id: 'd1', queries: ['rate(http_requests_total{service="foo"}[5m])'] },
+      { id: 'd2', queries: ['rate(errors_total{service="foo",job="api"}[5m])'] },
+      { id: 'd3', queries: ['rate(http_requests_total{job="api"}[5m])'] },
+    ];
+    for (const c of cases) {
+      await applyTier1PromqlAttribution(attribution, orgId, {
+        kind: 'dashboard',
+        id: c.id,
+        queries: c.queries,
+      });
+    }
+
+    const services = await attribution.listServices(orgId);
+    expect(services).toEqual([{ name: 'foo', resourceCount: 2 }]);
+
+    const unassigned = await attribution.listUnassigned(orgId, 'dashboard', dashboardIds);
+    expect(unassigned).toEqual(['d3']);
+  });
+
+  it('manual confirm writes user_confirmed row that overrides absence of label', async () => {
+    const orgId = 'org_main';
+    // d1 has no service label → unassigned at first.
+    await applyTier1PromqlAttribution(attribution, orgId, {
+      kind: 'dashboard',
+      id: 'd1',
+      queries: ['rate(http_requests_total[5m])'],
+    });
+    expect(await attribution.listUnassigned(orgId, 'dashboard', ['d1'])).toEqual(['d1']);
+
+    // User assigns to checkout-api → now visible.
+    await attribution.confirmAttribution(orgId, 'dashboard', 'd1', 'checkout-api', 'u1');
+    expect(await attribution.listUnassigned(orgId, 'dashboard', ['d1'])).toEqual([]);
+    const services = await attribution.listServices(orgId);
+    expect(services).toEqual([{ name: 'checkout-api', resourceCount: 1 }]);
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/index.ts
+++ b/packages/data-layer/src/repository/sqlite/index.ts
@@ -24,3 +24,4 @@ export { NotificationChannelRepository } from './notification-channel.js';
 export { SqliteConnectorRepository } from './connector.js';
 
 export { SqliteRemediationPlanRepository } from './remediation-plan.js';
+export { SqliteServiceAttributionRepository } from './service-attribution.js';

--- a/packages/data-layer/src/repository/sqlite/service-attribution.test.ts
+++ b/packages/data-layer/src/repository/sqlite/service-attribution.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { createTestDb } from '../../test-support/test-db.js';
+import { SqliteServiceAttributionRepository } from './service-attribution.js';
+import {
+  extractPromqlServiceLabel,
+  applyTier1PromqlAttribution,
+} from '../service-attribution-tier1.js';
+
+describe('SqliteServiceAttributionRepository', () => {
+  let db: SqliteClient;
+  let repo: SqliteServiceAttributionRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new SqliteServiceAttributionRepository(db);
+  });
+
+  it('upsert is idempotent on the UNIQUE constraint', async () => {
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd1',
+      serviceName: 'foo',
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    // Same (resource, source_kind) → updates rather than duplicating.
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd1',
+      serviceName: 'foo-renamed',
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    const rows = await repo.listAttributionsByResource(
+      'org_main',
+      'dashboard',
+      'd1',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.serviceName).toBe('foo-renamed');
+  });
+
+  it('listServices aggregates by service_name and respects visibility', async () => {
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd1',
+      serviceName: 'foo',
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd2',
+      serviceName: 'foo',
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    // Below threshold and unconfirmed — must not appear.
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd3',
+      serviceName: 'invisible',
+      sourceTier: 3,
+      sourceKind: 'ai_infer',
+      confidence: 0.4,
+      userConfirmed: false,
+    });
+    const summary = await repo.listServices('org_main');
+    expect(summary).toEqual([{ name: 'foo', resourceCount: 2 }]);
+  });
+
+  it('listUnassigned returns candidates with no visible attribution', async () => {
+    await repo.upsert('org_main', {
+      resourceKind: 'dashboard',
+      resourceId: 'd1',
+      serviceName: 'foo',
+      sourceTier: 1,
+      sourceKind: 'prom_label',
+      confidence: 0.95,
+      userConfirmed: false,
+    });
+    const unassigned = await repo.listUnassigned(
+      'org_main',
+      'dashboard',
+      ['d1', 'd2', 'd3'],
+    );
+    expect(unassigned.sort()).toEqual(['d2', 'd3']);
+  });
+
+  it('confirmAttribution writes a manual row with user_confirmed=1', async () => {
+    const row = await repo.confirmAttribution(
+      'org_main',
+      'dashboard',
+      'd1',
+      'checkout-api',
+      'u-1',
+    );
+    expect(row.userConfirmed).toBe(true);
+    expect(row.sourceTier).toBe(4);
+    expect(row.sourceKind).toBe('manual');
+    expect(row.confidence).toBe(1);
+    const summary = await repo.listServices('org_main');
+    expect(summary).toEqual([{ name: 'checkout-api', resourceCount: 1 }]);
+  });
+});
+
+describe('extractPromqlServiceLabel', () => {
+  it('extracts service="x" from PromQL', () => {
+    expect(
+      extractPromqlServiceLabel(
+        'sum by (pod) (rate(http_requests_total{service="ingress-gateway"}[5m]))',
+      ),
+    ).toBe('ingress-gateway');
+  });
+
+  it('accepts == and single quotes', () => {
+    expect(extractPromqlServiceLabel(`up{service=='foo'}`)).toBe('foo');
+  });
+
+  it('returns null when the label is absent', () => {
+    expect(extractPromqlServiceLabel('rate(http_requests_total{job="api"}[5m])')).toBeNull();
+  });
+
+  it('ignores regex matchers (Tier-3 territory)', () => {
+    expect(extractPromqlServiceLabel('up{service=~"foo.*"}')).toBeNull();
+  });
+});
+
+describe('applyTier1PromqlAttribution', () => {
+  it('writes a Tier-1 attribution row when service label is present', async () => {
+    const db = createTestDb();
+    const repo = new SqliteServiceAttributionRepository(db);
+    const result = await applyTier1PromqlAttribution(repo, 'org_main', {
+      kind: 'dashboard',
+      id: 'd1',
+      queries: ['rate(http_requests_total{service="foo"}[5m])'],
+    });
+    expect(result).toEqual({ attributed: true, service: 'foo' });
+    const rows = await repo.listAttributionsByResource('org_main', 'dashboard', 'd1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.sourceKind).toBe('prom_label');
+    expect(rows[0]!.confidence).toBe(0.95);
+  });
+
+  it('writes nothing when no service label is found — resource appears unassigned', async () => {
+    const db = createTestDb();
+    const repo = new SqliteServiceAttributionRepository(db);
+    const result = await applyTier1PromqlAttribution(repo, 'org_main', {
+      kind: 'dashboard',
+      id: 'd1',
+      queries: ['rate(http_requests_total{job="api"}[5m])'],
+    });
+    expect(result.attributed).toBe(false);
+    const unassigned = await repo.listUnassigned('org_main', 'dashboard', ['d1']);
+    expect(unassigned).toEqual(['d1']);
+  });
+});

--- a/packages/data-layer/src/repository/sqlite/service-attribution.ts
+++ b/packages/data-layer/src/repository/sqlite/service-attribution.ts
@@ -1,0 +1,206 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import type { SqliteClient } from '../../db/sqlite-client.js';
+import { resourceServiceAttribution } from '../../db/sqlite-schema.js';
+import type {
+  AttributionResourceKind,
+  AttributionSourceKind,
+  IServiceAttributionRepository,
+  ServiceAttribution,
+  ServiceSummary,
+  UnassignedResourceRef,
+} from '../interfaces.js';
+
+type Row = typeof resourceServiceAttribution.$inferSelect;
+
+function rowToAttribution(row: Row): ServiceAttribution {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    resourceKind: row.resourceKind as AttributionResourceKind,
+    resourceId: row.resourceId,
+    serviceName: row.serviceName,
+    sourceTier: row.sourceTier as ServiceAttribution['sourceTier'],
+    sourceKind: row.sourceKind as AttributionSourceKind,
+    confidence: row.confidence,
+    userConfirmed: Boolean(row.userConfirmed),
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * SQLite implementation of `IServiceAttributionRepository`. Visibility
+ * threshold (`user_confirmed = 1 OR confidence >= 0.8`) is applied at
+ * read time, matching the in-memory fixture.
+ */
+export class SqliteServiceAttributionRepository
+  implements IServiceAttributionRepository
+{
+  constructor(private readonly db: SqliteClient) {}
+
+  private visiblePredicate() {
+    return or(
+      eq(resourceServiceAttribution.userConfirmed, true),
+      sql`${resourceServiceAttribution.confidence} >= 0.8`,
+    );
+  }
+
+  async upsert(
+    orgId: string,
+    attribution: Omit<ServiceAttribution, 'id' | 'orgId' | 'createdAt'> & {
+      id?: string;
+      createdAt?: string;
+    },
+  ): Promise<ServiceAttribution> {
+    const existing = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, attribution.resourceKind),
+          eq(resourceServiceAttribution.resourceId, attribution.resourceId),
+          eq(resourceServiceAttribution.sourceKind, attribution.sourceKind),
+        ),
+      );
+
+    if (existing.length > 0) {
+      const id = existing[0]!.id;
+      const [updated] = await this.db
+        .update(resourceServiceAttribution)
+        .set({
+          serviceName: attribution.serviceName,
+          sourceTier: attribution.sourceTier,
+          confidence: attribution.confidence,
+          userConfirmed: attribution.userConfirmed,
+        })
+        .where(eq(resourceServiceAttribution.id, id))
+        .returning();
+      return rowToAttribution(updated!);
+    }
+
+    const [inserted] = await this.db
+      .insert(resourceServiceAttribution)
+      .values({
+        id: attribution.id ?? randomUUID(),
+        orgId,
+        resourceKind: attribution.resourceKind,
+        resourceId: attribution.resourceId,
+        serviceName: attribution.serviceName,
+        sourceTier: attribution.sourceTier,
+        sourceKind: attribution.sourceKind,
+        confidence: attribution.confidence,
+        userConfirmed: attribution.userConfirmed,
+        createdAt: attribution.createdAt ?? new Date().toISOString(),
+      })
+      .returning();
+    return rowToAttribution(inserted!);
+  }
+
+  async listAttributionsByResource(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+  ): Promise<ServiceAttribution[]> {
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, kind),
+          eq(resourceServiceAttribution.resourceId, id),
+        ),
+      );
+    return rows.map(rowToAttribution);
+  }
+
+  async listServices(orgId: string): Promise<ServiceSummary[]> {
+    // Aggregate in JS to keep the implementation portable and to match the
+    // dedup semantics of the in-memory fixture (one (resource, service)
+    // counts once even when attributed by multiple sources).
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(eq(resourceServiceAttribution.orgId, orgId), this.visiblePredicate()),
+      );
+    const seen = new Set<string>();
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      const r = rowToAttribution(row);
+      const key = `${r.resourceKind}::${r.resourceId}::${r.serviceName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      counts.set(r.serviceName, (counts.get(r.serviceName) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([name, resourceCount]) => ({ name, resourceCount }))
+      .sort((a, b) => b.resourceCount - a.resourceCount);
+  }
+
+  async listResourcesForService(
+    orgId: string,
+    name: string,
+  ): Promise<UnassignedResourceRef[]> {
+    const rows = await this.db
+      .select()
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.serviceName, name),
+          this.visiblePredicate(),
+        ),
+      );
+    const seen = new Set<string>();
+    const out: UnassignedResourceRef[] = [];
+    for (const row of rows) {
+      const r = rowToAttribution(row);
+      const key = `${r.resourceKind}::${r.resourceId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ kind: r.resourceKind, id: r.resourceId });
+    }
+    return out;
+  }
+
+  async listUnassigned(
+    orgId: string,
+    kind: AttributionResourceKind,
+    candidateIds: string[],
+  ): Promise<string[]> {
+    if (candidateIds.length === 0) return [];
+    const rows = await this.db
+      .select({ resourceId: resourceServiceAttribution.resourceId })
+      .from(resourceServiceAttribution)
+      .where(
+        and(
+          eq(resourceServiceAttribution.orgId, orgId),
+          eq(resourceServiceAttribution.resourceKind, kind),
+          inArray(resourceServiceAttribution.resourceId, candidateIds),
+          this.visiblePredicate(),
+        ),
+      );
+    const attributed = new Set(rows.map((r) => r.resourceId));
+    return candidateIds.filter((id) => !attributed.has(id));
+  }
+
+  async confirmAttribution(
+    orgId: string,
+    kind: AttributionResourceKind,
+    id: string,
+    serviceName: string,
+    _userId: string,
+  ): Promise<ServiceAttribution> {
+    return this.upsert(orgId, {
+      resourceKind: kind,
+      resourceId: id,
+      serviceName,
+      sourceTier: 4,
+      sourceKind: 'manual',
+      confidence: 1,
+      userConfirmed: true,
+    });
+  }
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -21,6 +21,9 @@ const Dashboards = lazy(() => import('./pages/Dashboards.js'));
 const DashboardWorkspace = lazy(() => import('./pages/DashboardWorkspace.js'));
 const Alerts = lazy(() => import('./pages/Alerts.js'));
 const AlertRuleEdit = lazy(() => import('./pages/AlertRuleEdit.js'));
+const Services = lazy(() => import('./pages/Services.js'));
+const Service = lazy(() => import('./pages/Service.js'));
+const UnassignedResources = lazy(() => import('./pages/UnassignedResources.js'));
 
 function RouteFallback() {
   return (
@@ -163,6 +166,9 @@ export default function App() {
                   <Route path="/dashboards/:id" element={<DashboardWorkspace />} />
                   <Route path="/alerts" element={<Alerts />} />
                   <Route path="/alerts/:id/edit" element={<AlertRuleEdit />} />
+                  <Route path="/services" element={<Services />} />
+                  <Route path="/services/unassigned" element={<UnassignedResources />} />
+                  <Route path="/services/:name" element={<Service />} />
                   <Route path="/connections" element={<Navigate to="/settings" replace />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Route>

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -43,6 +43,18 @@ function HomeIcon({ className }: { className?: string }) {
   );
 }
 
+/* Services — concentric rings to evoke the service-mesh /
+   service-as-primary concept (Wave 2 / Step 2). */
+function ServicesIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className ?? 'w-5 h-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+      <circle cx="12" cy="12" r="9" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="12" cy="12" r="5" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
 function DashboardIcon({ className }: { className?: string }) {
   return (
     <svg className={className ?? 'w-5 h-5'} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
@@ -488,6 +500,7 @@ export default function Navigation() {
       {(activeTab === 'nav' || !expanded) && (
         <div className={`flex flex-col gap-1 flex-1 ${expanded ? '' : 'items-center'}`}>
           <SidebarItem to="/" label="Home" icon={<HomeIcon />} end expanded={expanded} />
+          <SidebarItem to="/services" label="Services" icon={<ServicesIcon />} expanded={expanded} />
           <SidebarItem to="/dashboards" label="Dashboards" icon={<DashboardIcon />} expanded={expanded} />
           <SidebarItem to="/investigations" label="Investigations" icon={<InvestigationIcon />} expanded={expanded} />
           <SidebarItem to="/alerts" label="Alerts" icon={<AlertsIcon />} expanded={expanded} />

--- a/packages/web/src/pages/Service.tsx
+++ b/packages/web/src/pages/Service.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { apiClient } from '../api/client.js';
+
+interface ServiceDetail {
+  name: string;
+  dashboards: Array<{ id: string; title: string }>;
+  alertRules: Array<{ id: string; name: string; state: string; severity: string }>;
+  investigations: Array<{ id: string; intent: string; status: string }>;
+  owner: string | null;
+  deploys: Array<{ version: string; ts: string }>;
+}
+
+/**
+ * Service detail page (Wave 2 / Step 2). Single API call hydrates all
+ * sections; owner/deploys are stubbed null in this PR per scope.
+ */
+export default function Service() {
+  const { name } = useParams<{ name: string }>();
+  const [data, setData] = useState<ServiceDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!name) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiClient.get<ServiceDetail>(`/services/${encodeURIComponent(name)}`);
+        if (!cancelled) setData(res.data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load service');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [name]);
+
+  if (loading) return <div className="p-6">Loading…</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+  if (!data) return null;
+
+  return (
+    <div className="p-6 space-y-6">
+      <header>
+        <Link to="/services" className="text-sm text-blue-600 hover:underline">← Services</Link>
+        <h1 className="text-2xl font-semibold mt-2">{data.name}</h1>
+        {data.owner && <div className="text-sm text-gray-600">Owner: {data.owner}</div>}
+      </header>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">📊 Dashboards ({data.dashboards.length})</h2>
+        {data.dashboards.length === 0 ? (
+          <p className="text-sm text-gray-500">No dashboards attributed to this service.</p>
+        ) : (
+          <ul className="divide-y divide-outline rounded border border-outline">
+            {data.dashboards.map((d) => (
+              <li key={d.id} className="p-2">
+                <Link to={`/dashboards/${d.id}`} className="hover:underline">{d.title}</Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">🚨 Alerts ({data.alertRules.length})</h2>
+        {data.alertRules.length === 0 ? (
+          <p className="text-sm text-gray-500">No alerts attributed to this service.</p>
+        ) : (
+          <ul className="divide-y divide-outline rounded border border-outline">
+            {data.alertRules.map((r) => (
+              <li key={r.id} className="p-2 flex justify-between">
+                <Link to={`/alerts/${r.id}/edit`} className="hover:underline">{r.name}</Link>
+                <span className="text-sm text-gray-500">{r.state} · {r.severity}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">🔍 Investigations ({data.investigations.length})</h2>
+        {data.investigations.length === 0 ? (
+          <p className="text-sm text-gray-500">No investigations attributed to this service.</p>
+        ) : (
+          <ul className="divide-y divide-outline rounded border border-outline">
+            {data.investigations.map((i) => (
+              <li key={i.id} className="p-2 flex justify-between">
+                <Link to={`/investigations/${i.id}`} className="hover:underline">{i.intent}</Link>
+                <span className="text-sm text-gray-500">{i.status}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">📜 Recent changes</h2>
+        {data.deploys.length === 0 ? (
+          <p className="text-sm text-gray-500">Deploy timeline will appear once change-event linkage lands.</p>
+        ) : (
+          <ul>
+            {data.deploys.map((d, i) => (
+              <li key={i} className="text-sm">{d.version} ({d.ts})</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/pages/Services.tsx
+++ b/packages/web/src/pages/Services.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { apiClient } from '../api/client.js';
+
+interface ServiceSummary {
+  name: string;
+  resourceCount: number;
+}
+
+interface ServicesResponse {
+  services: ServiceSummary[];
+  unassignedCount: number;
+}
+
+/**
+ * Services list page (Wave 2 / Step 2).
+ *
+ * "Services" is the primary organizing concept — sorted by resource count
+ * desc. Resources without a high-confidence attribution surface in the
+ * Unassigned banner at the top of the list.
+ */
+export default function Services() {
+  const [data, setData] = useState<ServicesResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiClient.get<ServicesResponse>('/services');
+        if (!cancelled) setData(res.data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'failed to load services');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <div className="p-6">Loading…</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+  if (!data) return null;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Services</h1>
+
+      {data.unassignedCount > 0 && (
+        <div className="mb-4 p-3 rounded border border-amber-300 bg-amber-50 dark:bg-amber-950/30 flex items-center justify-between">
+          <span>
+            <span className="font-medium">⚠ {data.unassignedCount}</span> resources not attributed
+          </span>
+          <Link
+            to="/services/unassigned"
+            className="text-sm font-medium text-blue-600 hover:underline"
+          >
+            Assign in bulk →
+          </Link>
+        </div>
+      )}
+
+      {data.services.length === 0 ? (
+        <div className="text-gray-500">No services yet. Resources with a <code>service=</code> Prometheus label will appear here automatically.</div>
+      ) : (
+        <ul className="divide-y divide-outline rounded border border-outline">
+          {data.services.map((s) => (
+            <li key={s.name} className="p-3 hover:bg-surface-variant">
+              <Link to={`/services/${encodeURIComponent(s.name)}`} className="block">
+                <div className="font-medium">{s.name}</div>
+                <div className="text-sm text-gray-500">{s.resourceCount} resources</div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/UnassignedResources.tsx
+++ b/packages/web/src/pages/UnassignedResources.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { apiClient } from '../api/client.js';
+
+type ResourceKind = 'dashboard' | 'alert_rule' | 'investigation';
+
+interface UnassignedResource {
+  kind: ResourceKind;
+  id: string;
+  title: string;
+}
+
+interface ListResponse {
+  resources: UnassignedResource[];
+}
+
+/**
+ * Unassigned bucket page (Wave 2 / Step 2). Each row has a service-name
+ * input + Assign button. Bulk-assign (checkbox selection + single dropdown)
+ * is intentionally minimal in this PR; the table layout supports adding it
+ * later without restructuring.
+ *
+ * AI-suggested service name (the spec mentions next-to-each row) is stubbed
+ * — Tier 3 AI infer is deferred per the PR scope.
+ */
+export default function UnassignedResources() {
+  const [resources, setResources] = useState<UnassignedResource[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  async function reload() {
+    setLoading(true);
+    try {
+      const res = await apiClient.get<ListResponse>('/services/unassigned');
+      setResources(res.data.resources);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void reload();
+  }, []);
+
+  async function assign(resource: UnassignedResource): Promise<void> {
+    const key = `${resource.kind}::${resource.id}`;
+    const serviceName = (drafts[key] ?? '').trim();
+    if (!serviceName) return;
+    try {
+      await apiClient.post(
+        `/services/${encodeURIComponent(serviceName)}/assign`,
+        { resourceKind: resource.kind, resourceId: resource.id },
+      );
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'assign failed');
+    }
+  }
+
+  if (loading) return <div className="p-6">Loading…</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+
+  return (
+    <div className="p-6">
+      <Link to="/services" className="text-sm text-blue-600 hover:underline">← Services</Link>
+      <h1 className="text-2xl font-semibold mt-2 mb-4">Unassigned resources</h1>
+
+      {resources.length === 0 ? (
+        <p className="text-gray-500">All resources have a service. ✨</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b border-outline">
+              <th className="py-2">Kind</th>
+              <th>Resource</th>
+              <th>Assign to service</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {resources.map((r) => {
+              const key = `${r.kind}::${r.id}`;
+              return (
+                <tr key={key} className="border-b border-outline">
+                  <td className="py-2 pr-3 text-gray-500">{r.kind}</td>
+                  <td className="pr-3">{r.title}</td>
+                  <td className="pr-3">
+                    <input
+                      type="text"
+                      placeholder="service name"
+                      className="border border-outline rounded px-2 py-1 w-64"
+                      value={drafts[key] ?? ''}
+                      onChange={(e) => setDrafts((d) => ({ ...d, [key]: e.target.value }))}
+                    />
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      onClick={() => void assign(r)}
+                      className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+                      disabled={!(drafts[key] ?? '').trim()}
+                    >
+                      Assign
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Wave 2 Step 2 — Services becomes Rounds' primary organizing concept. Auto-attribution from Prometheus \`service=\` label (Tier 1). Unassigned bucket for the rest, with manual assignment + AI suggestions reserved for Tier 3.

## Changes

### Backend
- New table \`resource_service_attribution\` (sqlite + postgres) — \`UNIQUE(org, kind, id, source_kind)\`, indexes on \`(org, service_name)\` and \`(org, kind, id)\`
- \`IServiceAttributionRepository\` + sqlite/postgres/InMemory impls (ADR-001)
- **Tier 1 extractor** (\`service-attribution-tier1.ts\`):
  - \`extractPromqlServiceLabel(promql)\` — regex \`\bservice\s*=={0,1}\s*("…"|'…')\`. Equality only — \`=~\` regex matchers deferred to Tier 3.
  - \`applyTier1PromqlAttribution\` / \`applyTier1GithubRepoAttribution\` write with confidence 0.95
- **Wired into:**
  - \`POST/PUT /api/dashboards/:id/panels\` (extraction runs on panel writes — empty dashboard shell has nothing to extract)
  - \`POST /api/alert-rules\` (from \`rule.condition.query\`)
- REST:
  - \`GET /api/services\` → \`{ services: [{name, resourceCount}], unassignedCount }\`
  - \`GET /api/services/:name\` → \`{ name, dashboards, alertRules, investigations, owner?, deploys? }\`
  - \`GET /api/services/unassigned\`
  - \`POST /api/services/:name/assign\` body \`{ resourceKind, resourceId }\` → audit SERVICE_ATTRIBUTION_CONFIRM
- Visibility threshold: \`user_confirmed=1 OR confidence >= 0.8\` (so Tier-3 low-confidence rows stay hidden until promoted)

### Frontend
- \`Services.tsx\` (list) + \`Service.tsx\` (detail) + \`UnassignedResources.tsx\`
- Nav link "Services" between Home and Dashboards

## Deferred (intentional)

- **Tier 2 (k8s label reconciler)** + **Tier 3 (AI infer)** — future PRs
- **Change-event → investigation attribution** — helper \`applyTier1GithubRepoAttribution\` is ready but not wired; needs survey of the auto-investigation dispatch path
- **Owner / deploys in service detail** — returned \`null\` / \`[]\` (spec wireframe lists them but no data source yet)
- **AI-suggested service name column on unassigned page** — Tier 3 work
- **No separate \`services\` table** — service is a free string in attribution rows per RFC-4

## Test plan

- [x] 10 unit tests in \`service-attribution.test.ts\` (upsert idempotency, threshold, regex pos/neg/quoted/regex-matcher-ignored)
- [x] 2 integration tests (3-dashboards spec scenario: 2 with \`service=foo\`, 1 without → \`listServices=[{foo,2}]\`, unassignedCount=1)
- [x] 243 existing web tests still pass
- [ ] CI green

## Known limitation

API-gateway-side HTTP integration test for \`/api/services\` was moved to data-layer integration test because vitest's barrel resolution from api-gateway couldn't see \`InMemory*\` exports (cross-package star-re-export issue). Spec scenario fully covered at the repo+extractor layer.