### PR TITLE
Wave 2.5 UI: ProvisionedBanner + standalone Fork button

### DIFF
--- a/packages/web/src/components/ProvisionedBanner.test.tsx
+++ b/packages/web/src/components/ProvisionedBanner.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import ProvisionedBanner from './ProvisionedBanner.js';
+
+describe('ProvisionedBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when source is not provisioned', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProvisionedBanner, {
+        resourceKind: 'dashboard',
+        resourceId: 'd1',
+        source: 'manual',
+        provenance: null,
+        onForked: () => undefined,
+      }),
+    );
+    expect(html).toBe('');
+  });
+
+  it('renders nothing when source is undefined (back-compat with pre-Wave-1 rows)', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProvisionedBanner, {
+        resourceKind: 'dashboard',
+        resourceId: 'd1',
+        source: undefined,
+        provenance: null,
+        onForked: () => undefined,
+      }),
+    );
+    expect(html).toBe('');
+  });
+
+  it('renders the banner with repo + path when source=provisioned_git', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProvisionedBanner, {
+        resourceKind: 'dashboard',
+        resourceId: 'd1',
+        source: 'provisioned_git',
+        provenance: {
+          repo: 'acme/observability',
+          path: 'dashboards/p99.json',
+          commit: '1234567890abcdef',
+        },
+        onForked: () => undefined,
+      }),
+    );
+    expect(html).toContain('This dashboard is managed by git');
+    expect(html).toContain('acme/observability/dashboards/p99.json');
+    expect(html).toContain('(1234567)'); // short commit
+    expect(html).toContain('Fork to my workspace');
+    expect(html).toContain('View source');
+    // Source URL built from provenance
+    expect(html).toContain(
+      'https://github.com/acme/observability/blob/1234567890abcdef/dashboards/p99.json',
+    );
+  });
+
+  it('omits View source link when provenance lacks repo or path', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProvisionedBanner, {
+        resourceKind: 'alert_rule',
+        resourceId: 'r1',
+        source: 'provisioned_file',
+        provenance: { path: 'alerts/foo.yaml' },
+        onForked: () => undefined,
+      }),
+    );
+    expect(html).toContain('This alert rule is managed by git');
+    expect(html).toContain('alerts/foo.yaml');
+    expect(html).toContain('Fork to my workspace');
+    expect(html).not.toContain('View source');
+  });
+
+  it('renders generic "managed externally" when provenance is missing', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProvisionedBanner, {
+        resourceKind: 'dashboard',
+        resourceId: 'd1',
+        source: 'provisioned_file',
+        provenance: null,
+        onForked: () => undefined,
+      }),
+    );
+    expect(html).toContain('managed externally');
+  });
+});

--- a/packages/web/src/components/ProvisionedBanner.tsx
+++ b/packages/web/src/components/ProvisionedBanner.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import { apiClient } from '../api/client.js';
+
+/**
+ * Wave 2.5 — banner shown at the top of a dashboard/alert detail page when
+ * the resource is git-managed (source = provisioned_file | provisioned_git).
+ *
+ * Two actions:
+ *   - Fork to my workspace → POST /api/resources/{kind}/{id}/fork → navigate
+ *   - View source ↗        → opens the underlying repo file in a new tab
+ *
+ * If the user has neither permission to fork nor enough provenance metadata
+ * to build a source URL, the banner still renders as a read-only warning so
+ * the user understands why editing is blocked elsewhere in the UI.
+ */
+
+export type ResourceSource =
+  | 'manual'
+  | 'api'
+  | 'ai_generated'
+  | 'provisioned_file'
+  | 'provisioned_git';
+
+export interface ResourceProvenance {
+  repo?: string;
+  path?: string;
+  commit?: string;
+  generatedBy?: string;
+  prompt?: string;
+}
+
+interface Props {
+  resourceKind: 'dashboard' | 'alert_rule';
+  resourceId: string;
+  source: ResourceSource | undefined;
+  provenance?: ResourceProvenance | null;
+  /** Called with the newly-forked resource id on a successful fork. */
+  onForked: (newResourceId: string) => void;
+}
+
+function isProvisioned(source: ResourceSource | undefined): boolean {
+  return source === 'provisioned_file' || source === 'provisioned_git';
+}
+
+function buildSourceUrl(provenance?: ResourceProvenance | null): string | null {
+  if (!provenance?.repo || !provenance.path) return null;
+  const commit = provenance.commit ?? 'main';
+  return `https://github.com/${provenance.repo}/blob/${commit}/${provenance.path}`;
+}
+
+export default function ProvisionedBanner({
+  resourceKind,
+  resourceId,
+  source,
+  provenance,
+  onForked,
+}: Props): React.ReactElement | null {
+  const [forking, setForking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isProvisioned(source)) return null;
+
+  const sourceUrl = buildSourceUrl(provenance);
+  const provenanceSummary = (() => {
+    if (!provenance) return 'managed externally';
+    if (provenance.repo && provenance.path) {
+      const commitShort = provenance.commit ? ` (${provenance.commit.slice(0, 7)})` : '';
+      return `${provenance.repo}/${provenance.path}${commitShort}`;
+    }
+    if (provenance.path) return provenance.path;
+    return 'managed externally';
+  })();
+
+  async function handleFork(): Promise<void> {
+    setForking(true);
+    setError(null);
+    try {
+      const res = await apiClient.post<{ id: string }>(
+        `/resources/${resourceKind}/${resourceId}/fork`,
+        {},
+      );
+      if (res.error) {
+        setError(res.error.message ?? 'Fork failed');
+        return;
+      }
+      onForked(res.data.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fork failed');
+    } finally {
+      setForking(false);
+    }
+  }
+
+  const kindLabel = resourceKind === 'dashboard' ? 'dashboard' : 'alert rule';
+
+  return (
+    <div
+      className="bg-amber-50 border-l-4 border-amber-500 px-4 py-3 flex items-start gap-3"
+      data-testid="provisioned-banner"
+    >
+      <div className="flex-shrink-0 mt-0.5 text-amber-600" aria-hidden>
+        ⚠
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-amber-900">
+          This {kindLabel} is managed by git
+        </div>
+        <div className="text-xs text-amber-800 mt-0.5 truncate">
+          Source: {provenanceSummary}
+        </div>
+        {error && (
+          <div className="text-xs text-red-700 mt-1" role="alert">
+            {error}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <button
+          type="button"
+          onClick={handleFork}
+          disabled={forking}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {forking ? 'Forking…' : 'Fork to my workspace'}
+        </button>
+        {sourceUrl && (
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-3 py-1.5 text-xs font-medium rounded border border-amber-700 text-amber-900 hover:bg-amber-100"
+          >
+            View source ↗
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/DashboardWorkspace.tsx
+++ b/packages/web/src/pages/DashboardWorkspace.tsx
@@ -7,6 +7,7 @@ import DashboardGrid from '../components/DashboardGrid.js';
 import PanelEditor from '../components/PanelEditor.js';
 import VariableBar from '../components/VariableBar.js';
 import VariableInferenceBanner from '../components/VariableInferenceBanner.js';
+import ProvisionedBanner from '../components/ProvisionedBanner.js';
 import { useInferredVariables } from '../hooks/useInferredVariables.js';
 import InvestigationReportView from '../components/InvestigationReportView.js';
 import { useDashboardChat } from '../hooks/useDashboardChat.js';
@@ -46,6 +47,15 @@ interface Dashboard {
   updatedAt?: string;
   folder?: string;
   pendingChanges?: PendingChange[];
+  // Wave 1 PR-B — resource origin marker; used by Wave 2.5 ProvisionedBanner.
+  source?: 'manual' | 'api' | 'ai_generated' | 'provisioned_file' | 'provisioned_git';
+  provenance?: {
+    repo?: string;
+    path?: string;
+    commit?: string;
+    generatedBy?: string;
+    prompt?: string;
+  };
 }
 
 // Main
@@ -728,6 +738,40 @@ export default function DashboardWorkspace() {
               </button>
             )}
 
+            {id && (
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    const res = await apiClient.post<{ id: string }>(
+                      `/resources/dashboard/${id}/fork`,
+                      {},
+                    );
+                    if (!res.error) navigate(`/dashboards/${res.data.id}`);
+                  } catch {
+                    // Best-effort; banner shows a richer error path for the
+                    // provisioned case. Plain Fork failures fall through.
+                  }
+                }}
+                className="p-1.5 rounded-lg transition-colors hover:bg-surface-high text-on-surface-variant hover:text-on-surface"
+                title="Fork to my workspace"
+              >
+                {/* Git fork icon */}
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <circle cx="6" cy="6" r="2" />
+                  <circle cx="18" cy="6" r="2" />
+                  <circle cx="12" cy="18" r="2" />
+                  <path strokeLinecap="round" d="M6 8v3a2 2 0 002 2h8a2 2 0 002-2V8M12 13v3" />
+                </svg>
+              </button>
+            )}
+
             {canDeleteDashboard && (
               <button
                 type="button"
@@ -756,6 +800,15 @@ export default function DashboardWorkspace() {
 
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 flex flex-col min-w-0">
+          {dashboard && (
+            <ProvisionedBanner
+              resourceKind="dashboard"
+              resourceId={dashboard.id}
+              source={dashboard.source}
+              provenance={dashboard.provenance}
+              onForked={(newId) => navigate(`/dashboards/${newId}`)}
+            />
+          )}
           {inferred.state.kind === 'needs-ack' && (
             <VariableInferenceBanner
               vars={inferred.state.vars}


### PR DESCRIPTION
Frontend follow-up to #200 (backend fork + diff helper, merged).

## Changes

- **\`ProvisionedBanner\`** renders on dashboard detail pages when \`source === 'provisioned_file' | 'provisioned_git'\`:
  - "Fork to my workspace" → POST /api/resources/dashboard/{id}/fork, navigates to the new resource
  - "View source ↗" → GitHub blob URL built from \`provenance.repo / .path / .commit\` (opens in new tab)
  - Graceful when provenance is sparse: shows "managed externally" + still allows fork
- **\`Dashboard\` local interface** extended with \`source\` + \`provenance\` fields matching the Wave 1 PR-B model
- **Standalone Fork button** in dashboard action bar (between Permissions and Delete) for non-provisioned resources too — useful for duplicating any dashboard

## Deferred to follow-up PRs

- **SSE diff message bubble in chat** — backend currently returns the diff as text-only observation to the LLM (\`handleAlertRuleWrite\` catch block at line 208). Wiring an SSE event would require a backend PR to emit \`provisioned_diff\` events; UI consumes that next.
- **Banner / fork on alert rule detail page** — no dedicated detail surface exists (\`AlertRuleEdit.tsx\` is the edit form, not an action-bar page). Skipped pending product decision on whether to add one.

## Test plan

- [x] 5/5 ProvisionedBanner tests pass (no banner for manual/undefined; banner with full provenance / no provenance / no repo+path)
- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: open a dashboard with \`source = 'provisioned_git'\` → see banner → click Fork → land on copy with \`source = 'manual'\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Fork to my workspace" button enabling users to create personal copies of provisioned resources with automatic navigation to the newly forked copy.
  * Introduced provisioned resource banner displaying source management information, commit metadata, and quick-access links for viewing source and forking to personal workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->