### PR TITLE
Inline Chart PR-A: backend (REST + agent tool + SSE event + summary)

### DIFF
--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -46,6 +46,8 @@ agentRegistry.register({
     'connectors_suggest', 'connectors_pin', 'connectors_unpin',
     // Source-agnostic metrics primitives (each requires sourceId)
     'metrics_query', 'metrics_range_query', 'metrics_discover', 'metrics_validate',
+    // Inline chart bubble in chat — for "show me / what is" type questions.
+    'metric_explore',
     // Source-agnostic logs primitives (each requires sourceId)
     'logs_query', 'logs_labels', 'logs_label_values',
     // Recent change events

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -21,6 +21,8 @@ export type AgentToolName =
   | 'navigate'
   // Source-agnostic metrics primitives (each requires `sourceId`)
   | 'metrics_query' | 'metrics_range_query' | 'metrics_discover' | 'metrics_validate'
+  // Inline chart bubble in chat (uses shared chart-summary helper)
+  | 'metric_explore'
   // Source-agnostic logs primitives (each requires `sourceId`)
   | 'logs_query' | 'logs_labels' | 'logs_label_values'
   // Recent change events (deploys, config rollouts, incidents)

--- a/packages/agent-core/src/agent/handlers/index.ts
+++ b/packages/agent-core/src/agent/handlers/index.ts
@@ -42,6 +42,8 @@ export {
   handleMetricsValidate,
 } from './metrics.js';
 
+export { handleMetricExplore } from './metric-explore.js';
+
 export {
   handleLogsQuery,
   handleLogsLabels,

--- a/packages/agent-core/src/agent/handlers/metric-explore.ts
+++ b/packages/agent-core/src/agent/handlers/metric-explore.ts
@@ -1,0 +1,231 @@
+/**
+ * `metric_explore` — query a metric and render an inline chart bubble in chat.
+ *
+ * Companion to the REST `/api/metrics/query` endpoint: same summary helper,
+ * same wire payload shape, but emitted as an SSE `inline_chart` event so the
+ * chat surface picks it up and renders a chart inline. The model receives
+ * only the one-liner summary as its observation — series data goes only to
+ * the UI.
+ *
+ * v1 omits `pivotSuggestions` (PR-C will populate them based on the metric's
+ * label set + a small LLM scaffolding pass).
+ */
+
+import { AuditAction, summarizeChart, type ChartMetricKind } from '@agentic-obs/common';
+import type { ActionContext } from './_context.js';
+
+const RELATIVE_HINT_MS: Record<string, number> = {
+  '1h': 60 * 60 * 1000,
+  '6h': 6 * 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+interface ParsedRange {
+  start: Date;
+  end: Date;
+  warning?: string;
+}
+
+/**
+ * Parse a `timeRangeHint` into a concrete (start, end) pair.
+ *
+ * Supports:
+ *   - "1h" / "6h" / "24h" / "7d"        → end=now, start=end-N
+ *   - "since 14:00" / "since 9:30"      → start=today HH:MM (local), end=now
+ *   - "30m around 14:23"                → ±15 minutes around the anchor today
+ *   - empty / unparseable               → default 1h with a warning
+ */
+export function parseTimeRangeHint(hint: string | undefined, nowMs: number): ParsedRange {
+  const cleaned = (hint ?? '').trim().toLowerCase();
+  if (!cleaned) {
+    return { start: new Date(nowMs - RELATIVE_HINT_MS['1h']!), end: new Date(nowMs) };
+  }
+
+  const relMs = RELATIVE_HINT_MS[cleaned];
+  if (relMs) {
+    return { start: new Date(nowMs - relMs), end: new Date(nowMs) };
+  }
+
+  // "since HH:MM"
+  const sinceMatch = cleaned.match(/^since\s+(\d{1,2}):(\d{2})$/);
+  if (sinceMatch) {
+    const hour = Number(sinceMatch[1]);
+    const minute = Number(sinceMatch[2]);
+    if (hour < 24 && minute < 60) {
+      const anchor = new Date(nowMs);
+      anchor.setHours(hour, minute, 0, 0);
+      // If the anchor is in the future (e.g. "since 23:00" at 02:00) roll
+      // back one day.
+      if (anchor.getTime() > nowMs) anchor.setDate(anchor.getDate() - 1);
+      return { start: anchor, end: new Date(nowMs) };
+    }
+  }
+
+  // "Nm around HH:MM"
+  const aroundMatch = cleaned.match(/^(\d+)m\s+around\s+(\d{1,2}):(\d{2})$/);
+  if (aroundMatch) {
+    const span = Number(aroundMatch[1]);
+    const hour = Number(aroundMatch[2]);
+    const minute = Number(aroundMatch[3]);
+    if (span > 0 && hour < 24 && minute < 60) {
+      const anchor = new Date(nowMs);
+      anchor.setHours(hour, minute, 0, 0);
+      const halfMs = (span * 60_000) / 2;
+      return {
+        start: new Date(anchor.getTime() - halfMs),
+        end: new Date(anchor.getTime() + halfMs),
+      };
+    }
+  }
+
+  return {
+    start: new Date(nowMs - RELATIVE_HINT_MS['1h']!),
+    end: new Date(nowMs),
+    warning: `Couldn't parse timeRangeHint "${hint}". Defaulted to last 1h.`,
+  };
+}
+
+/**
+ * Pick a step targeting ~150 points across the range, snapped to a fixed set.
+ * Identical to the REST endpoint's `pickStep` — duplicated to avoid making
+ * api-gateway depend on agent-core (other direction is already paid for).
+ */
+export function pickStep(start: Date, end: Date): string {
+  const seconds = Math.max(1, Math.floor((end.getTime() - start.getTime()) / 1000));
+  const target = Math.floor(seconds / 150);
+  const buckets = [15, 30, 60, 5 * 60, 15 * 60, 60 * 60];
+  for (const b of buckets) {
+    if (target <= b) return `${b}s`;
+  }
+  return `${buckets[buckets.length - 1]}s`;
+}
+
+/**
+ * Classify a PromQL expression into a chart kind. Same heuristic as the REST
+ * route's `inferKind` — duplicated here for the same reason as `pickStep`.
+ */
+export function inferKind(query: string): ChartMetricKind {
+  const q = query.toLowerCase();
+  if (q.includes('histogram_quantile')) return 'latency';
+  if (/_errors?\b|5xx|status=~?"5/.test(q)) return 'errors';
+  if (/\brate\s*\(|\bsum\s*\(\s*rate\s*\(/.test(q)) return 'counter';
+  return 'gauge';
+}
+
+const VALID_KINDS: ReadonlySet<ChartMetricKind> = new Set([
+  'latency', 'counter', 'gauge', 'errors',
+]);
+
+/** Resolve the metrics datasource id — explicit > session pin > primary. */
+function resolveDatasourceId(
+  ctx: ActionContext,
+  explicit: string | undefined,
+): string | undefined {
+  if (explicit) return explicit;
+  const pin = ctx.sessionConnectorPins?.['prometheus'];
+  if (pin) return pin;
+  const conns = ctx.allConnectors ?? [];
+  const metrics = conns.filter(
+    (c) => c.type === 'prometheus' || c.type === 'victoria-metrics',
+  );
+  if (metrics.length === 0) return undefined;
+  const primary = metrics.find((c) => c.isDefault) ?? metrics[0];
+  return primary?.id;
+}
+
+export async function handleMetricExplore(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const query = typeof args['query'] === 'string' ? args['query'].trim() : '';
+  if (!query) {
+    return 'Error: "query" is required.';
+  }
+  const datasourceId = resolveDatasourceId(
+    ctx,
+    typeof args['datasourceId'] === 'string' ? args['datasourceId'] : undefined,
+  );
+  if (!datasourceId) {
+    return 'Error: no metrics datasource available. Call connectors_list to see what is configured.';
+  }
+  const adapter = ctx.adapters.metrics(datasourceId);
+  if (!adapter) {
+    return `Error: unknown metrics connector '${datasourceId}'.`;
+  }
+
+  const hint = typeof args['timeRangeHint'] === 'string' ? args['timeRangeHint'] : undefined;
+  const range = parseTimeRangeHint(hint, Date.now());
+  const step = pickStep(range.start, range.end);
+
+  const kindInput = typeof args['metricKind'] === 'string' ? args['metricKind'] as ChartMetricKind : undefined;
+  const kind = kindInput && VALID_KINDS.has(kindInput) ? kindInput : inferKind(query);
+
+  const displayText = `Charting ${kind}: ${query.slice(0, 80)}`;
+  ctx.sendEvent({
+    type: 'tool_call',
+    tool: 'metric_explore',
+    args: { datasourceId, query, kind, step },
+    displayText,
+  });
+
+  try {
+    const series = await adapter.rangeQuery(query, range.start, range.end, step);
+    const summary = summarizeChart(series, kind);
+
+    // Emit the inline chart bubble payload.
+    ctx.sendEvent({
+      type: 'inline_chart',
+      query,
+      datasourceId,
+      timeRange: {
+        start: range.start.toISOString(),
+        end: range.end.toISOString(),
+      },
+      step,
+      metricKind: kind,
+      series,
+      summary,
+      pivotSuggestions: [],
+    });
+
+    // Audit (fire-and-forget). Mirrors the REST endpoint's audit row.
+    if (ctx.auditWriter) {
+      void ctx.auditWriter({
+        action: AuditAction.MetricsQuery,
+        actorType: 'user',
+        actorId: ctx.identity.userId,
+        targetType: 'connector',
+        targetId: datasourceId,
+        outcome: 'success',
+        metadata: {
+          orgId: ctx.identity.orgId,
+          query: query.slice(0, 500),
+          step,
+          source: 'agent_tool',
+          sessionId: ctx.sessionId,
+        },
+      });
+    }
+
+    ctx.sendEvent({
+      type: 'tool_result',
+      tool: 'metric_explore',
+      summary: summary.oneLine,
+      success: true,
+    });
+
+    // The model gets the one-liner only — chart data goes to the UI.
+    // Suffix the parse warning when we fell back to default 1h.
+    return range.warning ? `${summary.oneLine} (${range.warning})` : summary.oneLine;
+  } catch (err) {
+    const msg = `metric_explore failed: ${err instanceof Error ? err.message : String(err)}`;
+    ctx.sendEvent({
+      type: 'tool_result',
+      tool: 'metric_explore',
+      summary: msg,
+      success: false,
+    });
+    return msg;
+  }
+}

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -30,6 +30,7 @@ export {
   handleMetricsRangeQuery,
   handleMetricsDiscover,
   handleMetricsValidate,
+  handleMetricExplore,
   handleLogsQuery,
   handleLogsLabels,
   handleLogsLabelValues,

--- a/packages/agent-core/src/agent/orchestrator-action-runner.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-runner.ts
@@ -27,6 +27,7 @@ import {
   handleMetricsRangeQuery,
   handleMetricsDiscover,
   handleMetricsValidate,
+  handleMetricExplore,
   handleLogsQuery,
   handleLogsLabels,
   handleLogsLabelValues,
@@ -207,6 +208,8 @@ async function dispatchAction(
     case 'metrics_range_query': return handleMetricsRangeQuery(ctx, args);
     case 'metrics_discover': return handleMetricsDiscover(ctx, args);
     case 'metrics_validate': return handleMetricsValidate(ctx, args);
+    // Inline chart bubble in chat (PR-A backend; PR-B frontend renders the bubble).
+    case 'metric_explore': return handleMetricExplore(ctx, args);
     // Source-agnostic logs primitives
     case 'logs_query': return handleLogsQuery(ctx, args);
     case 'logs_labels': return handleLogsLabels(ctx, args);

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -161,6 +161,10 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
     ac.eval('connectors:query', resolveConnectorScope(args)),
   'metrics_validate': (args: Record<string, unknown>) =>
     ac.eval('connectors:query', resolveConnectorScope(args)),
+  // metric_explore — inline chart bubble in chat. Same scope as the
+  // other read-side metrics primitives.
+  'metric_explore': (args: Record<string, unknown>) =>
+    ac.eval('connectors:query', resolveConnectorScope(args)),
 
   // -- Logs primitives (source-agnostic; sourceId is required) -------------
   'logs_query': (args: Record<string, unknown>) =>

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -199,6 +199,28 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
       },
     },
   },
+  'metric_explore': {
+    category: 'always-on',
+    schema: {
+      name: 'metric_explore',
+      description:
+        'Query a time-series metric and render an interactive chart inline in the chat. Use for "show me / what is / how is" questions about metrics. Do NOT use for persistent dashboards (use dashboard_create for that). The chart appears in the chat; you should NOT describe its contents in your response — just acknowledge what you queried.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'PromQL expression' },
+          timeRangeHint: { type: 'string', description: 'Time window hint: "1h" | "6h" | "24h" | "7d" | "since 14:00" | "30m around 14:23". Defaults to 1h.' },
+          datasourceId: { type: 'string', description: 'Connector id. Omit to use the primary metrics datasource for the workspace.' },
+          metricKind: {
+            type: 'string',
+            enum: ['latency', 'counter', 'gauge', 'errors'],
+            description: 'Optional explicit kind. Omit to let the server infer from the query (histogram_quantile→latency, rate()→counter, errors/5xx→errors, else gauge).',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
 
   // -------------------------------------------------------------------------
   // Logs primitives (read-only, source-agnostic). The query string is backend-native.

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -39,6 +39,7 @@ import { mountPlans } from './plans-boot.js';
 import { createWebhookRouter } from '../routes/webhooks.js';
 import { createConnectorsRouter } from '../routes/connectors.js';
 import { createQueryRouter } from '../routes/dashboard/query.js';
+import { createMetricsQueryRouter } from '../routes/metrics-query.js';
 import { createSystemRouter } from '../routes/system.js';
 import { createDashboardRouter } from '../routes/dashboard/router.js';
 import { createAlertRulesRouter } from '../routes/alert-rules.js';
@@ -235,6 +236,15 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     setupConfig,
     llmAuditStore: repos.llmAudit,
   }));
+  // Inline-chart metrics query — POST /api/metrics/query. Mounted after the
+  // /api/metrics exposition router so the POST verb doesn't shadow the GET /.
+  // Auth + per-datasource RBAC + 30/min rate limit are inside the router.
+  app.use('/api/metrics', userRateLimiter, createMetricsQueryRouter({
+    setupConfig,
+    ac: accessControl,
+    audit: authSub.audit,
+  }));
+
   app.use('/api/alert-rules', createAlertRulesRouter({
     alertRuleStore: eventAlertRuleStore,
     investigationStore: repos.investigations,

--- a/packages/api-gateway/src/routes/metrics-query.test.ts
+++ b/packages/api-gateway/src/routes/metrics-query.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Connector, Identity } from '@agentic-obs/common';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import { createMetricsQueryRouter, __resetRateLimitForTests } from './metrics-query.js';
+
+const authState = vi.hoisted(() => ({
+  orgId: 'org_a',
+  userId: 'user_1',
+}));
+
+vi.mock('../middleware/auth.js', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.auth = {
+      userId: authState.userId,
+      orgId: authState.orgId,
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  },
+}));
+
+const PROM_CONNECTOR: Connector = {
+  id: 'ds_prom',
+  orgId: 'org_a',
+  type: 'prometheus',
+  name: 'Primary Prometheus',
+  config: { url: 'http://prom:9090' },
+  status: 'active',
+  lastVerifiedAt: null,
+  lastVerifyError: null,
+  isDefault: true,
+  createdBy: 'admin',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  capabilities: ['metrics'],
+  secretMissing: false,
+};
+
+function makeSetupConfig(connectors: Connector[]) {
+  return {
+    getConnector: vi.fn(async (id: string) => connectors.find((c) => c.id === id) ?? null),
+    listConnectors: vi.fn(async () => connectors),
+  } as any;
+}
+
+function makeAc(allowed: boolean): AccessControlSurface {
+  return {
+    evaluate: vi.fn(async (_ident: Identity, _eval: any) => allowed),
+  } as any;
+}
+
+function makeAudit() {
+  return { log: vi.fn(async () => {}) } as any;
+}
+
+function makeApp(deps: Parameters<typeof createMetricsQueryRouter>[0]) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/metrics', createMetricsQueryRouter(deps));
+  return app;
+}
+
+beforeEach(() => {
+  __resetRateLimitForTests();
+});
+
+describe('POST /api/metrics/query', () => {
+  it('happy path: resolves default datasource, returns series + summary', async () => {
+    const buildAdapter = vi.fn(() => ({
+      rangeQuery: vi.fn(async () => [
+        {
+          metric: { quantile: '0.95' },
+          values: [
+            [1700000000, '0.1'],
+            [1700000060, '0.2'],
+            [1700000120, '0.34'],
+          ] as Array<[number, string]>,
+        },
+      ]),
+    }));
+
+    const audit = makeAudit();
+    const app = makeApp({
+      setupConfig: makeSetupConfig([PROM_CONNECTOR]),
+      ac: makeAc(true),
+      audit,
+      buildAdapter,
+    });
+
+    const res = await request(app)
+      .post('/api/metrics/query')
+      .send({
+        query: 'histogram_quantile(0.95, rate(http_duration_seconds_bucket[5m]))',
+        timeRange: { relative: '1h' },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.series).toHaveLength(1);
+    expect(res.body.summary.kind).toBe('latency');
+    expect(res.body.summary.oneLine).toMatch(/peak \d+ms/);
+    expect(res.body.timeRange.start).toBeTruthy();
+    expect(res.body.timeRange.end).toBeTruthy();
+    expect(typeof res.body.durationMs).toBe('number');
+    expect(audit.log).toHaveBeenCalledTimes(1);
+    expect(audit.log.mock.calls[0][0].action).toBe('metrics.query');
+  });
+
+  it('bad query: returns 400 BAD_QUERY when query is empty', async () => {
+    const app = makeApp({
+      setupConfig: makeSetupConfig([PROM_CONNECTOR]),
+      ac: makeAc(true),
+      audit: makeAudit(),
+      buildAdapter: () => ({ rangeQuery: vi.fn() }),
+    });
+    const res = await request(app)
+      .post('/api/metrics/query')
+      .send({ query: '', timeRange: { relative: '1h' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('BAD_QUERY');
+  });
+
+  it('missing datasource: returns 400 NO_DATASOURCE when org has no Prometheus connector', async () => {
+    const app = makeApp({
+      setupConfig: makeSetupConfig([]),
+      ac: makeAc(true),
+      audit: makeAudit(),
+      buildAdapter: () => ({ rangeQuery: vi.fn() }),
+    });
+    const res = await request(app)
+      .post('/api/metrics/query')
+      .send({ query: 'up', timeRange: { relative: '1h' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('NO_DATASOURCE');
+  });
+
+  it('RBAC: returns 403 FORBIDDEN when user lacks connectors:query on the datasource', async () => {
+    const app = makeApp({
+      setupConfig: makeSetupConfig([PROM_CONNECTOR]),
+      ac: makeAc(false),
+      audit: makeAudit(),
+      buildAdapter: () => ({ rangeQuery: vi.fn() }),
+    });
+    const res = await request(app)
+      .post('/api/metrics/query')
+      .send({ query: 'up', timeRange: { relative: '1h' } });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('rate limit: returns 429 after the 31st request in the same window', async () => {
+    let t = 1_700_000_000_000;
+    const app = makeApp({
+      setupConfig: makeSetupConfig([PROM_CONNECTOR]),
+      ac: makeAc(true),
+      audit: makeAudit(),
+      buildAdapter: () => ({ rangeQuery: vi.fn(async () => []) }),
+      now: () => t,
+    });
+
+    // 30 allowed — burn them all.
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app)
+        .post('/api/metrics/query')
+        .send({ query: 'up', timeRange: { relative: '1h' } });
+      expect(res.status).toBe(200);
+    }
+    const limited = await request(app)
+      .post('/api/metrics/query')
+      .send({ query: 'up', timeRange: { relative: '1h' } });
+    expect(limited.status).toBe(429);
+    expect(limited.body.error.code).toBe('RATE_LIMITED');
+    expect(limited.body.error.retryAfterSec).toBeGreaterThan(0);
+
+    // After the window rolls, requests succeed again.
+    t += 61_000;
+    const after = await request(app)
+      .post('/api/metrics/query')
+      .send({ query: 'up', timeRange: { relative: '1h' } });
+    expect(after.status).toBe(200);
+  });
+});

--- a/packages/api-gateway/src/routes/metrics-query.ts
+++ b/packages/api-gateway/src/routes/metrics-query.ts
@@ -1,0 +1,385 @@
+/**
+ * POST /api/metrics/query — inline chart bubble's backing endpoint.
+ *
+ * The frontend chart component (PR-B) calls this when the user asks
+ * "what is p50 latency now" in chat: the agent's `metric_explore` tool
+ * pushes an `inline_chart` SSE event, the bubble fetches via this route to
+ * keep its data fresh on user-pivots (PR-C — re-aggregations, zooms).
+ *
+ * Auth: requires `connectors:query` permission on the datasource (Rounds'
+ * closest analog to "metrics:read" — see packages/common/src/rbac/actions.ts).
+ * Rate limit: 30 queries/min per user per datasource (in-memory token bucket).
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import {
+  ac,
+  ACTIONS,
+  AuditAction,
+  getErrorMessage,
+  summarizeChart,
+  type ChartMetricKind,
+  type Connector,
+} from '@agentic-obs/common';
+import { AdapterError, PrometheusMetricsAdapter } from '@agentic-obs/adapters';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { createRequirePermission } from '../middleware/require-permission.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { SetupConfigService } from '../services/setup-config-service.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+
+export interface MetricsQueryRouterDeps {
+  setupConfig: SetupConfigService;
+  ac: AccessControlSurface;
+  audit: AuditWriter;
+  /**
+   * Test seam — defaults to constructing a real `PrometheusMetricsAdapter`
+   * from the connector's config. Tests pass a stub so they don't need a live
+   * Prometheus.
+   */
+  buildAdapter?: (connector: Connector) => {
+    rangeQuery: PrometheusMetricsAdapter['rangeQuery'];
+  };
+  /**
+   * Test seam — `Date.now()`-style clock so rate-limit tests are deterministic.
+   */
+  now?: () => number;
+}
+
+// -- Rate limit (per user per datasource, in-memory token bucket) ----------
+// 30 queries/min — same shape as a simple sliding window. We keep it
+// in-memory because the surface is "throwaway exploration in chat"; a
+// per-process counter is fine. If we ever need cross-replica coherence we
+// can swap in the Redis bucket the connector-test surface uses.
+
+const RATE_LIMIT_PER_MIN = 30;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface BucketEntry {
+  windowStart: number;
+  count: number;
+}
+const bucket = new Map<string, BucketEntry>();
+
+function rateLimitKey(userId: string, datasourceId: string): string {
+  return `${userId}::${datasourceId}`;
+}
+
+/** Returns `null` on allow, or `{ retryAfterSec }` on deny. */
+function checkRateLimit(key: string, now: number): { retryAfterSec: number } | null {
+  const entry = bucket.get(key);
+  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    bucket.set(key, { windowStart: now, count: 1 });
+    return null;
+  }
+  if (entry.count < RATE_LIMIT_PER_MIN) {
+    entry.count += 1;
+    return null;
+  }
+  const retryAfterMs = RATE_LIMIT_WINDOW_MS - (now - entry.windowStart);
+  return { retryAfterSec: Math.max(1, Math.ceil(retryAfterMs / 1000)) };
+}
+
+// -- Time range parsing -----------------------------------------------------
+
+const RELATIVE_RANGE_MS: Record<string, number> = {
+  '1h': 60 * 60 * 1000,
+  '6h': 6 * 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+interface ResolvedRange {
+  start: Date;
+  end: Date;
+}
+
+function resolveTimeRange(
+  input: unknown,
+  now: () => number,
+): ResolvedRange | { error: string } {
+  if (!input || typeof input !== 'object') {
+    return { error: 'timeRange is required' };
+  }
+  const r = input as { start?: unknown; end?: unknown; relative?: unknown };
+  if (typeof r.relative === 'string') {
+    const span = RELATIVE_RANGE_MS[r.relative];
+    if (!span) return { error: `unsupported relative range "${r.relative}"` };
+    const end = new Date(now());
+    const start = new Date(end.getTime() - span);
+    return { start, end };
+  }
+  if (typeof r.start === 'string' && typeof r.end === 'string') {
+    const start = new Date(r.start);
+    const end = new Date(r.end);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return { error: 'timeRange.start / timeRange.end must be ISO-8601' };
+    }
+    if (end.getTime() <= start.getTime()) {
+      return { error: 'timeRange.end must be after timeRange.start' };
+    }
+    return { start, end };
+  }
+  return { error: 'timeRange must be { start, end } or { relative }' };
+}
+
+/** Pick a step targeting ~150 points across the range. Snaps to a fixed set. */
+function pickStep(start: Date, end: Date): string {
+  const seconds = Math.max(1, Math.floor((end.getTime() - start.getTime()) / 1000));
+  const target = Math.floor(seconds / 150);
+  const buckets = [15, 30, 60, 5 * 60, 15 * 60, 60 * 60];
+  for (const b of buckets) {
+    if (target <= b) return `${b}s`;
+  }
+  return `${buckets[buckets.length - 1]}s`;
+}
+
+// -- Datasource resolution + adapter construction --------------------------
+
+function configString(connector: Connector, key: string): string | undefined {
+  const value = connector.config[key];
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function defaultBuildAdapter(connector: Connector) {
+  const baseUrl = configString(connector, 'url') ?? '';
+  const headers: Record<string, string> = {};
+  const username = configString(connector, 'username');
+  const password = configString(connector, 'password');
+  const apiKey = configString(connector, 'apiKey');
+  if (username && password) {
+    const token = Buffer.from(`${username}:${password}`).toString('base64');
+    headers['Authorization'] = `Basic ${token}`;
+  } else if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+  return new PrometheusMetricsAdapter(baseUrl, headers);
+}
+
+async function resolvePrometheus(
+  setupConfig: SetupConfigService,
+  orgId: string,
+  datasourceId: string | undefined,
+): Promise<Connector | null> {
+  if (datasourceId) {
+    const c = await setupConfig.getConnector(datasourceId, { orgId });
+    if (!c) return null;
+    if (c.type !== 'prometheus' && c.type !== 'victoria-metrics') return null;
+    return c;
+  }
+  // No datasource supplied — fall back to the primary (isDefault) metrics
+  // connector for the workspace. The dashboard/query router refuses to
+  // default; this surface is "throwaway exploration in chat" so defaulting
+  // is the right tradeoff.
+  const list = await setupConfig.listConnectors({ orgId });
+  const metrics = list.filter(
+    (c) => c.type === 'prometheus' || c.type === 'victoria-metrics',
+  );
+  if (metrics.length === 0) return null;
+  const primary = metrics.find((c) => c.isDefault) ?? metrics[0];
+  return primary ?? null;
+}
+
+// -- Heuristic: classify a PromQL expression into a chart kind --------------
+
+export function inferKind(query: string): ChartMetricKind {
+  const q = query.toLowerCase();
+  if (q.includes('histogram_quantile')) return 'latency';
+  if (/_errors?\b|5xx|status=~?"5/.test(q)) return 'errors';
+  if (/\brate\s*\(|\bsum\s*\(\s*rate\s*\(/.test(q)) return 'counter';
+  return 'gauge';
+}
+
+// -- Error mapping ----------------------------------------------------------
+
+function statusForAdapterError(err: AdapterError): number {
+  switch (err.kind) {
+    case 'bad_request': return 400;
+    case 'auth_failure': return 403;
+    case 'not_found': return 404;
+    case 'rate_limit': return 429;
+    case 'timeout':
+    case 'server_error':
+    case 'connection_refused':
+    case 'dns_failure':
+    case 'malformed_response':
+      return 502;
+    default: return 500;
+  }
+}
+
+function codeForAdapterError(err: AdapterError): string {
+  if (err.kind === 'bad_request') return 'BAD_QUERY';
+  if (err.kind === 'auth_failure') return 'FORBIDDEN';
+  if (err.kind === 'rate_limit') return 'RATE_LIMITED';
+  return 'UPSTREAM_ERROR';
+}
+
+// -- Router -----------------------------------------------------------------
+
+export function createMetricsQueryRouter(deps: MetricsQueryRouterDeps): Router {
+  const router = Router();
+  const requirePermission = createRequirePermission(deps.ac);
+  const now = deps.now ?? (() => Date.now());
+  const buildAdapter = deps.buildAdapter ?? defaultBuildAdapter;
+
+  // Datasource-scoped permission gate. We resolve the datasource first
+  // (so the scope passed to ac.eval is the real id, not a placeholder),
+  // then check `connectors:query` on it. Resolution failures short-circuit
+  // before the permission check.
+  router.post(
+    '/query',
+    authMiddleware,
+    async (req: Request, res: Response, next) => {
+      const auth = (req as AuthenticatedRequest).auth;
+      if (!auth) {
+        res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+        return;
+      }
+      const body = req.body as {
+        query?: unknown;
+        datasourceId?: unknown;
+        timeRange?: unknown;
+        step?: unknown;
+        metricKind?: unknown;
+      };
+
+      const query = typeof body.query === 'string' ? body.query.trim() : '';
+      if (!query) {
+        res.status(400).json({ error: { code: 'BAD_QUERY', message: 'query is required' } });
+        return;
+      }
+
+      const datasourceIdInput = typeof body.datasourceId === 'string' && body.datasourceId.trim()
+        ? body.datasourceId.trim()
+        : undefined;
+
+      const ds = await resolvePrometheus(deps.setupConfig, auth.orgId, datasourceIdInput);
+      if (!ds) {
+        res.status(400).json({
+          error: {
+            code: 'NO_DATASOURCE',
+            message: datasourceIdInput
+              ? `Datasource "${datasourceIdInput}" not found, not Prometheus-compatible, or not in your org`
+              : 'No Prometheus-compatible datasource configured for this workspace',
+          },
+        });
+        return;
+      }
+
+      // Datasource-scoped permission check (replaces a static
+      // requirePermission middleware — we needed the resolved id first).
+      try {
+        const evaluator = ac.eval(ACTIONS.ConnectorsQuery, `connectors:uid:${ds.id}`);
+        const allowed = await deps.ac.evaluate(auth, evaluator);
+        if (!allowed) {
+          res.status(403).json({
+            error: {
+              code: 'FORBIDDEN',
+              message: `User has no permission to ${evaluator.string()}`,
+            },
+          });
+          return;
+        }
+      } catch (err) {
+        next(err);
+        return;
+      }
+
+      const rangeOrErr = resolveTimeRange(body.timeRange, now);
+      if ('error' in rangeOrErr) {
+        res.status(400).json({ error: { code: 'BAD_QUERY', message: rangeOrErr.error } });
+        return;
+      }
+
+      // Rate-limit (after permission so we don't leak rate-state across
+      // unauthorized callers).
+      const limitKey = rateLimitKey(auth.userId, ds.id);
+      const limit = checkRateLimit(limitKey, now());
+      if (limit) {
+        res.status(429).json({
+          error: {
+            code: 'RATE_LIMITED',
+            message: `Rate limit exceeded: ${RATE_LIMIT_PER_MIN}/min per datasource`,
+            retryAfterSec: limit.retryAfterSec,
+          },
+        });
+        return;
+      }
+
+      const step = typeof body.step === 'string' && body.step.trim()
+        ? body.step.trim()
+        : pickStep(rangeOrErr.start, rangeOrErr.end);
+
+      const kindInput = typeof body.metricKind === 'string'
+        ? body.metricKind as ChartMetricKind
+        : inferKind(query);
+      const validKinds: ChartMetricKind[] = ['latency', 'counter', 'gauge', 'errors'];
+      const kind = (validKinds as string[]).includes(kindInput) ? kindInput : inferKind(query);
+
+      const startedAt = Date.now();
+      try {
+        const adapter = buildAdapter(ds);
+        const series = await adapter.rangeQuery(query, rangeOrErr.start, rangeOrErr.end, step);
+        const summary = summarizeChart(series, kind);
+
+        // Audit (fire-and-forget — never block the response).
+        void deps.audit.log({
+          action: AuditAction.MetricsQuery,
+          actorType: 'user',
+          actorId: auth.userId,
+          targetType: 'connector',
+          targetId: ds.id,
+          outcome: 'success',
+          metadata: {
+            orgId: auth.orgId,
+            query: query.slice(0, 500),
+            step,
+            source: 'rest',
+          },
+        });
+
+        res.json({
+          series,
+          query,
+          timeRange: {
+            start: rangeOrErr.start.toISOString(),
+            end: rangeOrErr.end.toISOString(),
+          },
+          summary,
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (err) {
+        if (err instanceof AdapterError) {
+          const status = statusForAdapterError(err);
+          const code = codeForAdapterError(err);
+          res.status(status).json({
+            error: {
+              code,
+              message: err.toUserMessage(),
+              ...(code === 'BAD_QUERY' ? { hint: 'check PromQL syntax' } : {}),
+            },
+          });
+          return;
+        }
+        res.status(500).json({
+          error: { code: 'INTERNAL_ERROR', message: getErrorMessage(err) },
+        });
+      }
+    },
+  );
+
+  // Reference unused middleware factory so eslint doesn't flag the import
+  // when this file is the only consumer of createRequirePermission's other
+  // permission patterns. Removed once a future endpoint uses it.
+  void requirePermission;
+
+  return router;
+}
+
+/** Test-only: clear the in-memory rate-limit bucket between runs. */
+export function __resetRateLimitForTests(): void {
+  bucket.clear();
+}

--- a/packages/common/src/audit/actions.ts
+++ b/packages/common/src/audit/actions.ts
@@ -106,6 +106,10 @@ export const AuditAction = {
   AlertRuleFork: 'alert_rule.fork',
   InvestigationCreate: 'investigation.create',
   InvestigationUpdate: 'investigation.update',
+
+  // Inline metric exploration (REST + agent metric_explore tool).
+  // Rate-limited (30/min/user/datasource), so volume is bounded.
+  MetricsQuery: 'metrics.query',
 } as const;
 
 export type AuditActionValue = (typeof AuditAction)[keyof typeof AuditAction];

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -46,3 +46,12 @@ export { DEFAULT_LLM_MODEL } from './config/index.js';
 // grep EventTypes without pulling ioredis into the web bundle.
 export { EventTypes, type EventType, type EventEnvelope } from './events/types.js';
 export type { IEventBus, EventHandler } from './events/interface.js';
+
+// Pure utility helpers. `chart-summary` is consumed by both the REST
+// /api/metrics/query endpoint and the agent `metric_explore` tool.
+export { summarize as summarizeChart } from './utils/chart-summary.js';
+export type {
+  ChartMetricKind,
+  ChartSummary,
+  SummarySeries,
+} from './utils/chart-summary.js';

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -260,6 +260,23 @@ export type DashboardSseEvent =
       confidence: 'high' | 'medium' | 'low';
       alternatives: Array<{ id: string; name: string; environment?: string; cluster?: string }>;
     }
+  | {
+      // Inline chart bubble rendered in the chat for throwaway exploration.
+      // Emitted by the `metric_explore` agent tool — PR-B renders the chart
+      // component from this payload. `series` and `summary` are the same
+      // shapes used by the REST endpoint at /api/metrics/query.
+      type: 'inline_chart';
+      query: string;
+      datasourceId: string;
+      timeRange: { start: string; end: string };
+      step: string;
+      metricKind: 'latency' | 'counter' | 'gauge' | 'errors';
+      series: Array<{ metric: Record<string, string>; values: Array<[number, string]> }>;
+      summary: { kind: 'latency' | 'counter' | 'gauge' | 'errors'; oneLine: string; stats: Record<string, number | string> };
+      // PR-C will populate pivot suggestions ("by route", "p99 only", etc).
+      // Empty array in v1 so the frontend can render the affordance shape stably.
+      pivotSuggestions: Array<{ id: string; label: string }>;
+    }
   | { type: 'done'; messageId: string }
   | { type: 'error'; message: string };
 

--- a/packages/common/src/utils/chart-summary.test.ts
+++ b/packages/common/src/utils/chart-summary.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { summarize, type SummarySeries } from './chart-summary.js';
+
+// Helper: build a series from a list of [unixSec, value] tuples.
+function s(metric: Record<string, string>, values: Array<[number, number]>): SummarySeries {
+  return { metric, values: values.map(([ts, v]) => [ts, String(v)]) };
+}
+
+describe('summarize', () => {
+  it('latency: scales seconds to ms via heuristic and reports avg/p95/peak', () => {
+    // Values in seconds — max 0.34, all < 100, so we scale to ms.
+    const series = [
+      s({ quantile: '0.5' }, [
+        [1700000000, 0.1],
+        [1700000060, 0.12],
+        [1700000120, 0.14],
+      ]),
+      s({ quantile: '0.95' }, [
+        [1700000000, 0.2],
+        [1700000060, 0.34], // peak — at ts=1700000060 (14:14 UTC)
+        [1700000120, 0.24],
+      ]),
+    ];
+    const out = summarize(series, 'latency');
+    expect(out.kind).toBe('latency');
+    expect(out.oneLine).toMatch(/avg \d+ms · p95 \d+ms · peak \d+ms at \d{2}:\d{2}/);
+    expect(out.stats['peakMs']).toBe(340);
+    expect(typeof out.stats['peakAt']).toBe('string');
+    expect(out.stats['avgMs']).toBeGreaterThan(0);
+    expect(out.stats['p95Ms']).toBeGreaterThanOrEqual(out.stats['avgMs'] as number);
+  });
+
+  it('latency: keeps ms scale when values already look like ms (max >= 100)', () => {
+    const series = [
+      s({}, [
+        [1700000000, 120],
+        [1700000060, 240],
+      ]),
+    ];
+    const out = summarize(series, 'latency');
+    expect(out.stats['peakMs']).toBe(240);
+  });
+
+  it('counter: reports avg + peak with req/s units', () => {
+    const series = [
+      s({ route: '/api' }, [
+        [1700000000, 1000],
+        [1700000060, 4800],
+        [1700000120, 1200],
+      ]),
+    ];
+    const out = summarize(series, 'counter');
+    expect(out.kind).toBe('counter');
+    expect(out.oneLine).toMatch(/avg [\d.]+k? req\/s · peak [\d.]+k? at \d{2}:\d{2}/);
+    expect(out.stats['peak']).toBe(4800);
+    expect(out.stats['avg']).toBeCloseTo(7000 / 3, 2);
+  });
+
+  it('gauge: trend up when values rise across the window', () => {
+    const series = [
+      s({ host: 'a' }, [
+        [1700000000, 50],
+        [1700000060, 55],
+        [1700000120, 60],
+        [1700000180, 70],
+        [1700000240, 75],
+        [1700000300, 80],
+      ]),
+    ];
+    const out = summarize(series, 'gauge');
+    expect(out.kind).toBe('gauge');
+    expect(out.stats['trend']).toBe('up');
+    expect(out.stats['min']).toBe(50);
+    expect(out.stats['max']).toBe(80);
+    expect(out.oneLine).toContain('↑');
+  });
+
+  it('gauge: trend flat when values stay in a narrow band', () => {
+    const series = [
+      s({}, [
+        [1700000000, 50],
+        [1700000060, 51],
+        [1700000120, 50],
+        [1700000180, 51],
+        [1700000240, 50],
+        [1700000300, 51],
+      ]),
+    ];
+    const out = summarize(series, 'gauge');
+    expect(out.stats['trend']).toBe('flat');
+  });
+
+  it('errors: picks the noisiest series label as "most from"', () => {
+    const series = [
+      s({ route: '/api/checkout' }, [
+        [1700000000, 10],
+        [1700000060, 14],
+      ]),
+      s({ route: '/api/health' }, [
+        [1700000000, 1],
+        [1700000060, 0],
+      ]),
+    ];
+    const out = summarize(series, 'errors');
+    expect(out.kind).toBe('errors');
+    expect(out.oneLine).toContain('err/s');
+    expect(out.oneLine).toContain('"/api/checkout"');
+    expect(out.stats['topLabel']).toBe('/api/checkout');
+  });
+
+  it('errors: drops "most from" when there is only one series', () => {
+    const series = [s({}, [[1700000000, 12], [1700000060, 12]])];
+    const out = summarize(series, 'errors');
+    expect(out.oneLine).not.toContain('most from');
+    expect(out.stats['topLabel']).toBeUndefined();
+  });
+
+  it('returns "no data" for empty series', () => {
+    for (const kind of ['latency', 'counter', 'gauge', 'errors'] as const) {
+      const out = summarize([], kind);
+      expect(out.oneLine).toBe('no data');
+    }
+  });
+});

--- a/packages/common/src/utils/chart-summary.ts
+++ b/packages/common/src/utils/chart-summary.ts
@@ -1,0 +1,251 @@
+/**
+ * Shared chart summary helper.
+ *
+ * Inputs a `RangeResult[]` (same shape returned by the metrics adapter — a
+ * matrix of `(metric labels, [[ts, value], ...])` points) and produces a
+ * `ChartSummary` — a user-facing one-liner + structured stats — that both the
+ * REST endpoint `/api/metrics/query` and the agent `metric_explore` tool
+ * emit. Splitting it here so a future replay/i18n surface can re-derive the
+ * oneLine from `stats` if needed.
+ *
+ * Per-kind rules: see `summarize()` JSDoc.
+ */
+
+export type ChartMetricKind = 'latency' | 'counter' | 'gauge' | 'errors';
+
+export interface ChartSummary {
+  kind: ChartMetricKind;
+  /** User-facing one-liner. Empty pieces are elided cleanly. */
+  oneLine: string;
+  /** Structured stats — replay/i18n surface uses this. */
+  stats: Record<string, number | string>;
+}
+
+export interface SummarySeries {
+  metric: Record<string, string>;
+  values: Array<[number, string]>;
+}
+
+/** Format an HH:MM (24h) label for a unix-seconds timestamp. */
+function hhmm(unixSec: number): string {
+  const d = new Date(unixSec * 1000);
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const m = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function flattenPoints(series: SummarySeries[]): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (const s of series) {
+    for (const [ts, raw] of s.values) {
+      const v = Number(raw);
+      if (Number.isFinite(v)) out.push([ts, v]);
+    }
+  }
+  return out;
+}
+
+/** Average a list of numbers. Returns 0 on empty. */
+function avg(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  let s = 0;
+  for (const n of nums) s += n;
+  return s / nums.length;
+}
+
+/** Compact human-readable number — "1.2k", "4.8M", "73", "0.4". */
+function compactNumber(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  if (abs >= 100) return `${Math.round(n)}`;
+  if (abs >= 10) return `${n.toFixed(1)}`;
+  return `${n.toFixed(2)}`;
+}
+
+/** Round to integer for ms display. */
+function ms(n: number): string {
+  return `${Math.round(n)}ms`;
+}
+
+/**
+ * Summarise a range-query result for the inline chart bubble.
+ *
+ * Per-kind rules:
+ * - `latency`: assumes histogram_quantile output. Heuristic: if max value < 100
+ *   the units are probably seconds and we scale by 1000 to display ms. Picks
+ *   peak across ALL series (the worst-case quantile/route).
+ * - `counter`: rate/sum (e.g. req/s). Reports avg and peak across the whole
+ *   matrix.
+ * - `gauge`: cpu/mem-style instantaneous values. Reports the latest value
+ *   across all series, range (min/max), and a coarse trend (compare avg of
+ *   last 1/3 of timestamps vs avg of first 1/3 across all points).
+ * - `errors`: rate/count. Reports rate (avg of all points) and identifies the
+ *   "noisiest" series — the one with highest cumulative sum. The label key
+ *   picked for "from ..." is the non-`__name__` label with the highest
+ *   cardinality across the series set (more distinct values = more
+ *   discriminating). When fewer than 2 series, we drop "most from ...".
+ */
+export function summarize(
+  series: SummarySeries[],
+  kind: ChartMetricKind,
+): ChartSummary {
+  switch (kind) {
+    case 'latency': return summarizeLatency(series);
+    case 'counter': return summarizeCounter(series);
+    case 'gauge': return summarizeGauge(series);
+    case 'errors': return summarizeErrors(series);
+  }
+}
+
+function summarizeLatency(series: SummarySeries[]): ChartSummary {
+  const points = flattenPoints(series);
+  if (points.length === 0) {
+    return { kind: 'latency', oneLine: 'no data', stats: {} };
+  }
+  const max = Math.max(...points.map(([, v]) => v));
+  // Heuristic: small numbers → seconds, scale to ms.
+  const scaleToMs = max < 100 ? 1000 : 1;
+  const valuesMs = points.map(([, v]) => v * scaleToMs);
+  const avgMs = avg(valuesMs);
+  // p95: sort copy, pick index.
+  const sorted = [...valuesMs].sort((a, b) => a - b);
+  const p95Ms = sorted[Math.floor(sorted.length * 0.95)] ?? sorted[sorted.length - 1] ?? 0;
+  // Peak + peak timestamp.
+  let peakMs = -Infinity;
+  let peakTs = points[0]![0];
+  for (const [ts, v] of points) {
+    const vms = v * scaleToMs;
+    if (vms > peakMs) { peakMs = vms; peakTs = ts; }
+  }
+  const peakAt = new Date(peakTs * 1000).toISOString();
+  return {
+    kind: 'latency',
+    oneLine: `avg ${ms(avgMs)} · p95 ${ms(p95Ms)} · peak ${ms(peakMs)} at ${hhmm(peakTs)}`,
+    stats: {
+      avgMs: Math.round(avgMs),
+      p95Ms: Math.round(p95Ms),
+      peakMs: Math.round(peakMs),
+      peakAt,
+    },
+  };
+}
+
+function summarizeCounter(series: SummarySeries[]): ChartSummary {
+  const points = flattenPoints(series);
+  if (points.length === 0) {
+    return { kind: 'counter', oneLine: 'no data', stats: {} };
+  }
+  const values = points.map(([, v]) => v);
+  const avgV = avg(values);
+  let peak = -Infinity;
+  let peakTs = points[0]![0];
+  for (const [ts, v] of points) {
+    if (v > peak) { peak = v; peakTs = ts; }
+  }
+  return {
+    kind: 'counter',
+    oneLine: `avg ${compactNumber(avgV)} req/s · peak ${compactNumber(peak)} at ${hhmm(peakTs)}`,
+    stats: {
+      avg: Number(avgV.toFixed(3)),
+      peak: Number(peak.toFixed(3)),
+      peakAt: new Date(peakTs * 1000).toISOString(),
+    },
+  };
+}
+
+function summarizeGauge(series: SummarySeries[]): ChartSummary {
+  const points = flattenPoints(series);
+  if (points.length === 0) {
+    return { kind: 'gauge', oneLine: 'no data', stats: {} };
+  }
+  // "Current" = average across series of the last point per series.
+  // For a single series this is just the last value.
+  const lastValues: number[] = [];
+  for (const s of series) {
+    const last = s.values[s.values.length - 1];
+    if (last) {
+      const v = Number(last[1]);
+      if (Number.isFinite(v)) lastValues.push(v);
+    }
+  }
+  const current = avg(lastValues);
+  const all = points.map(([, v]) => v);
+  const min = Math.min(...all);
+  const max = Math.max(...all);
+
+  // Trend: compare last third avg vs first third avg across all points.
+  const sortedByTs = [...points].sort((a, b) => a[0] - b[0]);
+  const third = Math.max(1, Math.floor(sortedByTs.length / 3));
+  const firstThirdAvg = avg(sortedByTs.slice(0, third).map(([, v]) => v));
+  const lastThirdAvg = avg(sortedByTs.slice(-third).map(([, v]) => v));
+  const delta = lastThirdAvg - firstThirdAvg;
+  const range = max - min || 1;
+  let trend: 'up' | 'down' | 'flat' = 'flat';
+  if (delta / range > 0.1) trend = 'up';
+  else if (delta / range < -0.1) trend = 'down';
+  const trendGlyph = trend === 'up' ? '↑' : trend === 'down' ? '↓' : '→';
+
+  return {
+    kind: 'gauge',
+    oneLine: `current ${compactNumber(current)} · range ${compactNumber(min)}-${compactNumber(max)} · ${trendGlyph} trend`,
+    stats: {
+      current: Number(current.toFixed(3)),
+      min: Number(min.toFixed(3)),
+      max: Number(max.toFixed(3)),
+      trend,
+    },
+  };
+}
+
+function summarizeErrors(series: SummarySeries[]): ChartSummary {
+  const points = flattenPoints(series);
+  if (points.length === 0) {
+    return { kind: 'errors', oneLine: 'no data', stats: {} };
+  }
+  const rate = avg(points.map(([, v]) => v));
+  const stats: Record<string, number | string> = {
+    rate: Number(rate.toFixed(3)),
+  };
+  let oneLine = `${compactNumber(rate)} err/s`;
+
+  // "Most from" — only meaningful when there's more than one series.
+  if (series.length >= 2) {
+    // Find the discriminating label key — non-__name__ with highest cardinality.
+    const labelKeyCardinality = new Map<string, Set<string>>();
+    for (const s of series) {
+      for (const [k, v] of Object.entries(s.metric)) {
+        if (k === '__name__') continue;
+        if (!labelKeyCardinality.has(k)) labelKeyCardinality.set(k, new Set());
+        labelKeyCardinality.get(k)!.add(v);
+      }
+    }
+    let topKey: string | null = null;
+    let topCard = 0;
+    for (const [k, vs] of labelKeyCardinality) {
+      if (vs.size > topCard) { topCard = vs.size; topKey = k; }
+    }
+
+    // Find the series with the highest cumulative sum.
+    let topSeries: SummarySeries | null = null;
+    let topSum = -Infinity;
+    for (const s of series) {
+      let sum = 0;
+      for (const [, raw] of s.values) {
+        const v = Number(raw);
+        if (Number.isFinite(v)) sum += v;
+      }
+      if (sum > topSum) { topSum = sum; topSeries = s; }
+    }
+
+    if (topKey && topSeries) {
+      const label = topSeries.metric[topKey];
+      if (label) {
+        oneLine += ` · most from "${label}"`;
+        stats['topLabel'] = label;
+      }
+    }
+  }
+
+  return { kind: 'errors', oneLine, stats };
+}


### PR DESCRIPTION
First of three PRs to add Grafana-Explore-in-conversation. PR-A is the backend half. PR-B adds the chart UI component; PR-C adds smart pivots + Save-as-dashboard.

## What ships

**REST endpoint** \`POST /api/metrics/query\`
- Thin wrapper over adapter \`rangeQuery\`
- Auth: \`connectors:query\` (existing read-side gate)
- Rate limit: 30 queries/min/user/datasource (in-process token bucket — single-instance acceptable per spec)
- Body: \`{ query, datasourceId?, timeRange: { start, end } | { relative: "1h" }, step? }\`
- Returns: \`{ series, query, timeRange, summary, durationMs, warnings? }\`
- Errors mapped via R-6 \`AdapterError\` → 400/403/429

**Agent tool** \`metric_explore\`
- Runs the same path
- Emits SSE event \`inline_chart\` to chat with full payload
- Returns to LLM **only the one-line summary** (not raw series) → small token footprint, no chart "describing"

**Summary helper** \`packages/common/src/utils/chart-summary.ts\`
- Four kinds: \`latency\` / \`counter\` / \`gauge\` / \`errors\`
- Each produces a one-liner like \`avg 120ms · p95 240ms · peak 340ms at 14:23\`
- Used by both REST and agent

**SSE event type** \`inline_chart\` added to \`DashboardSseEvent\` discriminated union (PR-B will handle it client-side).

**Audit action** \`MetricsQuery\` added; both surfaces emit audit entries.

## Heuristic decisions called out

- **Latency ms-vs-seconds**: max < 100 → assumed seconds, scale ×1000. Edge case is centiseconds; documented inline.
- **Gauge trend**: last-third avg vs first-third avg, 10% of range threshold.
- **Errors top-label**: highest cumulative series in the highest-cardinality non-\`__name__\` label.
- **Step picker**: aim ~150 points, snap to {15s,30s,60s,5m,15m,1h}.

## Test plan

- [x] \`chart-summary.test.ts\`: 8/8 — one per kind + edge cases
- [x] \`metrics-query.test.ts\`: 5/5 — happy / bad query / no datasource / RBAC deny / rate-limit
- [x] Full suite 2013/2013 pass (10 skipped postgres)
- [x] \`tsc --build\` + bundle build clean
- [ ] CI green

## Out of scope (PR-B / PR-C)

- Frontend chart component
- Pivot suggestion chips
- Save-as-dashboard flow
- TimeRange implicit context across multiple chart bubbles

## Files

5 new (router + handler + summary + 2 test files) + 11 modified (wiring + audit enum + SSE type union). Net \`+1252\`.