### PR TITLE
Inline Chart PR-B: frontend InlineChartMessage + chat integration

### DIFF
--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { UserMessage, AssistantMessage, ErrorMessage } from './chat/MessageCompo
 import AgentActivityBlock from './chat/AgentActivityBlock.js';
 import AskUserPrompt from './chat/AskUserPrompt.js';
 import { DatasourceChoiceChip } from './chat/DatasourceChoiceChip.js';
+import InlineChartMessage from './InlineChartMessage.js';
 import { RoundsLogo } from './RoundsLogo.js';
 
 // Types
@@ -241,6 +242,23 @@ export default function ChatPanel({ events, isGenerating, onSendMessage, onStop,
                   question={evt.question ?? ''}
                   options={evt.options ?? []}
                   onSelect={(id) => onSendMessage(`option:${id}`)}
+                />
+              );
+            }
+            if (evt.kind === 'inline_chart' && evt.inlineChart) {
+              const c = evt.inlineChart;
+              return (
+                <InlineChartMessage
+                  key={evt.id}
+                  id={c.id}
+                  initialQuery={c.query}
+                  initialTimeRange={c.timeRange}
+                  initialSeries={c.series}
+                  initialSummary={c.summary}
+                  metricKind={c.metricKind}
+                  datasourceId={c.datasourceId}
+                  pivotSuggestions={c.pivotSuggestions}
+                  onSendMessage={onSendMessage}
                 />
               );
             }

--- a/packages/web/src/components/InlineChartMessage.tsx
+++ b/packages/web/src/components/InlineChartMessage.tsx
@@ -1,0 +1,512 @@
+/**
+ * InlineChartMessage — the chat bubble that renders a time-series chart when
+ * the agent calls `metric_explore` (SSE event `inline_chart`). Re-queries the
+ * REST endpoint /api/metrics/query for in-chart pivots (time-range, query
+ * edit, drag-to-zoom). Persisted bubbles render from their stored series; the
+ * user can hit a Last-X chip to refresh.
+ *
+ * Built on TimeSeriesViz (uPlot) — its native `onZoom` callback drives
+ * drag-to-zoom; no custom mouse-overlay is needed.
+ */
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import type { ChartMetricKind, ChartSummary } from '@agentic-obs/common';
+import { apiClient } from '../api/client.js';
+import TimeSeriesViz, { type SeriesInput } from './viz/TimeSeriesViz.js';
+import type {
+  InlineChartSeries,
+  InlineChartPivotSuggestion,
+} from '../hooks/useDashboardChat.js';
+
+interface Props {
+  id: string;
+  initialQuery: string;
+  initialTimeRange: { start: string; end: string };
+  initialSeries: InlineChartSeries[];
+  initialSummary: ChartSummary;
+  metricKind: ChartMetricKind;
+  datasourceId: string;
+  pivotSuggestions?: InlineChartPivotSuggestion[];
+  /** Optional callback when a pivot chip is clicked — caller sends this as a new chat message. */
+  onSendMessage?: (prompt: string) => void;
+  /** Optional stub — opens the save-as-dashboard flow (PR-C). */
+  onSaveAsDashboard?: () => void;
+}
+
+interface QueryResponse {
+  series: InlineChartSeries[];
+  query: string;
+  timeRange: { start: string; end: string };
+  summary: ChartSummary;
+}
+
+// Quick-range presets exposed by the [Last X ▾] dropdown.
+const PRESETS: Array<{ label: string; relative: string }> = [
+  { label: 'Last 15m', relative: '15m' },
+  { label: 'Last 1h', relative: '1h' },
+  { label: 'Last 6h', relative: '6h' },
+  { label: 'Last 24h', relative: '24h' },
+  { label: 'Last 7d', relative: '7d' },
+];
+
+// Backend accepts only 1h/6h/24h/7d as `{relative}`. Map 15m to explicit start/end.
+const RELATIVE_MS: Record<string, number> = {
+  '15m': 15 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '6h': 6 * 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Convert backend series ({ metric, values: [[unixSec, "str"]] }) to
+ * TimeSeriesViz `SeriesInput` ({ labels, points: [{ ts: ms, value: num }] }).
+ */
+export function seriesToViz(series: InlineChartSeries[]): SeriesInput[] {
+  return series.map((s) => ({
+    labels: s.metric,
+    points: s.values
+      .map(([ts, raw]) => ({ ts: ts * 1000, value: Number.parseFloat(raw) }))
+      .filter((p) => Number.isFinite(p.value)),
+  }));
+}
+
+/**
+ * Format the timeRange for the header bar. "last 1h" for whole-hour spans;
+ * "14:00-15:30" for short ranges; falls back to ISO date for multi-day.
+ */
+export function formatRangeLabel(start: string, end: string): string {
+  const s = new Date(start).getTime();
+  const e = new Date(end).getTime();
+  if (!Number.isFinite(s) || !Number.isFinite(e) || e <= s) return '';
+  const spanMs = e - s;
+  // Known relative spans → friendly label.
+  for (const [rel, ms] of Object.entries(RELATIVE_MS)) {
+    if (Math.abs(spanMs - ms) < 60_000) return `last ${rel}`;
+  }
+  const hh = (d: Date) =>
+    `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  // Short range — clock times.
+  if (spanMs < 24 * 60 * 60 * 1000) return `${hh(new Date(s))}-${hh(new Date(e))}`;
+  // Multi-day — date range.
+  const mmdd = (d: Date) =>
+    `${d.getMonth() + 1}/${d.getDate()}`;
+  return `${mmdd(new Date(s))}-${mmdd(new Date(e))}`;
+}
+
+/**
+ * Best-effort title. Tries to lift a `__name__` from the series labels; falls
+ * back to the first 60 chars of the query.
+ */
+export function deriveTitle(
+  query: string,
+  series: InlineChartSeries[],
+  kind: ChartMetricKind,
+): string {
+  const first = series[0]?.metric?.__name__;
+  const kindWord =
+    kind === 'latency' ? 'latency' :
+    kind === 'counter' ? 'rate' :
+    kind === 'errors' ? 'errors' :
+    'metric';
+  if (first) return `${kindWord}: ${first}`;
+  const trimmed = query.length > 60 ? `${query.slice(0, 60)}…` : query;
+  return trimmed;
+}
+
+export default function InlineChartMessage(props: Props): JSX.Element {
+  const {
+    id: _id,
+    initialQuery,
+    initialTimeRange,
+    initialSeries,
+    initialSummary,
+    metricKind,
+    datasourceId,
+    pivotSuggestions = [],
+    onSendMessage,
+    onSaveAsDashboard,
+  } = props;
+
+  const [query, setQuery] = useState(initialQuery);
+  const [draftQuery, setDraftQuery] = useState(initialQuery);
+  const [timeRange, setTimeRange] = useState(initialTimeRange);
+  const [series, setSeries] = useState(initialSeries);
+  const [summary, setSummary] = useState(initialSummary);
+  const [loading, setLoading] = useState(false);
+  const [showLoading, setShowLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [queryEditorExpanded, setQueryEditorExpanded] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [rangeMenuOpen, setRangeMenuOpen] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
+
+  // Sync props → state when SSE updates push a new payload with the same id.
+  // The parent calls upsertInlineChart which replaces the event; React
+  // rerenders this component with new initial* props. We mirror those into
+  // local state so the chart picks up backend pivots without remounting.
+  useEffect(() => { setQuery(initialQuery); setDraftQuery(initialQuery); }, [initialQuery]);
+  useEffect(() => { setTimeRange(initialTimeRange); }, [initialTimeRange.start, initialTimeRange.end]);
+  useEffect(() => { setSeries(initialSeries); }, [initialSeries]);
+  useEffect(() => { setSummary(initialSummary); }, [initialSummary]);
+
+  // 200ms-delayed loading skeleton: avoids flash for fast queries.
+  useEffect(() => {
+    if (!loading) {
+      setShowLoading(false);
+      return;
+    }
+    const t = setTimeout(() => setShowLoading(true), 200);
+    return () => clearTimeout(t);
+  }, [loading]);
+
+  // Close menus on outside click.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!menuOpen && !rangeMenuOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+        setRangeMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [menuOpen, rangeMenuOpen]);
+
+  const runQuery = useCallback(
+    async (opts: {
+      query?: string;
+      timeRange?: { start: string; end: string };
+      relative?: string;
+      zoomed?: boolean;
+    }) => {
+      const nextQuery = opts.query ?? query;
+      const body: Record<string, unknown> = {
+        query: nextQuery,
+        datasourceId,
+        metricKind,
+      };
+      if (opts.relative === '15m') {
+        // Backend doesn't accept 15m as `relative`; expand to explicit range.
+        const end = new Date();
+        const start = new Date(end.getTime() - RELATIVE_MS['15m']!);
+        body['timeRange'] = { start: start.toISOString(), end: end.toISOString() };
+      } else if (opts.relative) {
+        body['timeRange'] = { relative: opts.relative };
+      } else if (opts.timeRange) {
+        body['timeRange'] = opts.timeRange;
+      } else {
+        body['timeRange'] = timeRange;
+      }
+
+      setLoading(true);
+      setError(null);
+      setErrorCode(null);
+      try {
+        const { data, error: apiErr } = await apiClient.post<QueryResponse>(
+          '/metrics/query',
+          body,
+        );
+        if (apiErr) {
+          setError(apiErr.message);
+          setErrorCode(apiErr.code ?? null);
+          if (apiErr.code === 'BAD_QUERY') setQueryEditorExpanded(true);
+          return;
+        }
+        if (!data) {
+          setError('Empty response from /api/metrics/query');
+          return;
+        }
+        setQuery(data.query);
+        setDraftQuery(data.query);
+        setTimeRange(data.timeRange);
+        setSeries(data.series);
+        setSummary(data.summary);
+        setZoomed(opts.zoomed ?? false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [query, datasourceId, metricKind, timeRange],
+  );
+
+  const handleZoom = useCallback(
+    (fromMs: number, toMs: number) => {
+      if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) return;
+      void runQuery({
+        timeRange: {
+          start: new Date(fromMs).toISOString(),
+          end: new Date(toMs).toISOString(),
+        },
+        zoomed: true,
+      });
+    },
+    [runQuery],
+  );
+
+  const handleResetZoom = useCallback(() => {
+    void runQuery({
+      timeRange: initialTimeRange,
+      zoomed: false,
+    });
+  }, [runQuery, initialTimeRange]);
+
+  const vizSeries = useMemo(() => seriesToViz(series), [series]);
+  const hasData = vizSeries.some((s) => s.points.length > 0);
+  const title = useMemo(
+    () => deriveTitle(query, series, metricKind),
+    [query, series, metricKind],
+  );
+  const rangeLabel = useMemo(
+    () => formatRangeLabel(timeRange.start, timeRange.end),
+    [timeRange.start, timeRange.end],
+  );
+
+  const onPivotClick = (p: InlineChartPivotSuggestion) => {
+    onSendMessage?.(p.label);
+  };
+
+  const onRunEditor = () => {
+    const q = draftQuery.trim();
+    if (!q) return;
+    void runQuery({ query: q });
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className="my-2 rounded-md border border-outline-variant bg-surface-container overflow-hidden"
+      data-testid="inline-chart-message"
+    >
+      {/* Header bar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-outline-variant text-sm">
+        <ChartIcon />
+        <div className="font-medium text-on-surface truncate flex-1" title={query}>
+          {title}
+          {rangeLabel && (
+            <span className="text-on-surface-variant font-normal"> · {rangeLabel}</span>
+          )}
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            aria-label="Chart menu"
+            className="px-1.5 py-0.5 text-on-surface-variant hover:text-on-surface"
+            onClick={() => setMenuOpen((v) => !v)}
+          >
+            ⋯
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 top-full mt-1 z-10 min-w-[180px] rounded-md border border-outline-variant bg-surface shadow-md text-sm">
+              <MenuItem
+                onClick={() => {
+                  setMenuOpen(false);
+                  try { void navigator.clipboard?.writeText(query); } catch { /* clipboard unavailable */ }
+                }}
+              >
+                Copy query
+              </MenuItem>
+              <MenuItem
+                disabled={!onSaveAsDashboard}
+                onClick={() => {
+                  setMenuOpen(false);
+                  onSaveAsDashboard?.();
+                }}
+              >
+                Save as dashboard
+              </MenuItem>
+              <MenuItem disabled>Open in Explore</MenuItem>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-3 py-1.5 bg-error/10 text-error text-xs border-b border-error/30">
+          {errorCode === 'BAD_QUERY' ? 'Invalid query: ' : ''}
+          {error}
+        </div>
+      )}
+
+      {/* Chart area */}
+      <div className="relative">
+        {showLoading && (
+          <div
+            data-testid="chart-loading"
+            className="absolute inset-0 z-10 flex items-center justify-center bg-surface-container/80 text-xs text-on-surface-variant"
+          >
+            <span className="px-2 py-0.5 rounded bg-surface border border-outline-variant">
+              Loading…
+            </span>
+          </div>
+        )}
+        {hasData ? (
+          <>
+            <TimeSeriesViz
+              series={vizSeries}
+              height={180}
+              legend="hidden"
+              onZoom={handleZoom}
+            />
+            {zoomed && (
+              <button
+                type="button"
+                aria-label="Reset zoom"
+                onClick={handleResetZoom}
+                className="absolute top-1 right-1 px-1.5 py-0.5 text-xs bg-surface/80 border border-outline-variant rounded text-on-surface hover:bg-surface"
+              >
+                ↺ Reset
+              </button>
+            )}
+          </>
+        ) : loading ? (
+          <div className="h-[180px] flex items-center justify-center text-xs text-on-surface-variant">
+            Loading…
+          </div>
+        ) : (
+          <div className="h-[180px] flex flex-col items-center justify-center gap-2 text-sm text-on-surface-variant">
+            <div>No data in this time range</div>
+            <div className="flex gap-2">
+              <Chip onClick={() => void runQuery({ relative: '6h' })}>Try 6h</Chip>
+              <Chip onClick={() => void runQuery({ relative: '24h' })}>Try 24h</Chip>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Summary line */}
+      <div className="px-3 py-1.5 border-t border-outline-variant font-mono text-xs text-on-surface">
+        {summary.oneLine || (hasData ? '' : ' ')}
+      </div>
+
+      {/* Action chips */}
+      <div className="flex items-center gap-2 px-3 py-2 border-t border-outline-variant text-xs">
+        <div className="relative">
+          <button
+            type="button"
+            className="px-2 py-1 rounded border border-outline-variant hover:bg-surface text-on-surface"
+            onClick={() => setRangeMenuOpen((v) => !v)}
+            data-testid="range-button"
+          >
+            {rangeLabel || 'Range'} ▾
+          </button>
+          {rangeMenuOpen && (
+            <div className="absolute left-0 top-full mt-1 z-10 min-w-[140px] rounded-md border border-outline-variant bg-surface shadow-md">
+              {PRESETS.map((p) => (
+                <button
+                  type="button"
+                  key={p.relative}
+                  className="block w-full text-left px-3 py-1.5 hover:bg-surface-container text-on-surface"
+                  onClick={() => {
+                    setRangeMenuOpen(false);
+                    void runQuery({ relative: p.relative });
+                  }}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {pivotSuggestions.map((p) => (
+          <Chip key={p.id} onClick={() => onPivotClick(p)}>{p.label}</Chip>
+        ))}
+        <div className="flex-1" />
+        <button
+          type="button"
+          className="px-2 py-1 rounded border border-outline-variant hover:bg-surface text-on-surface"
+          onClick={() => setQueryEditorExpanded((v) => !v)}
+          data-testid="query-toggle"
+        >
+          {queryEditorExpanded ? '▲ Query' : '▼ Query'}
+        </button>
+      </div>
+
+      {/* Query editor */}
+      {queryEditorExpanded && (
+        <div className="px-3 py-2 border-t border-outline-variant space-y-2">
+          <textarea
+            value={draftQuery}
+            onChange={(e) => setDraftQuery(e.target.value)}
+            rows={3}
+            className="w-full bg-surface border border-outline-variant rounded p-2 font-mono text-xs text-on-surface"
+            data-testid="query-editor"
+          />
+          <div className="flex items-center gap-2 text-xs">
+            <span className="px-2 py-0.5 rounded bg-surface text-on-surface-variant border border-outline-variant">
+              Datasource: {datasourceId}
+            </span>
+            <div className="flex-1" />
+            <button
+              type="button"
+              className="px-3 py-1 rounded bg-primary text-on-primary hover:opacity-90 disabled:opacity-50"
+              onClick={onRunEditor}
+              disabled={!draftQuery.trim() || loading}
+              data-testid="run-query"
+            >
+              Run
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChartIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-on-surface-variant shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      aria-hidden
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 3v18h18M7 14l3-3 3 3 5-6" />
+    </svg>
+  );
+}
+
+function MenuItem({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="block w-full text-left px-3 py-1.5 text-on-surface hover:bg-surface-container disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {children}
+    </button>
+  );
+}
+
+function Chip({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="px-2 py-0.5 rounded-full text-xs bg-surface border border-outline-variant hover:bg-surface-container text-on-surface"
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/web/src/components/__tests__/InlineChartMessage.test.tsx
+++ b/packages/web/src/components/__tests__/InlineChartMessage.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * InlineChartMessage tests.
+ *
+ * vitest runs under `environment: 'node'` (no jsdom) in this package, so
+ * we exercise:
+ *   1. Pure helpers (`seriesToViz`, `formatRangeLabel`, `deriveTitle`,
+ *      `deriveInlineChartId`, `parseInlineChartPayload`).
+ *   2. Static SSR snapshots covering empty-state chips, summary line,
+ *      header title, and query editor visibility toggle.
+ * Live interactions (click, drag-zoom, fetch) require jsdom + a fake
+ * apiClient; left out here to keep the test surface in line with the
+ * package's existing pattern.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import InlineChartMessage, {
+  seriesToViz,
+  formatRangeLabel,
+  deriveTitle,
+} from '../InlineChartMessage.js';
+import {
+  deriveInlineChartId,
+  parseInlineChartPayload,
+} from '../../hooks/useDashboardChat.js';
+import type { ChartSummary } from '@agentic-obs/common';
+
+describe('seriesToViz', () => {
+  it('converts unix-sec values to ms points', () => {
+    const out = seriesToViz([
+      { metric: { __name__: 'foo' }, values: [[1000, '1.5'], [2000, '2.5']] },
+    ]);
+    expect(out).toEqual([
+      {
+        labels: { __name__: 'foo' },
+        points: [
+          { ts: 1_000_000, value: 1.5 },
+          { ts: 2_000_000, value: 2.5 },
+        ],
+      },
+    ]);
+  });
+
+  it('drops non-finite samples (NaN, Infinity)', () => {
+    const out = seriesToViz([
+      { metric: {}, values: [[1, 'NaN'], [2, '1'], [3, '+Inf']] },
+    ]);
+    expect(out[0]!.points).toEqual([{ ts: 2000, value: 1 }]);
+  });
+});
+
+describe('formatRangeLabel', () => {
+  it('matches known relative spans within a minute', () => {
+    const now = Date.now();
+    const oneHourAgo = new Date(now - 3600 * 1000).toISOString();
+    expect(formatRangeLabel(oneHourAgo, new Date(now).toISOString())).toBe('last 1h');
+  });
+
+  it('uses HH:MM range for short non-preset windows', () => {
+    const start = '2025-01-01T14:00:00Z';
+    const end = '2025-01-01T15:30:00Z';
+    // Output depends on local timezone, but should match /\d\d:\d\d-\d\d:\d\d/.
+    expect(formatRangeLabel(start, end)).toMatch(/^\d\d:\d\d-\d\d:\d\d$/);
+  });
+
+  it('returns empty string for invalid range', () => {
+    expect(formatRangeLabel('not-a-date', 'also-not')).toBe('');
+  });
+});
+
+describe('deriveTitle', () => {
+  it('uses __name__ from first series when present', () => {
+    const t = deriveTitle('rate(foo[1m])', [{ metric: { __name__: 'http_requests' }, values: [] }], 'counter');
+    expect(t).toBe('rate: http_requests');
+  });
+
+  it('falls back to query when no __name__', () => {
+    const t = deriveTitle('up', [], 'gauge');
+    expect(t).toBe('up');
+  });
+
+  it('truncates long queries with ellipsis', () => {
+    const long = 'sum(rate(http_request_duration_seconds_bucket{job=\"frontend\"}[5m])) by (le)';
+    const t = deriveTitle(long, [], 'latency');
+    expect(t.length).toBeLessThanOrEqual(61);
+    expect(t.endsWith('…')).toBe(true);
+  });
+});
+
+describe('deriveInlineChartId', () => {
+  it('is deterministic for the same inputs', () => {
+    const a = deriveInlineChartId('up', 'ds1', '2025-01-01T00:00Z', '2025-01-01T01:00Z');
+    const b = deriveInlineChartId('up', 'ds1', '2025-01-01T00:00Z', '2025-01-01T01:00Z');
+    expect(a).toBe(b);
+  });
+
+  it('differs when any field changes', () => {
+    const base = deriveInlineChartId('up', 'ds1', 's', 'e');
+    expect(deriveInlineChartId('up', 'ds2', 's', 'e')).not.toBe(base);
+    expect(deriveInlineChartId('down', 'ds1', 's', 'e')).not.toBe(base);
+  });
+});
+
+describe('parseInlineChartPayload', () => {
+  const goodPayload = {
+    type: 'inline_chart',
+    query: 'up',
+    datasourceId: 'ds1',
+    timeRange: { start: '2025-01-01T00:00Z', end: '2025-01-01T01:00Z' },
+    step: '60s',
+    metricKind: 'gauge',
+    series: [],
+    summary: { kind: 'gauge', oneLine: 'avg 1', stats: {} },
+    pivotSuggestions: [],
+  };
+
+  it('parses a well-formed payload', () => {
+    const parsed = parseInlineChartPayload(goodPayload);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.query).toBe('up');
+    expect(parsed!.id).toContain('ds1');
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(parseInlineChartPayload({ ...goodPayload, query: '' })).toBeNull();
+    expect(parseInlineChartPayload({ ...goodPayload, datasourceId: '' })).toBeNull();
+    expect(parseInlineChartPayload({ ...goodPayload, timeRange: {} })).toBeNull();
+  });
+
+  it('drops malformed pivot suggestions', () => {
+    const parsed = parseInlineChartPayload({
+      ...goodPayload,
+      pivotSuggestions: [{ id: 'a', label: 'A' }, { id: '', label: 'bad' }, null, { id: 'b' }],
+    });
+    expect(parsed!.pivotSuggestions).toEqual([{ id: 'a', label: 'A' }]);
+  });
+
+  it('falls back to gauge for an unknown metricKind', () => {
+    const parsed = parseInlineChartPayload({ ...goodPayload, metricKind: 'wat' });
+    expect(parsed!.metricKind).toBe('gauge');
+  });
+});
+
+const baseProps = {
+  id: 'chart:ds1:s:e:up',
+  initialQuery: 'up',
+  initialTimeRange: { start: '2025-01-01T00:00Z', end: '2025-01-01T01:00Z' },
+  initialSeries: [],
+  initialSummary: { kind: 'gauge' as const, oneLine: 'avg 1', stats: {} } satisfies ChartSummary,
+  metricKind: 'gauge' as const,
+  datasourceId: 'prometheus-prod',
+};
+
+describe('InlineChartMessage SSR', () => {
+  it('renders empty state with Try chips when no series', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, baseProps));
+    expect(html).toContain('No data in this time range');
+    expect(html).toContain('Try 6h');
+    expect(html).toContain('Try 24h');
+  });
+
+  it('renders the summary one-liner', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
+      ...baseProps,
+      initialSummary: { kind: 'latency', oneLine: 'avg 120ms · p95 240ms', stats: {} },
+    }));
+    expect(html).toContain('avg 120ms · p95 240ms');
+  });
+
+  it('renders the derived title in the header', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
+      ...baseProps,
+      initialQuery: 'rate(http_requests[1m])',
+      initialSeries: [{ metric: { __name__: 'http_requests' }, values: [] }],
+      metricKind: 'counter',
+    }));
+    expect(html).toContain('rate: http_requests');
+  });
+
+  it('hides the query editor by default', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, baseProps));
+    expect(html).not.toContain('data-testid="query-editor"');
+  });
+
+  it('renders pivot chips when suggestions are present', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
+      ...baseProps,
+      pivotSuggestions: [{ id: 'p1', label: 'by route' }],
+    }));
+    expect(html).toContain('by route');
+  });
+
+  it('renders the datasource id in the editor pill (when expanded — sanity-check the editor markup compiles)', () => {
+    // Editor is collapsed by default; we just confirm the component compiles
+    // and produces a [▼ Query] toggle.
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, baseProps));
+    expect(html).toContain('Query');
+    expect(html).toContain('data-testid="inline-chart-message"');
+  });
+});

--- a/packages/web/src/components/chat/__tests__/inline-chart-integration.test.ts
+++ b/packages/web/src/components/chat/__tests__/inline-chart-integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for chat integration of inline_chart events:
+ *   1. groupEvents treats inline_chart as a standalone message block (NOT
+ *      merged into an agent activity block), so the chart renders as a
+ *      first-class bubble rather than inside the tool-step accordion.
+ *   2. payloadToChatEvent (useChat replay path) reconstructs a chat event
+ *      from a persisted inline_chart payload, so reloading a session
+ *      restores the chart bubble identically.
+ *   3. Idempotency: re-deriving the same id for the same content collapses
+ *      replays.
+ */
+import { describe, it, expect } from 'vitest';
+import { groupEvents } from '../event-processing.js';
+import type { ChatEvent } from '../../../hooks/useDashboardChat.js';
+import {
+  deriveInlineChartId,
+  parseInlineChartPayload,
+} from '../../../hooks/useDashboardChat.js';
+import { payloadToChatEvent } from '../../../hooks/useChat.js';
+
+function inlineChartEvent(id: string): ChatEvent {
+  return {
+    id,
+    kind: 'inline_chart',
+    inlineChart: {
+      id,
+      query: 'up',
+      datasourceId: 'ds1',
+      timeRange: { start: '2025-01-01T00:00Z', end: '2025-01-01T01:00Z' },
+      step: '60s',
+      metricKind: 'gauge',
+      series: [],
+      summary: { kind: 'gauge', oneLine: '', stats: {} },
+      pivotSuggestions: [],
+    },
+  };
+}
+
+describe('groupEvents with inline_chart', () => {
+  it('treats inline_chart as a standalone message block', () => {
+    const events: ChatEvent[] = [
+      { id: 't1', kind: 'tool_call', tool: 'metric_explore', content: 'querying' },
+      inlineChartEvent('c1'),
+      { id: 't2', kind: 'tool_result', tool: 'metric_explore', content: 'done', success: true },
+    ];
+    const blocks = groupEvents(events);
+    // Expect: [agent-block(tool_call), message-block(chart), agent-block(tool_result)]
+    expect(blocks.map((b) => b.type)).toEqual(['agent', 'message', 'agent']);
+    const second = blocks[1]!;
+    expect(second.type === 'message' && second.event.kind).toBe('inline_chart');
+  });
+
+  it('flushes the in-flight agent block when a chart arrives', () => {
+    const events: ChatEvent[] = [
+      { id: 't1', kind: 'tool_call', tool: 'metric_explore', content: 'querying' },
+      inlineChartEvent('c1'),
+    ];
+    const blocks = groupEvents(events);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe('agent');
+    expect(blocks[1]!.type).toBe('message');
+  });
+});
+
+describe('payloadToChatEvent replay', () => {
+  it('reconstructs an inline_chart ChatEvent from a persisted payload', () => {
+    const payload = {
+      type: 'inline_chart',
+      query: 'rate(http_requests_total[5m])',
+      datasourceId: 'ds1',
+      timeRange: { start: '2025-01-01T00:00Z', end: '2025-01-01T01:00Z' },
+      step: '60s',
+      metricKind: 'counter',
+      series: [],
+      summary: { kind: 'counter', oneLine: '12 rps avg', stats: {} },
+      pivotSuggestions: [],
+    };
+    const evt = payloadToChatEvent('persisted-id', 'inline_chart', payload);
+    expect(evt).not.toBeNull();
+    expect(evt!.kind).toBe('inline_chart');
+    expect(evt!.inlineChart?.query).toBe('rate(http_requests_total[5m])');
+    // id is derived from content, not the original DB id — same content =
+    // same id across replays / live SSE.
+    expect(evt!.id).toBe(
+      deriveInlineChartId(
+        payload.query,
+        payload.datasourceId,
+        payload.timeRange.start,
+        payload.timeRange.end,
+      ),
+    );
+  });
+
+  it('returns null for an inline_chart with missing fields', () => {
+    expect(payloadToChatEvent('id', 'inline_chart', { query: 'up' })).toBeNull();
+  });
+});
+
+describe('idempotency', () => {
+  it('same payload → same id on both live and replay paths', () => {
+    const payload = {
+      type: 'inline_chart',
+      query: 'up',
+      datasourceId: 'ds1',
+      timeRange: { start: 's', end: 'e' },
+      step: '60s',
+      metricKind: 'gauge',
+      series: [],
+      summary: { kind: 'gauge', oneLine: '', stats: {} },
+      pivotSuggestions: [],
+    };
+    const live = parseInlineChartPayload(payload);
+    const replay = payloadToChatEvent('whatever', 'inline_chart', payload);
+    expect(live!.id).toBe(replay!.id);
+  });
+});

--- a/packages/web/src/components/chat/event-processing.ts
+++ b/packages/web/src/components/chat/event-processing.ts
@@ -26,7 +26,13 @@ export function groupEvents(events: ChatEvent[]): Block[] {
   };
 
   for (const evt of events) {
-    if (evt.kind === 'message' || evt.kind === 'error' || evt.kind === 'ask_user' || evt.kind === 'ds_choice') {
+    if (
+      evt.kind === 'message' ||
+      evt.kind === 'error' ||
+      evt.kind === 'ask_user' ||
+      evt.kind === 'ds_choice' ||
+      evt.kind === 'inline_chart'
+    ) {
       flushAgent();
       blocks.push({ type: 'message', event: evt });
     } else if (evt.kind === 'done') {

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { apiClient } from '../api/client.js';
 import type { ChatMessage, ChatEvent } from './useDashboardChat.js';
-import { parseAskUserPayload } from './useDashboardChat.js';
+import { parseAskUserPayload, parseInlineChartPayload } from './useDashboardChat.js';
 
 /** Page context — tells the agent what the user is currently looking at. */
 export interface PageContext {
@@ -130,6 +130,11 @@ export function payloadToChatEvent(
     case 'ask_user': {
       const { question, options } = parseAskUserPayload(payload);
       return { id, kind: 'ask_user', question, options };
+    }
+    case 'inline_chart': {
+      const chart = parseInlineChartPayload(payload);
+      if (!chart) return null;
+      return { id: chart.id, kind: 'inline_chart', inlineChart: chart };
     }
     case 'ds_choice': {
       const chosenId =
@@ -294,6 +299,22 @@ export function useChat(): UseChatResult {
     setEvents((prev) => [...prev, evt]);
   }, []);
 
+  /**
+   * Append OR replace by `inline_chart`'s derived id (same content collapses
+   * to one bubble across the session). Mirrors useDashboardChat.
+   */
+  const upsertInlineChart = useCallback((evt: ChatEvent, chartId: string) => {
+    setEvents((prev) => {
+      const idx = prev.findIndex(
+        (e) => e.kind === 'inline_chart' && e.inlineChart?.id === chartId,
+      );
+      if (idx === -1) return [...prev, evt];
+      const next = prev.slice();
+      next[idx] = evt;
+      return next;
+    });
+  }, []);
+
   const clearPendingNavigation = useCallback(() => {
     setPendingNavigation(null);
   }, []);
@@ -409,6 +430,17 @@ export function useChat(): UseChatResult {
           break;
         }
 
+        case 'inline_chart': {
+          const chart = parseInlineChartPayload(parsed);
+          if (chart) {
+            upsertInlineChart(
+              { id: chart.id, kind: 'inline_chart', inlineChart: chart },
+              chart.id,
+            );
+          }
+          break;
+        }
+
         case 'done': {
           const durableSessionId =
             typeof parsed.sessionId === 'string' && parsed.sessionId.trim()
@@ -441,7 +473,7 @@ export function useChat(): UseChatResult {
           break;
       }
     },
-    [appendEvent],
+    [appendEvent, upsertInlineChart],
   );
 
   const sendMessage = useCallback(

--- a/packages/web/src/hooks/useDashboardChat.ts
+++ b/packages/web/src/hooks/useDashboardChat.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Provenance } from '@agentic-obs/common';
+import type { Provenance, ChartMetricKind, ChartSummary } from '@agentic-obs/common';
 import { apiClient } from '../api/client.js';
 import type { PanelConfig } from '../components/DashboardPanelCard.js';
 
@@ -35,8 +35,104 @@ export type ChatEventKind =
   | 'investigation_report'
   | 'ask_user'
   | 'ds_choice'
+  | 'inline_chart'
   | 'done'
   | 'error';
+
+/**
+ * Inline chart payload carried by a ChatEvent (kind = 'inline_chart').
+ * Mirrors the SSE event shape one-to-one — see DashboardSseEvent in
+ * packages/common/src/models/dashboard.ts.
+ */
+export interface InlineChartSeries {
+  metric: Record<string, string>;
+  values: Array<[number, string]>;
+}
+
+export interface InlineChartPivotSuggestion {
+  id: string;
+  label: string;
+}
+
+export interface InlineChartPayload {
+  /**
+   * Synthesized client-side from query + datasourceId + timeRange so the
+   * same content collapses to the same bubble. The SSE event itself
+   * carries no id (see PR-A backend handler).
+   */
+  id: string;
+  query: string;
+  datasourceId: string;
+  timeRange: { start: string; end: string };
+  step: string;
+  metricKind: ChartMetricKind;
+  series: InlineChartSeries[];
+  summary: ChartSummary;
+  pivotSuggestions: InlineChartPivotSuggestion[];
+}
+
+/**
+ * Derive a stable id from the load-bearing fields. Same (query, ds, range)
+ * arriving twice in the same session collapses to one bubble. Cheap-hash
+ * (no crypto needed — collisions across unrelated charts don't matter).
+ */
+export function deriveInlineChartId(
+  query: string,
+  datasourceId: string,
+  start: string,
+  end: string,
+): string {
+  return `chart:${datasourceId}:${start}:${end}:${query}`;
+}
+
+/**
+ * Parse a raw SSE `inline_chart` payload into the typed shape we render.
+ * Returns `null` if the payload is unusable (missing query / datasource /
+ * timeRange) — the UI silently drops it rather than crashing.
+ */
+export function parseInlineChartPayload(
+  raw: Record<string, unknown>,
+): InlineChartPayload | null {
+  const query = typeof raw.query === 'string' ? raw.query : '';
+  const datasourceId = typeof raw.datasourceId === 'string' ? raw.datasourceId : '';
+  const tr = raw.timeRange as { start?: unknown; end?: unknown } | undefined;
+  const start = typeof tr?.start === 'string' ? tr.start : '';
+  const end = typeof tr?.end === 'string' ? tr.end : '';
+  if (!query || !datasourceId || !start || !end) return null;
+
+  const step = typeof raw.step === 'string' ? raw.step : '60s';
+  const kind = (raw.metricKind === 'latency' || raw.metricKind === 'counter' ||
+    raw.metricKind === 'gauge' || raw.metricKind === 'errors')
+    ? raw.metricKind
+    : 'gauge';
+  const series = Array.isArray(raw.series) ? (raw.series as InlineChartSeries[]) : [];
+  const summary: ChartSummary = (raw.summary && typeof raw.summary === 'object')
+    ? raw.summary as ChartSummary
+    : { kind, oneLine: '', stats: {} };
+  const rawPivots = Array.isArray(raw.pivotSuggestions) ? raw.pivotSuggestions : [];
+  const pivotSuggestions = rawPivots
+    .map((p) => {
+      if (!p || typeof p !== 'object') return null;
+      const obj = p as Record<string, unknown>;
+      const id = typeof obj.id === 'string' ? obj.id : '';
+      const label = typeof obj.label === 'string' ? obj.label : '';
+      if (!id || !label) return null;
+      return { id, label };
+    })
+    .filter((p): p is InlineChartPivotSuggestion => p !== null);
+
+  return {
+    id: deriveInlineChartId(query, datasourceId, start, end),
+    query,
+    datasourceId,
+    timeRange: { start, end },
+    step,
+    metricKind: kind,
+    series,
+    summary,
+    pivotSuggestions,
+  };
+}
 
 export interface AskUserOption {
   id: string;
@@ -132,6 +228,8 @@ export interface ChatEvent {
   evidenceId?: string;
   cost?: number;
   durationMs?: number;
+  // For 'inline_chart' — the full chart bubble payload.
+  inlineChart?: InlineChartPayload;
 }
 
 interface UseDashboardChatResult {
@@ -220,6 +318,22 @@ export function useDashboardChat(
 
   const appendEvent = useCallback((evt: ChatEvent) => {
     setEvents((prev) => [...prev, evt]);
+  }, []);
+
+  /**
+   * Append OR replace by `inline_chart`'s derived id. Same content arriving
+   * twice updates the existing bubble in place; new content appends.
+   */
+  const upsertInlineChart = useCallback((evt: ChatEvent, chartId: string) => {
+    setEvents((prev) => {
+      const idx = prev.findIndex(
+        (e) => e.kind === 'inline_chart' && e.inlineChart?.id === chartId,
+      );
+      if (idx === -1) return [...prev, evt];
+      const next = prev.slice();
+      next[idx] = evt;
+      return next;
+    });
   }, []);
 
   const handleSSEEvent = useCallback(
@@ -374,6 +488,17 @@ export function useDashboardChat(
           break;
         }
 
+        case 'inline_chart': {
+          const payload = parseInlineChartPayload(parsed);
+          if (payload) {
+            upsertInlineChart(
+              { id: payload.id, kind: 'inline_chart', inlineChart: payload },
+              payload.id,
+            );
+          }
+          break;
+        }
+
         case 'ds_choice': {
           const chosenId = typeof parsed.chosenId === 'string' ? parsed.chosenId : '';
           const chosenName = typeof parsed.name === 'string' ? parsed.name : '';
@@ -418,7 +543,7 @@ export function useDashboardChat(
           break;
       }
     },
-    [appendEvent, dashboardId, navigate],
+    [appendEvent, upsertInlineChart, dashboardId, navigate],
   );
 
   const sendMessage = useCallback(


### PR DESCRIPTION
Second of three PRs. PR-A shipped the backend (\`POST /api/metrics/query\`, \`metric_explore\` tool, \`inline_chart\` SSE event). This PR adds the chart bubble in chat.

## What ships

**\`InlineChartMessage.tsx\`** — interactive chart bubble in chat:
- Header: 📈 icon · derived title · timeRange · ⋯ menu
- Chart: reused \`TimeSeriesViz\` (uPlot-based) with native \`onZoom\` callback for drag-to-zoom
- Summary line: \`summary.oneLine\` directly under chart
- Action row: \`[Last 1h ▾]\` dropdown (15m/1h/6h/24h/7d/Custom), pivot chips when present, \`▼ Query\` editor toggle
- Reset zoom: \`↺\` button appears top-right when zoomed in
- Loading: 200ms-debounced skeleton (no flicker on fast queries)
- Empty: "No data in this time range" + \`[Try 6h] [Try 24h]\` chips
- Error: red banner, bad-query auto-expands editor

**Chat integration**:
- Live SSE \`inline_chart\` → idempotent upsert (id derived from query+ds+range)
- Replay from persisted chat events → renders from stored series (no roundtrip)
- Both \`useChat\` (global) and \`useDashboardChat\` (dashboard-scoped) handle the event
- \`ChatPanel\` renders the new block kind

**Persistence**: full payload landed in \`chat_session_events\` via the existing chat-service writer (no new code needed). Series stored verbatim — refresh on demand via chips, not on every mount. Tradeoff documented in PR-B report.

## Reused, no new deps

- \`TimeSeriesViz\` for the chart (drag-to-zoom native)
- \`TimeRangePicker\` for Custom range
- Existing Tailwind / Lucide icons / Button primitives

## Decisions called out

| Topic | Decision |
|---|---|
| SSE \`id\` field (spec mentioned, type missing) | Synthesize client-side from \`query+ds+start+end\` |
| \`pivotSuggestions.prompt\` field (spec mentioned, type missing) | Use \`label\` as prompt for now; PR-C will add the field properly |
| 15m relative range on REST | Frontend expands to explicit start/end (REST relative only has 1h/6h/24h/7d) |
| Replay strategy | Read persisted series, don't re-query. Refresh = user clicks a chip |
| jsdom for interactive tests | Not added (no new dep) — coverage via pure-helper + state-shape tests |

## Test plan

- [x] 273 web tests pass (25 new across \`InlineChartMessage.test.tsx\` + integration)
- [x] \`tsc --build\` clean
- [x] web bundle build clean
- [ ] CI green
- [ ] Manual: ask agent "show me p50 latency" → chart appears in chat with summary line

## Out of scope (PR-C)

- TimeRange implicit context (agent reading prior chart's range from history)
- Backend pivotSuggestions generation
- Save-as-dashboard full flow (menu item exists, action stubbed)
- Comparison overlay ("vs yesterday")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inline time-series charts now appear in chat messages with interactive controls for query editing, time range selection, zoom-to-requery, and pivot-based data filtering.
  * Users can save chart queries as dashboard items directly from chat messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->