### PR TITLE
Wire setup notification config into alert routing

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -151,7 +151,11 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   app.use(
     '/api/system',
     bootstrapAwareAuthOnly,
-    createSystemRouter({ setupConfig, ac: accessControl }),
+    createSystemRouter({
+      setupConfig,
+      ac: accessControl,
+      notificationStore: repos.notifications,
+    }),
   );
   app.use(
     '/api/query',

--- a/packages/api-gateway/src/routes/system-notifications.test.ts
+++ b/packages/api-gateway/src/routes/system-notifications.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Application } from 'express';
+import request from 'supertest';
+import {
+  InstanceConfigRepository,
+  NotificationChannelRepository,
+  SqliteConnectorRepository,
+  SqliteNotificationRepository,
+  createTestDb,
+} from '@agentic-obs/data-layer';
+import type { SqliteClient } from '@agentic-obs/data-layer';
+import { createSystemRouter } from './system.js';
+import { SetupConfigService } from '../services/setup-config-service.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+
+const allowAc: AccessControlSurface = {
+  getUserPermissions: async () => [],
+  evaluate: async () => true,
+  ensurePermissions: async () => [],
+  filterByPermission: async (_id, items) => [...items],
+};
+
+const noopAudit = {
+  log: async () => undefined,
+} as unknown as AuditWriter;
+
+interface Ctx {
+  app: Application;
+  db: SqliteClient;
+  notifications: SqliteNotificationRepository;
+}
+
+function buildApp(): Ctx {
+  const db = createTestDb();
+  const setupConfig = new SetupConfigService({
+    instanceConfig: new InstanceConfigRepository(db),
+    connectors: new SqliteConnectorRepository(db),
+    notificationChannels: new NotificationChannelRepository(db),
+    audit: noopAudit,
+  });
+  const notifications = new SqliteNotificationRepository(db);
+  const app = express();
+  app.use(express.json());
+  app.use((_req, res, next) => {
+    res.locals['allowBootstrapUnauthenticated'] = true;
+    next();
+  });
+  app.use(
+    '/api/system',
+    createSystemRouter({
+      setupConfig,
+      ac: allowAc,
+      notificationStore: notifications,
+    }),
+  );
+  return { app, db, notifications };
+}
+
+describe('PUT /api/system/notifications', () => {
+  const prevSecret = process.env['SECRET_KEY'];
+
+  beforeAll(() => {
+    process.env['SECRET_KEY'] =
+      prevSecret ?? 'test-secret-key-for-system-notifications-xxxxxxxxxxxx';
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) delete process.env['SECRET_KEY'];
+    else process.env['SECRET_KEY'] = prevSecret;
+  });
+
+  let ctx: Ctx;
+
+  beforeEach(() => {
+    ctx = buildApp();
+  });
+
+  it('syncs the setup Slack webhook into the default alert contact point', async () => {
+    const res = await request(ctx.app)
+      .put('/api/system/notifications')
+      .send({
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/ONE' },
+      });
+
+    expect(res.status).toBe(200);
+    const contactPoints = await ctx.notifications.findAllContactPoints();
+    expect(contactPoints).toHaveLength(1);
+    expect(contactPoints[0]!.name).toBe('Slack');
+    expect(contactPoints[0]!.integrations).toEqual([
+      {
+        id: 'system-slack',
+        type: 'slack',
+        name: 'Slack',
+        settings: { webhookUrl: 'https://hooks.slack.com/services/T/B/ONE' },
+      },
+    ]);
+    const policyTree = await ctx.notifications.getPolicyTree();
+    expect(policyTree.contactPointId).toBe(contactPoints[0]!.id);
+  });
+
+  it('updates the managed Slack contact point without replacing custom routing', async () => {
+    const custom = await ctx.notifications.createContactPoint({
+      name: 'Custom on-call',
+      integrations: [],
+    });
+    await ctx.notifications.updatePolicyTree({
+      ...(await ctx.notifications.getPolicyTree()),
+      contactPointId: custom.id,
+    });
+
+    await request(ctx.app)
+      .put('/api/system/notifications')
+      .send({
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/ONE' },
+      })
+      .expect(200);
+    await request(ctx.app)
+      .put('/api/system/notifications')
+      .send({
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/TWO' },
+      })
+      .expect(200);
+
+    const contactPoints = await ctx.notifications.findAllContactPoints();
+    const managed = contactPoints.find((cp) =>
+      cp.integrations.some((integration) => integration.id === 'system-slack'),
+    );
+    expect(managed?.integrations[0]?.settings).toEqual({
+      webhookUrl: 'https://hooks.slack.com/services/T/B/TWO',
+    });
+    expect((await ctx.notifications.getPolicyTree()).contactPointId).toBe(
+      custom.id,
+    );
+  });
+
+  it('removes the managed Slack routing when Slack is cleared', async () => {
+    await request(ctx.app)
+      .put('/api/system/notifications')
+      .send({
+        slack: { webhookUrl: 'https://hooks.slack.com/services/T/B/ONE' },
+      })
+      .expect(200);
+
+    await request(ctx.app)
+      .put('/api/system/notifications')
+      .send({})
+      .expect(200);
+
+    expect(await ctx.notifications.findAllContactPoints()).toEqual([]);
+    expect((await ctx.notifications.getPolicyTree()).contactPointId).toBe('');
+  });
+});

--- a/packages/api-gateway/src/routes/system.ts
+++ b/packages/api-gateway/src/routes/system.ts
@@ -18,12 +18,16 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import {
   ac,
   ACTIONS,
+  type ContactPoint,
+  type ContactPointIntegration,
   type NewInstanceLlmConfig,
   type NotificationChannelConfig,
+  type NotificationPolicyNode,
   type NewNotificationChannel,
   type LlmConfigWire,
   type NotificationsWire,
 } from '@agentic-obs/common';
+import type { INotificationRepository } from '@agentic-obs/data-layer';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
@@ -35,7 +39,16 @@ export interface SystemRouterDeps {
    * accept the surface rather than the concrete service.
    */
   ac: AccessControlSurface;
+  /**
+   * Alerting notification store. `/api/system/notifications` is the wizard /
+   * settings entrypoint, while alert dispatch reads contact points and the
+   * policy tree. Supplying this store keeps those two surfaces in sync.
+   */
+  notificationStore?: INotificationRepository;
 }
+
+const MANAGED_SLACK_INTEGRATION_ID = 'system-slack';
+const MANAGED_SLACK_CONTACT_POINT_NAME = 'Slack';
 
 function actorFromReq(req: Request): { userId: string | null } {
   const ar = req as AuthenticatedRequest;
@@ -47,6 +60,83 @@ function inClusterAvailable(): boolean {
     process.env['KUBERNETES_SERVICE_HOST'] &&
     process.env['KUBERNETES_SERVICE_PORT'],
   );
+}
+
+function findManagedSlackContactPoint(contactPoints: ContactPoint[]): ContactPoint | undefined {
+  return contactPoints.find((cp) =>
+    cp.integrations.some((integration) => integration.id === MANAGED_SLACK_INTEGRATION_ID),
+  );
+}
+
+function contactPointIsReferenced(node: NotificationPolicyNode, contactPointId: string): boolean {
+  if (node.contactPointId === contactPointId) return true;
+  return node.children.some((child) => contactPointIsReferenced(child, contactPointId));
+}
+
+async function syncSlackNotificationRouting(
+  notificationStore: INotificationRepository | undefined,
+  webhookUrl: string | undefined,
+): Promise<void> {
+  if (!notificationStore) return;
+
+  const contactPoints = await notificationStore.findAllContactPoints();
+  const existing = findManagedSlackContactPoint(contactPoints);
+
+  if (!webhookUrl) {
+    if (!existing) return;
+    const tree = await notificationStore.getPolicyTree();
+    const updatedTree =
+      tree.contactPointId === existing.id
+        ? { ...tree, contactPointId: '' }
+        : tree;
+    if (updatedTree !== tree) {
+      await notificationStore.updatePolicyTree(updatedTree);
+    }
+    if (!contactPointIsReferenced(updatedTree, existing.id)) {
+      await notificationStore.deleteContactPoint(existing.id);
+    }
+    return;
+  }
+
+  const integration: ContactPointIntegration = {
+    id: MANAGED_SLACK_INTEGRATION_ID,
+    type: 'slack',
+    name: MANAGED_SLACK_CONTACT_POINT_NAME,
+    settings: { webhookUrl },
+  };
+
+  const contactPoint = existing
+    ? await notificationStore.updateContactPoint(existing.id, {
+        name: existing.name || MANAGED_SLACK_CONTACT_POINT_NAME,
+        integrations: existing.integrations.some((item) => item.id === MANAGED_SLACK_INTEGRATION_ID)
+          ? existing.integrations.map((item) =>
+              item.id === MANAGED_SLACK_INTEGRATION_ID ? integration : item,
+            )
+          : [...existing.integrations, integration],
+      })
+    : await notificationStore.createContactPoint({
+        name: MANAGED_SLACK_CONTACT_POINT_NAME,
+        integrations: [integration],
+      });
+
+  if (!contactPoint) return;
+
+  const tree = await notificationStore.getPolicyTree();
+  const rootContactPointMissing =
+    tree.contactPointId !== ''
+      && !contactPoints.some((cp) => cp.id === tree.contactPointId)
+      && tree.contactPointId !== contactPoint.id;
+  if (
+    tree.contactPointId === ''
+    || tree.contactPointId === contactPoint.id
+    || rootContactPointMissing
+  ) {
+    await notificationStore.updatePolicyTree({
+      ...tree,
+      contactPointId: contactPoint.id,
+      isDefault: true,
+    });
+  }
 }
 
 export function createSystemRouter(deps: SystemRouterDeps): Router {
@@ -173,6 +263,7 @@ export function createSystemRouter(deps: SystemRouterDeps): Router {
         await setupConfig.deleteNotificationChannel(c.id, actor);
       }
     }
+    await syncSlackNotificationRouting(deps.notificationStore, dto.slack?.webhookUrl);
     res.json({ ok: true });
   });
 


### PR DESCRIPTION
## Summary
- Sync Slack and PagerDuty saved through /api/system/notifications into the alert contact point store
- Keep Slack and PagerDuty on one managed default contact point so default routing can fan out to both
- Add a PagerDuty Events API v2 sender and register it with alert notification dispatch
- Preserve custom notification routing and remove managed routing when setup notifications are cleared

## Tests
- npm run typecheck
- npm test -- --run packages/api-gateway/src/routes/system-notifications.test.ts packages/api-gateway/src/services/notification-senders/pagerduty.test.ts packages/api-gateway/src/services/notification-senders/slack.test.ts packages/api-gateway/src/services/notification-consumer.test.ts