### PR TITLE
fix(chat): drop ?chat=<id> URL param — kill stale-id loop at source

### DIFF
--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import Navigation from './Navigation.js';
 import GlobalSearch from './GlobalSearch.js';
@@ -18,11 +18,7 @@ function LayoutInner() {
     clearPendingNavigation,
     loadError,
     retryLoadSession,
-    loadSession,
-    currentSessionId,
-    startNewSession,
   } = useGlobalChat();
-  const loadedUrlChatRef = useRef<string | null>(null);
 
   // Hide the global ChatPanel on Home, the top-level list pages
   // (Dashboards / Investigations / Alerts), and configuration surfaces
@@ -42,42 +38,11 @@ function LayoutInner() {
       (p) => pathname === p || pathname.startsWith(`${p}/`),
     );
 
-  // URL chat identity is canonical on resource pages. Loading here keeps
-  // dashboards, investigations, and future resource details on the same path.
-  useEffect(() => {
-    const chatId = new URLSearchParams(location.search).get('chat');
-    if (!chatId) {
-      if (showChat) {
-        loadedUrlChatRef.current = null;
-        startNewSession();
-      }
-      return;
-    }
-    if (chatId === currentSessionId) {
-      loadedUrlChatRef.current = chatId;
-      return;
-    }
-    if (loadedUrlChatRef.current === chatId) return;
-    loadedUrlChatRef.current = chatId;
-    void loadSession(chatId);
-  }, [currentSessionId, location.search, loadSession, showChat, startNewSession]);
-
-  useEffect(() => {
-    if (!showChat || !currentSessionId) return;
-    const params = new URLSearchParams(location.search);
-    if (params.get('chat') === currentSessionId) return;
-    params.set('chat', currentSessionId);
-    navigate(
-      { pathname: location.pathname, search: `?${params.toString()}` },
-      { replace: true },
-    );
-  }, [
-    currentSessionId,
-    location.pathname,
-    location.search,
-    navigate,
-    showChat,
-  ]);
+  // Session id no longer lives in the URL. ChatProvider's React state holds
+  // currentSessionId and persists across route changes within the tab, so
+  // the ChatPanel here just reflects whatever conversation is live.
+  // Refresh / new tab = empty state = new conversation, matching the
+  // "open page = fresh slate" UX appropriate for an SRE tool.
 
   // Handle agent-initiated navigation
   useEffect(() => {

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -369,24 +369,22 @@ export default function Navigation() {
     wasGeneratingRef.current = globalChat.isGenerating;
   }, [activeTab, globalChat.isGenerating, refreshSessions]);
 
-  const chatIdFromUrl =
-    new URLSearchParams(location.search).get('chat') ?? undefined;
+  const activeSessionId = globalChat.currentSessionId || undefined;
 
   const openSession = useCallback(
     (sessionId: string) => {
       void globalChat.loadSession(sessionId);
-      navigate({
-        pathname: '/',
-        search: `?chat=${encodeURIComponent(sessionId)}`,
-      });
+      // No URL mutation — session id lives in ChatProvider's React state.
+      // Just ensure we're on Home so the conversation surface is visible.
+      if (location.pathname !== '/') navigate('/');
     },
-    [globalChat, navigate],
+    [globalChat, navigate, location.pathname],
   );
 
   const startNew = useCallback(() => {
     globalChat.startNewSession();
-    navigate('/', { replace: true });
-  }, [globalChat, navigate]);
+    if (location.pathname !== '/') navigate('/');
+  }, [globalChat, navigate, location.pathname]);
 
   // Pending-plan badge for the Action Center entry. Polled every 30s
   // (per the UX brief) so operators see remediation work waiting on them
@@ -534,7 +532,7 @@ export default function Navigation() {
             ) : (
               <ul className="flex flex-col gap-0.5">
                 {sessions.map((s) => {
-                  const active = s.id === chatIdFromUrl;
+                  const active = s.id === activeSessionId;
                   return (
                     <li key={s.id}>
                       <button

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -240,16 +240,11 @@ export function rebuildChatEventsFromSession(
   );
 }
 
-function withChatQuery(path: string, sessionId: string): string {
-  if (!sessionId || !path.startsWith('/')) return path;
-  try {
-    const url = new URL(path, window.location.origin);
-    url.searchParams.set('chat', sessionId);
-    return `${url.pathname}${url.search}${url.hash}`;
-  } catch {
-    return path;
-  }
-}
+// withChatQuery used to append `?chat=<id>` to agent-emitted navigation paths
+// so the destination page could rebind the same chat. That's now redundant:
+// currentSessionId lives in ChatProvider's React state and persists across
+// route changes within the tab. URL-based session restore was also a source
+// of stale-id bugs (see preceding commits) and is no longer the model.
 
 /**
  * Global chat hook — not tied to any specific dashboard.
@@ -384,7 +379,7 @@ export function useChat(): UseChatResult {
         case 'navigate': {
           const path = (parsed.path as string) ?? '';
           if (path) {
-            setPendingNavigation(withChatQuery(path, sessionIdRef.current));
+            setPendingNavigation(path);
           }
           break;
         }
@@ -427,12 +422,7 @@ export function useChat(): UseChatResult {
           // Check if done carries a navigate directive as well
           const navigateTo = parsed.navigate as string | undefined;
           if (navigateTo) {
-            setPendingNavigation(
-              withChatQuery(
-                navigateTo,
-                durableSessionId || sessionIdRef.current,
-              ),
-            );
+            setPendingNavigation(navigateTo);
           }
           appendEvent({ id, kind: 'done', content: 'Generation complete' });
           break;

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -128,23 +128,10 @@ export default function Home() {
   const blocks = useMemo(() => groupEvents(events), [events]);
   const liveBlockId = useMemo(() => liveAgentBlockId(blocks, isGenerating), [blocks, isGenerating]);
 
-  const chatIdFromUrl = useMemo(
-    () => new URLSearchParams(location.search).get('chat'),
-    [location.search],
-  );
-
-  // Home is the new conversation entry point unless the URL explicitly names
-  // a durable personal chat to reopen.
-  useEffect(() => {
-    if (chatIdFromUrl) {
-      if (chatIdFromUrl !== currentSessionId) {
-        void loadSession(chatIdFromUrl);
-      }
-    } else {
-      globalChat.startNewSession();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatIdFromUrl, currentSessionId]);
+  // Session id is owned by ChatProvider's React state (currentSessionId), not
+  // the URL. Refresh / new tab = empty state = new conversation. Explicit
+  // resume = Recents click in Navigation.tsx, which calls loadSession(id).
+  // Home renders whatever state globalChat currently holds.
 
   const handleDeleteDashboard = useCallback(async (id: string) => {
     const res = await apiClient.delete(`/dashboards/${id}`);
@@ -171,16 +158,6 @@ export default function Home() {
   useEffect(() => {
     refreshSessions();
   }, [refreshSessions]);
-
-  useEffect(() => {
-    if (!currentSessionId || currentSessionId === chatIdFromUrl) return;
-    const params = new URLSearchParams(location.search);
-    params.set('chat', currentSessionId);
-    navigate(
-      { pathname: '/', search: `?${params.toString()}` },
-      { replace: true },
-    );
-  }, [chatIdFromUrl, currentSessionId, location.search, navigate]);
 
   const wasGeneratingRef = useRef(false);
   useEffect(() => {
@@ -216,12 +193,12 @@ export default function Home() {
   const handleOpenSession = useCallback(
     (sessionId: string) => {
       void loadSession(sessionId);
-      navigate({
-        pathname: '/',
-        search: `?chat=${encodeURIComponent(sessionId)}`,
-      });
+      // No URL mutation — session id lives in React state, the route stays '/'.
+      // Browser back-button still works via the normal history stack since
+      // we don't push entries for chat switches anymore.
+      if (location.pathname !== '/') navigate('/');
     },
-    [loadSession, navigate],
+    [loadSession, navigate, location.pathname],
   );
 
   // Reusable input component (used in both modes)


### PR DESCRIPTION
Follow-up to #205. Same class of bug, second shape.

## Symptom hit after #205

Refresh a page that still has \`?chat=<old-id>\` in URL → Home's URL effect calls \`loadSession(old)\` → 404 → state clears → URL unchanged → effect re-runs → **infinite loop** GET'ing \`/chat/sessions/<id>/messages\`, eventually 429.

## Root cause

#205 removed \`localStorage.chat_session_id\` — but \`?chat=<id>\` in URL was the **second** redundant persistence of a server-side session id with no invalidation contract. Same bug shape.

I was about to patch Home with a loop guard + URL cleanup. User pushed back: stop patching, fix it architecturally.

## The architectural fix

\`currentSessionId\` lives in **one place**: ChatProvider's React state.

| | Before | After |
|---|---|---|
| Source of truth | localStorage + URL + React state | React state only |
| Refresh tab | restore last session via stored id | empty state, new conversation |
| In-tab navigation | URL carries \`?chat=\` | state persists in ChatProvider (wraps whole router) |
| Explicit resume | URL deeplink or Recents | Recents only (calls \`loadSession(id)\`) |
| Stale-id loop | possible | structurally impossible |

## Deferred (intentional)

Shareable conversation URLs are dropped. Can be added back later as an explicit \`/chat/<id>\` route with its own loading + 404 page — that would be a feature with deliberate UX, not the silent client-side caching we had.

## Changes

- \`useChat.ts\` — removed \`withChatQuery()\`; agent-emitted nav paths are raw
- \`Home.tsx\` — dropped \`chatIdFromUrl\` and the two URL effects; Recents click doesn't mutate URL
- \`Layout.tsx\` — dropped the resource-page URL effects; \`loadedUrlChatRef\` gone
- \`Navigation.tsx\` — Recents 'active' highlight uses \`currentSessionId\` state, not URL

## Test plan

- [x] useChat tests pass
- [x] build clean
- [ ] CI green
- [ ] Manual: refresh, send chat, navigate to dashboard, come back — conversation persists
- [ ] Manual: open new tab — fresh empty conversation
- [ ] Manual: click a session in Recents — loads, no URL change, no loop