### PR TITLE
Inline Chart PR-C: TimeRange context + pivot chips + Save as dashboard

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/metric-explore.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/metric-explore.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the metric_explore handler's PR-C surface:
+ *   - inheriting the prior chart's timeRange when timeRangeHint is absent
+ *   - emitting a stale-data warning when the prior chart is > 5 min old
+ *   - computing pivot suggestions and including them in the SSE payload
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { handleMetricExplore } from '../metric-explore.js';
+import { makeFakeActionContext } from '../_test-helpers.js';
+import { AdapterRegistry } from '../../../adapters/registry.js';
+import type { ActionContext } from '../_context.js';
+
+function makeAdapters(rangeQuery = vi.fn().mockResolvedValue([])): AdapterRegistry {
+  const reg = new AdapterRegistry();
+  reg.register({
+    info: { id: 'prom', name: 'prom', type: 'prometheus', signalType: 'metrics' },
+    metrics: { rangeQuery } as never,
+  });
+  return reg;
+}
+
+const FIXED_NOW = new Date('2026-05-13T12:00:00Z').getTime();
+
+describe('handleMetricExplore — timeRange inheritance', () => {
+  it('uses explicit timeRangeHint when provided', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const lookup = vi.fn();
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+      recentEventLookup: lookup as ActionContext['recentEventLookup'],
+    });
+    await handleMetricExplore(ctx, { query: 'up', timeRangeHint: '1h' });
+    // Explicit hint → no inheritance lookup.
+    expect(lookup).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('inherits range from the most recent inline_chart event when hint is absent', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const priorEnd = new Date(FIXED_NOW - 60_000).toISOString(); // 1 min ago — fresh
+    const priorStart = new Date(FIXED_NOW - 60 * 60_000 - 60_000).toISOString();
+    const lookup = vi.fn().mockResolvedValue({
+      payload: { timeRange: { start: priorStart, end: priorEnd } },
+      timestamp: new Date(FIXED_NOW - 60_000).toISOString(),
+    });
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+      recentEventLookup: lookup as ActionContext['recentEventLookup'],
+    });
+    await handleMetricExplore(ctx, { query: 'up' });
+
+    const inlineChart = (ctx.sendEvent as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .find((e) => e?.type === 'inline_chart');
+    expect(inlineChart).toBeDefined();
+    expect(inlineChart.timeRange.start).toBe(priorStart);
+    expect(inlineChart.timeRange.end).toBe(priorEnd);
+    expect(inlineChart.warnings).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it('inherits but warns when the prior chart is stale (> 5 min ago)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const priorEnd = new Date(FIXED_NOW - 10 * 60_000).toISOString(); // 10 min ago
+    const priorStart = new Date(FIXED_NOW - 70 * 60_000).toISOString();
+    const lookup = vi.fn().mockResolvedValue({
+      payload: { timeRange: { start: priorStart, end: priorEnd } },
+      timestamp: priorEnd,
+    });
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+      recentEventLookup: lookup as ActionContext['recentEventLookup'],
+    });
+    await handleMetricExplore(ctx, { query: 'up' });
+
+    const inlineChart = (ctx.sendEvent as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .find((e) => e?.type === 'inline_chart');
+    expect(inlineChart.timeRange.end).toBe(priorEnd);
+    expect(inlineChart.warnings).toEqual([
+      expect.stringContaining('Inherited time range from earlier chart'),
+    ]);
+    vi.useRealTimers();
+  });
+
+  it('falls back to default 1h when no prior chart and no hint', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const lookup = vi.fn().mockResolvedValue(null);
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+      recentEventLookup: lookup as ActionContext['recentEventLookup'],
+    });
+    await handleMetricExplore(ctx, { query: 'up' });
+
+    const inlineChart = (ctx.sendEvent as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .find((e) => e?.type === 'inline_chart');
+    const span =
+      new Date(inlineChart.timeRange.end).getTime() -
+      new Date(inlineChart.timeRange.start).getTime();
+    expect(span).toBe(60 * 60_000);
+    vi.useRealTimers();
+  });
+
+  it('includes pivot suggestions in the emitted inline_chart event', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+    });
+    await handleMetricExplore(ctx, {
+      query: 'histogram_quantile(0.5, sum(rate(http_duration_bucket[5m])) by (le))',
+      timeRangeHint: '1h',
+    });
+
+    const inlineChart = (ctx.sendEvent as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0])
+      .find((e) => e?.type === 'inline_chart');
+    expect(inlineChart.pivotSuggestions.length).toBeGreaterThan(0);
+    expect(
+      inlineChart.pivotSuggestions.every(
+        (p: unknown) =>
+          typeof p === 'object' &&
+          p !== null &&
+          typeof (p as { label?: unknown }).label === 'string' &&
+          typeof (p as { prompt?: unknown }).prompt === 'string',
+      ),
+    ).toBe(true);
+    vi.useRealTimers();
+  });
+});

--- a/packages/agent-core/src/agent/handlers/_context.ts
+++ b/packages/agent-core/src/agent/handlers/_context.ts
@@ -104,6 +104,16 @@ export interface ActionContext {
    */
   auditWriter?: (entry: NewAuditLogEntry) => Promise<void>;
 
+  /**
+   * Optional chat-event lookup — used by `metric_explore` to inherit the
+   * prior chart's timeRange on follow-up questions. The fixed interface
+   * shape (`findLatestByKind`) avoids pulling the full repository surface
+   * into agent-core; chat-service supplies a bound closure.
+   */
+  recentEventLookup?: (
+    kind: string,
+  ) => Promise<{ payload: Record<string, unknown>; timestamp: string } | null>;
+
   actionExecutor: ActionExecutor;
 
   emitAgentEvent(event: AgentEvent): void;

--- a/packages/agent-core/src/agent/handlers/metric-explore.ts
+++ b/packages/agent-core/src/agent/handlers/metric-explore.ts
@@ -11,8 +11,16 @@
  * label set + a small LLM scaffolding pass).
  */
 
-import { AuditAction, summarizeChart, type ChartMetricKind } from '@agentic-obs/common';
+import {
+  AuditAction,
+  suggestPivots,
+  summarizeChart,
+  type ChartMetricKind,
+} from '@agentic-obs/common';
 import type { ActionContext } from './_context.js';
+
+/** How fresh the prior chart's end must be to inherit silently (no warning). */
+const INHERIT_FRESH_WINDOW_MS = 5 * 60 * 1000;
 
 const RELATIVE_HINT_MS: Record<string, number> = {
   '1h': 60 * 60 * 1000,
@@ -134,6 +142,44 @@ function resolveDatasourceId(
   return primary?.id;
 }
 
+/**
+ * Look up the most recent `inline_chart` event in this session and return
+ * its timeRange. When the chart is older than `INHERIT_FRESH_WINDOW_MS`, the
+ * range is still inherited but a `warning` is attached so the UI can
+ * surface it. Returns `null` when no prior chart exists or the lookup is
+ * not wired.
+ */
+export async function tryInheritRange(
+  ctx: ActionContext,
+  nowMs: number,
+): Promise<{ range: ParsedRange; warning?: string } | null> {
+  if (!ctx.recentEventLookup) return null;
+  try {
+    const prior = await ctx.recentEventLookup('inline_chart');
+    if (!prior) return null;
+    const tr = (prior.payload['timeRange'] as { start?: unknown; end?: unknown } | undefined);
+    const startStr = typeof tr?.start === 'string' ? tr.start : '';
+    const endStr = typeof tr?.end === 'string' ? tr.end : '';
+    if (!startStr || !endStr) return null;
+    const start = new Date(startStr);
+    const end = new Date(endStr);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+    const ageMs = nowMs - end.getTime();
+    const range: ParsedRange = { start, end };
+    if (ageMs > INHERIT_FRESH_WINDOW_MS) {
+      const minutes = Math.round(ageMs / 60_000);
+      return {
+        range,
+        warning: `Inherited time range from earlier chart (${minutes} min ago)`,
+      };
+    }
+    return { range };
+  } catch {
+    // Lookup failures should never break the handler — fall back to default.
+    return null;
+  }
+}
+
 export async function handleMetricExplore(
   ctx: ActionContext,
   args: Record<string, unknown>,
@@ -155,7 +201,16 @@ export async function handleMetricExplore(
   }
 
   const hint = typeof args['timeRangeHint'] === 'string' ? args['timeRangeHint'] : undefined;
-  const range = parseTimeRangeHint(hint, Date.now());
+  const nowMs = Date.now();
+  const parsed = parseTimeRangeHint(hint, nowMs);
+  // Inherit prior chart's range when the LLM didn't supply an explicit hint
+  // (parseTimeRangeHint falls back to "1h" — distinguishable by `hint` being
+  // absent or the warning marker on garbage input).
+  const hintAbsent = !hint || hint.trim() === '';
+  const inherited = hintAbsent ? await tryInheritRange(ctx, nowMs) : null;
+  const range = inherited?.range ?? parsed;
+  const warnings: string[] = [];
+  if (inherited?.warning) warnings.push(inherited.warning);
   const step = pickStep(range.start, range.end);
 
   const kindInput = typeof args['metricKind'] === 'string' ? args['metricKind'] as ChartMetricKind : undefined;
@@ -172,6 +227,7 @@ export async function handleMetricExplore(
   try {
     const series = await adapter.rangeQuery(query, range.start, range.end, step);
     const summary = summarizeChart(series, kind);
+    const pivotSuggestions = suggestPivots({ query, metricKind: kind, summary });
 
     // Emit the inline chart bubble payload.
     ctx.sendEvent({
@@ -186,7 +242,8 @@ export async function handleMetricExplore(
       metricKind: kind,
       series,
       summary,
-      pivotSuggestions: [],
+      pivotSuggestions,
+      ...(warnings.length > 0 ? { warnings } : {}),
     });
 
     // Audit (fire-and-forget). Mirrors the REST endpoint's audit row.

--- a/packages/agent-core/src/agent/orchestrator-action-context.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-context.ts
@@ -59,6 +59,14 @@ export interface OrchestratorActionContextDeps {
    * (dashboard_create, alert_rule_write, …) actually persist audit rows.
    */
   auditEntryWriter?: (entry: NewAuditLogEntry) => Promise<void>;
+  /**
+   * Optional lookup for the most recent chat-event of a given kind in this
+   * session. Used by metric_explore to inherit timeRange from a prior
+   * inline_chart event. Chat-service binds this to the repository.
+   */
+  recentEventLookup?: (
+    kind: string,
+  ) => Promise<{ payload: Record<string, unknown>; timestamp: string } | null>;
 }
 
 export interface OrchestratorActionRuntime {
@@ -112,6 +120,7 @@ export function buildActionContext(
     identity: deps.identity,
     accessControl: deps.accessControl,
     auditWriter: deps.auditEntryWriter,
+    recentEventLookup: deps.recentEventLookup,
     actionExecutor: runtime.actionExecutor,
     emitAgentEvent: runtime.emitAgentEvent,
     makeAgentEvent: runtime.makeAgentEvent,

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -104,6 +104,14 @@ export interface OrchestratorDeps {
    */
   auditEntryWriter?: (entry: NewAuditLogEntry) => Promise<void>
   /**
+   * Optional chat-event lookup (most-recent by kind in this session).
+   * Wired by chat-service from the chat-session-event repository so
+   * `metric_explore` can inherit timeRange from a prior `inline_chart`.
+   */
+  recentEventLookup?: (
+    kind: string,
+  ) => Promise<{ payload: Record<string, unknown>; timestamp: string } | null>
+  /**
    * Which specialized agent this run uses. Defaults to `orchestrator`. Pick a
    * narrower type to tighten the allowedTools ceiling (Layer 1).
    */

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -209,7 +209,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
         type: 'object',
         properties: {
           query: { type: 'string', description: 'PromQL expression' },
-          timeRangeHint: { type: 'string', description: 'Time window hint: "1h" | "6h" | "24h" | "7d" | "since 14:00" | "30m around 14:23". Defaults to 1h.' },
+          timeRangeHint: { type: 'string', description: 'Time window hint: "1h" | "6h" | "24h" | "7d" | "since 14:00" | "30m around 14:23". Omit on follow-ups about the same incident/metric to inherit the previous chart\'s range automatically (a small note is surfaced if the prior chart is stale).' },
           datasourceId: { type: 'string', description: 'Connector id. Omit to use the primary metrics datasource for the workspace.' },
           metricKind: {
             type: 'string',

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -40,6 +40,7 @@ import { createWebhookRouter } from '../routes/webhooks.js';
 import { createConnectorsRouter } from '../routes/connectors.js';
 import { createQueryRouter } from '../routes/dashboard/query.js';
 import { createMetricsQueryRouter } from '../routes/metrics-query.js';
+import { createMetricsSaveAsDashboardRouter } from '../routes/metrics-save-as-dashboard.js';
 import { createSystemRouter } from '../routes/system.js';
 import { createDashboardRouter } from '../routes/dashboard/router.js';
 import { createAlertRulesRouter } from '../routes/alert-rules.js';
@@ -241,6 +242,12 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   // Auth + per-datasource RBAC + 30/min rate limit are inside the router.
   app.use('/api/metrics', userRateLimiter, createMetricsQueryRouter({
     setupConfig,
+    ac: accessControl,
+    audit: authSub.audit,
+  }));
+  // PR-C — save inline chart as a dashboard panel (new or append).
+  app.use('/api/metrics', userRateLimiter, createMetricsSaveAsDashboardRouter({
+    dashboardStore: repos.dashboards,
     ac: accessControl,
     audit: authSub.audit,
   }));

--- a/packages/api-gateway/src/routes/metrics-save-as-dashboard.test.ts
+++ b/packages/api-gateway/src/routes/metrics-save-as-dashboard.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the inline-chart save-as-dashboard endpoints:
+ *   - /preview  → similarity matches
+ *   - /save     → creates new or appends panel
+ */
+import { describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Dashboard, PanelConfig, Identity } from '@agentic-obs/common';
+import type { IGatewayDashboardStore } from '@agentic-obs/data-layer';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import {
+  createMetricsSaveAsDashboardRouter,
+  normalizePromQL,
+  querySimilarity,
+} from './metrics-save-as-dashboard.js';
+
+vi.mock('../middleware/auth.js', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.auth = {
+      userId: 'user_1',
+      orgId: 'org_main',
+      orgRole: 'Admin',
+      isServerAdmin: false,
+      authenticatedBy: 'session',
+    };
+    next();
+  },
+}));
+
+function panel(overrides: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    id: 'p1',
+    title: 'Latency',
+    description: '',
+    visualization: 'time_series',
+    row: 0,
+    col: 0,
+    width: 6,
+    height: 4,
+    ...overrides,
+  };
+}
+
+function dashboard(overrides: Partial<Dashboard> = {}): Dashboard {
+  return {
+    id: 'dash_a',
+    type: 'dashboard',
+    title: 'HTTP Service Health',
+    description: '',
+    prompt: '',
+    userId: 'user_1',
+    status: 'ready',
+    panels: [],
+    variables: [],
+    refreshIntervalSec: 30,
+    datasourceIds: ['ds_prom'],
+    useExistingMetrics: true,
+    workspaceId: 'org_main',
+    source: 'manual',
+    createdAt: '2026-04-26T00:00:00.000Z',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeStore(dashboards: Dashboard[]): IGatewayDashboardStore {
+  const map = new Map(dashboards.map((d) => [d.id, { ...d }] as const));
+  return {
+    create: vi.fn(async (input: Parameters<IGatewayDashboardStore['create']>[0]) => {
+      const d = dashboard({
+        id: 'dash_new',
+        title: input.title,
+        prompt: input.prompt,
+        datasourceIds: input.datasourceIds ?? [],
+        userId: input.userId,
+        workspaceId: input.workspaceId ?? 'org_main',
+        panels: [],
+      });
+      map.set(d.id, d);
+      return d;
+    }),
+    findById: vi.fn(async (id: string) => map.get(id)),
+    findAll: vi.fn(async () => Array.from(map.values())),
+    listByWorkspace: vi.fn(async () => Array.from(map.values())),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    updatePanels: vi.fn(async (id: string, panels: PanelConfig[]) => {
+      const d = map.get(id);
+      if (!d) return undefined;
+      const updated = { ...d, panels };
+      map.set(id, updated);
+      return updated;
+    }),
+    updateVariables: vi.fn(),
+    delete: vi.fn(),
+    getFolderUid: vi.fn(async () => null),
+  } as unknown as IGatewayDashboardStore;
+}
+
+function makeAc(allowed: boolean): AccessControlSurface {
+  return {
+    evaluate: vi.fn(async (_id: Identity, _e: any) => allowed),
+  } as unknown as AccessControlSurface;
+}
+
+function makeAudit() {
+  return { log: vi.fn(async () => {}) } as any;
+}
+
+function makeApp(store: IGatewayDashboardStore, allowed = true) {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/metrics',
+    createMetricsSaveAsDashboardRouter({
+      dashboardStore: store,
+      ac: makeAc(allowed),
+      audit: makeAudit(),
+    }),
+  );
+  return app;
+}
+
+describe('normalizePromQL + querySimilarity', () => {
+  it('sorts label selectors and lowercases', () => {
+    expect(normalizePromQL('Up{job="api", env="prod"}')).toBe('up{env="prod",job="api"}');
+  });
+  it('high similarity for nearly-identical queries', () => {
+    const a = 'sum(rate(http_requests_total{job="api"}[5m]))';
+    const b = 'sum(rate(http_requests_total{job="api"}[1m]))';
+    expect(querySimilarity(a, b)).toBeGreaterThanOrEqual(0.6);
+  });
+  it('low similarity for unrelated queries', () => {
+    expect(querySimilarity('node_memory_used_bytes', 'rate(http_5xx_total[1m])')).toBeLessThan(0.6);
+  });
+});
+
+describe('POST /api/metrics/save-as-dashboard/preview', () => {
+  it('returns matches above the 60% threshold sorted by similarity', async () => {
+    const matching = dashboard({
+      id: 'dash_match',
+      title: 'HTTP Service Health',
+      panels: [panel({ queries: [{ refId: 'A', expr: 'sum(rate(http_requests_total[5m]))' }] })],
+    });
+    const unrelated = dashboard({
+      id: 'dash_other',
+      title: 'Memory',
+      panels: [panel({ queries: [{ refId: 'A', expr: 'node_memory_used_bytes' }] })],
+    });
+    const store = makeStore([matching, unrelated]);
+    const res = await request(makeApp(store))
+      .post('/api/metrics/save-as-dashboard/preview')
+      .send({ query: 'sum(rate(http_requests_total[1m]))' });
+    expect(res.status).toBe(200);
+    expect(res.body.matches).toHaveLength(1);
+    expect(res.body.matches[0].dashboardId).toBe('dash_match');
+    expect(res.body.matches[0].similarityPct).toBeGreaterThanOrEqual(60);
+  });
+
+  it('returns empty matches when nothing is similar', async () => {
+    const store = makeStore([
+      dashboard({ panels: [panel({ queries: [{ refId: 'A', expr: 'node_memory_used_bytes' }] })] }),
+    ]);
+    const res = await request(makeApp(store))
+      .post('/api/metrics/save-as-dashboard/preview')
+      .send({ query: 'histogram_quantile(0.95, rate(http_duration_bucket[5m]))' });
+    expect(res.status).toBe(200);
+    expect(res.body.matches).toEqual([]);
+  });
+});
+
+describe('POST /api/metrics/save-as-dashboard', () => {
+  it('creates a new dashboard with one panel when no existing id is given', async () => {
+    const store = makeStore([]);
+    const res = await request(makeApp(store))
+      .post('/api/metrics/save-as-dashboard')
+      .send({
+        title: 'p50 latency (2026-05-13)',
+        query: 'histogram_quantile(0.5, sum(rate(http_duration_bucket[5m])) by (le))',
+        metricKind: 'latency',
+        datasourceId: 'ds_prom',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.dashboardId).toBe('dash_new');
+    expect(res.body.url).toBe('/dashboards/dash_new');
+    expect(store.create).toHaveBeenCalledOnce();
+    expect(store.updatePanels).toHaveBeenCalledOnce();
+  });
+
+  it('appends a panel to an existing dashboard when addToExistingDashboardId is set', async () => {
+    const existing = dashboard({
+      id: 'dash_existing',
+      panels: [panel({ id: 'p_old', row: 0, height: 4 })],
+    });
+    const store = makeStore([existing]);
+    const res = await request(makeApp(store))
+      .post('/api/metrics/save-as-dashboard')
+      .send({
+        title: 'New panel',
+        query: 'rate(http_requests_total[1m])',
+        metricKind: 'counter',
+        datasourceId: 'ds_prom',
+        addToExistingDashboardId: 'dash_existing',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.dashboardId).toBe('dash_existing');
+    const call = vi.mocked(store.updatePanels).mock.calls[0]!;
+    expect(call[0]).toBe('dash_existing');
+    expect(call[1]).toHaveLength(2);
+    // New panel placed after the old one (row 4).
+    expect(call[1][1]!.row).toBe(4);
+  });
+
+  it('rejects with 403 when access control denies', async () => {
+    const store = makeStore([]);
+    const res = await request(makeApp(store, /*allowed=*/ false))
+      .post('/api/metrics/save-as-dashboard')
+      .send({
+        title: 't',
+        query: 'up',
+        metricKind: 'gauge',
+        datasourceId: 'ds_prom',
+      });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects with 400 when required fields are missing', async () => {
+    const store = makeStore([]);
+    const res = await request(makeApp(store))
+      .post('/api/metrics/save-as-dashboard')
+      .send({ title: '', query: '', metricKind: 'gauge', datasourceId: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api-gateway/src/routes/metrics-save-as-dashboard.ts
+++ b/packages/api-gateway/src/routes/metrics-save-as-dashboard.ts
@@ -1,0 +1,304 @@
+/**
+ * POST /api/metrics/save-as-dashboard — finalize an inline-chart bubble
+ * into a persistent dashboard panel.
+ *
+ * Companion to `POST /api/metrics/save-as-dashboard/preview` which surfaces
+ * "this looks similar to an existing dashboard" suggestions so the user
+ * can append a panel instead of creating a new dashboard.
+ *
+ * Similarity heuristic = normalized-PromQL Jaccard token overlap. Threshold
+ * 60%. Deliberately simple — the surface is "throwaway exploration" and
+ * the user always sees the title before committing.
+ *
+ * Auth: requires `dashboards:write` on the target (existing dashboard) or
+ * `dashboards:create` on `folders:*` (new dashboard). Audit rows are
+ * dashboard.create or dashboard.update.
+ */
+
+import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import {
+  ac,
+  ACTIONS,
+  AuditAction,
+  type ChartMetricKind,
+  type PanelConfig,
+  type PanelVisualization,
+} from '@agentic-obs/common';
+import type { IGatewayDashboardStore } from '@agentic-obs/data-layer';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { authMiddleware } from '../middleware/auth.js';
+import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
+import { getOrgId } from '../middleware/workspace-context.js';
+
+export interface SaveAsDashboardRouterDeps {
+  dashboardStore: IGatewayDashboardStore;
+  ac: AccessControlSurface;
+  audit: AuditWriter;
+}
+
+const SIMILARITY_THRESHOLD = 0.6;
+
+/** Visualization choice based on metric kind. Mirrors the chart bubble. */
+function pickVisualization(kind: ChartMetricKind): PanelVisualization {
+  // All kinds map to time_series in v1 — same widget the chart bubble uses.
+  // Future: stat for gauge, heatmap for latency histograms, etc.
+  void kind;
+  return 'time_series';
+}
+
+/**
+ * Normalize a PromQL expression for similarity hashing. Strips whitespace,
+ * lowercases, and sorts label-selector pairs inside `{…}` so e.g.
+ * `{job="api", env="prod"}` and `{env="prod",job="api"}` hash identically.
+ */
+export function normalizePromQL(query: string): string {
+  const lower = query.toLowerCase().replace(/\s+/g, '');
+  // Sort label selectors inside braces.
+  return lower.replace(/\{([^}]+)\}/g, (_match, inner: string) => {
+    const parts = inner.split(',').map((s) => s.trim()).filter(Boolean);
+    parts.sort();
+    return `{${parts.join(',')}}`;
+  });
+}
+
+/** Tokenize a normalized PromQL string into a set of meaningful tokens. */
+function tokens(normalized: string): Set<string> {
+  // Split on non-word chars; keep alpha/numeric chunks length ≥ 2 to
+  // avoid one-letter tokens dominating short queries.
+  const ts = normalized
+    .split(/[^a-z0-9_]+/)
+    .filter((t) => t.length >= 2);
+  return new Set(ts);
+}
+
+/** Jaccard token overlap on normalized PromQL — 0..1. */
+export function querySimilarity(a: string, b: string): number {
+  const ta = tokens(normalizePromQL(a));
+  const tb = tokens(normalizePromQL(b));
+  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let inter = 0;
+  for (const t of ta) if (tb.has(t)) inter += 1;
+  const union = ta.size + tb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+interface SaveBody {
+  title?: unknown;
+  query?: unknown;
+  metricKind?: unknown;
+  datasourceId?: unknown;
+  addToExistingDashboardId?: unknown;
+}
+
+interface PreviewBody {
+  query?: unknown;
+}
+
+function buildPanel(args: {
+  title: string;
+  query: string;
+  metricKind: ChartMetricKind;
+  datasourceId: string;
+  row: number;
+}): PanelConfig {
+  return {
+    id: randomUUID(),
+    title: args.title,
+    description: '',
+    queries: [
+      {
+        refId: 'A',
+        expr: args.query,
+        datasourceId: args.datasourceId,
+      },
+    ],
+    visualization: pickVisualization(args.metricKind),
+    row: args.row,
+    col: 0,
+    width: 12,
+    height: 8,
+  };
+}
+
+export function createMetricsSaveAsDashboardRouter(
+  deps: SaveAsDashboardRouterDeps,
+): Router {
+  const router = Router();
+  router.use(authMiddleware);
+
+  // POST /save-as-dashboard/preview — similarity hints (no mutation).
+  router.post('/save-as-dashboard/preview', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const auth = (req as AuthenticatedRequest).auth;
+      if (!auth) {
+        res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+        return;
+      }
+      const body = req.body as PreviewBody;
+      const query = typeof body.query === 'string' ? body.query.trim() : '';
+      if (!query) {
+        res.status(400).json({ error: { code: 'INVALID_INPUT', message: 'query is required' } });
+        return;
+      }
+
+      const orgId = auth.orgId || getOrgId(req);
+      const all = await deps.dashboardStore.findAll();
+      const matches: Array<{ dashboardId: string; title: string; similarityPct: number }> = [];
+
+      for (const d of all) {
+        if (d.workspaceId !== orgId) continue;
+        let best = 0;
+        for (const panel of d.panels) {
+          const exprs: string[] = [];
+          if (panel.query) exprs.push(panel.query);
+          for (const q of panel.queries ?? []) exprs.push(q.expr);
+          for (const expr of exprs) {
+            const sim = querySimilarity(query, expr);
+            if (sim > best) best = sim;
+          }
+        }
+        if (best >= SIMILARITY_THRESHOLD) {
+          matches.push({
+            dashboardId: d.id,
+            title: d.title,
+            similarityPct: Math.round(best * 100),
+          });
+        }
+      }
+
+      matches.sort((a, b) => b.similarityPct - a.similarityPct);
+      res.json({ matches: matches.slice(0, 5) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // POST /save-as-dashboard — create or append.
+  router.post('/save-as-dashboard', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const auth = (req as AuthenticatedRequest).auth;
+      if (!auth) {
+        res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
+        return;
+      }
+      const body = req.body as SaveBody;
+      const title = typeof body.title === 'string' ? body.title.trim() : '';
+      const query = typeof body.query === 'string' ? body.query.trim() : '';
+      const datasourceId = typeof body.datasourceId === 'string' ? body.datasourceId.trim() : '';
+      const metricKindInput = typeof body.metricKind === 'string' ? body.metricKind : '';
+      const validKinds: ChartMetricKind[] = ['latency', 'counter', 'gauge', 'errors'];
+      const metricKind = (validKinds as string[]).includes(metricKindInput)
+        ? (metricKindInput as ChartMetricKind)
+        : 'gauge';
+      const addToExistingDashboardId =
+        typeof body.addToExistingDashboardId === 'string' && body.addToExistingDashboardId.trim()
+          ? body.addToExistingDashboardId.trim()
+          : undefined;
+
+      if (!title || !query || !datasourceId) {
+        res.status(400).json({
+          error: { code: 'INVALID_INPUT', message: 'title, query, and datasourceId are required' },
+        });
+        return;
+      }
+
+      const orgId = auth.orgId || getOrgId(req);
+
+      if (addToExistingDashboardId) {
+        // -- Append to existing dashboard. --
+        const existing = await deps.dashboardStore.findById(addToExistingDashboardId);
+        if (!existing || existing.workspaceId !== orgId) {
+          res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Dashboard not found' } });
+          return;
+        }
+        const allowed = await deps.ac.evaluate(
+          auth,
+          ac.eval(ACTIONS.DashboardsWrite, `dashboards:uid:${existing.id}`),
+        );
+        if (!allowed) {
+          res.status(403).json({ error: { code: 'FORBIDDEN', message: 'No write permission' } });
+          return;
+        }
+
+        const lastRow = existing.panels.reduce(
+          (acc, p) => Math.max(acc, p.row + p.height),
+          0,
+        );
+        const panel = buildPanel({ title, query, metricKind, datasourceId, row: lastRow });
+        const updated = await deps.dashboardStore.updatePanels(existing.id, [...existing.panels, panel]);
+        if (!updated) {
+          res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Dashboard not found' } });
+          return;
+        }
+
+        void deps.audit.log({
+          action: AuditAction.DashboardUpdate,
+          actorType: 'user',
+          actorId: auth.userId,
+          orgId,
+          targetType: 'dashboard',
+          targetId: existing.id,
+          targetName: existing.title,
+          outcome: 'success',
+          metadata: { source: 'save_as_dashboard', panelId: panel.id },
+        });
+
+        res.status(200).json({
+          dashboardId: existing.id,
+          panelId: panel.id,
+          url: `/dashboards/${existing.id}`,
+        });
+        return;
+      }
+
+      // -- Create new dashboard. --
+      const allowed = await deps.ac.evaluate(
+        auth,
+        ac.eval(ACTIONS.DashboardsCreate, 'folders:*'),
+      );
+      if (!allowed) {
+        res.status(403).json({ error: { code: 'FORBIDDEN', message: 'No create permission' } });
+        return;
+      }
+
+      const dashboard = await deps.dashboardStore.create({
+        title,
+        description: '',
+        prompt: query,
+        userId: auth.userId,
+        datasourceIds: [datasourceId],
+        useExistingMetrics: true,
+        workspaceId: orgId,
+        source: 'api',
+      });
+      const panel = buildPanel({ title, query, metricKind, datasourceId, row: 0 });
+      await deps.dashboardStore.updatePanels(dashboard.id, [panel]);
+
+      void deps.audit.log({
+        action: AuditAction.DashboardCreate,
+        actorType: 'user',
+        actorId: auth.userId,
+        orgId,
+        targetType: 'dashboard',
+        targetId: dashboard.id,
+        targetName: dashboard.title,
+        outcome: 'success',
+        metadata: { source: 'save_as_dashboard' },
+      });
+
+      res.status(201).json({
+        dashboardId: dashboard.id,
+        panelId: panel.id,
+        url: `/dashboards/${dashboard.id}`,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -518,6 +518,19 @@ export class ChatService {
           ? { approvalRequests: this.deps.approvalStore }
           : {}),
         sendEvent: wrappedSendEvent,
+        // Recent-event lookup for handlers that want to peek at prior SSE
+        // payloads (e.g. metric_explore inheriting the last chart's range).
+        // Bound to this session; null when no event store is wired.
+        ...(eventStore
+          ? {
+              recentEventLookup: async (kind: string) => {
+                const row = await eventStore.findLatestByKind(resolvedSessionId, kind);
+                return row
+                  ? { payload: row.payload, timestamp: row.timestamp }
+                  : null;
+              },
+            }
+          : {}),
         timeRange,
         conversationSummary,
         identity,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -55,3 +55,5 @@ export type {
   ChartSummary,
   SummarySeries,
 } from './utils/chart-summary.js';
+export { suggestPivots } from './utils/chart-pivots.js';
+export type { PivotSuggestion, SuggestPivotsArgs } from './utils/chart-pivots.js';

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -273,9 +273,14 @@ export type DashboardSseEvent =
       metricKind: 'latency' | 'counter' | 'gauge' | 'errors';
       series: Array<{ metric: Record<string, string>; values: Array<[number, string]> }>;
       summary: { kind: 'latency' | 'counter' | 'gauge' | 'errors'; oneLine: string; stats: Record<string, number | string> };
-      // PR-C will populate pivot suggestions ("by route", "p99 only", etc).
-      // Empty array in v1 so the frontend can render the affordance shape stably.
-      pivotSuggestions: Array<{ id: string; label: string }>;
+      // Pivot chips computed by the backend — clicking sends `prompt` as a
+      // new chat message. See suggestPivots() in utils/chart-pivots.ts.
+      pivotSuggestions: Array<{ label: string; prompt: string }>;
+      /**
+       * User-facing notes about the chart (e.g. "Inherited time range from
+       * earlier chart"). Optional — empty/omitted by default.
+       */
+      warnings?: string[];
     }
   | { type: 'done'; messageId: string }
   | { type: 'error'; message: string };

--- a/packages/common/src/utils/chart-pivots.test.ts
+++ b/packages/common/src/utils/chart-pivots.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { suggestPivots } from './chart-pivots.js';
+import type { ChartSummary } from './chart-summary.js';
+
+const emptySummary = (kind: ChartSummary['kind']): ChartSummary => ({
+  kind,
+  oneLine: '',
+  stats: {},
+});
+
+describe('suggestPivots', () => {
+  it('latency p50 query → suggests p99', () => {
+    const chips = suggestPivots({
+      query: 'histogram_quantile(0.5, sum(rate(http_duration_bucket[5m])) by (le))',
+      metricKind: 'latency',
+      summary: emptySummary('latency'),
+    });
+    expect(chips[0]).toEqual({ label: 'Show p99', prompt: 'Show p99 instead' });
+    expect(chips.some((c) => c.label === 'Show errors')).toBe(true);
+    expect(chips.length).toBeLessThanOrEqual(3);
+  });
+
+  it('latency p99 query → suggests p50+p99 combo', () => {
+    const chips = suggestPivots({
+      query: 'histogram_quantile(0.99, sum(rate(http_duration_bucket[5m])) by (le))',
+      metricKind: 'latency',
+      summary: emptySummary('latency'),
+    });
+    expect(chips.find((c) => c.label === 'Show p50 + p99')).toBeTruthy();
+  });
+
+  it('counter rate query, no status grouping → suggests breakdown + errors + daily', () => {
+    const chips = suggestPivots({
+      query: 'sum(rate(http_requests_total[1m]))',
+      metricKind: 'counter',
+      summary: emptySummary('counter'),
+    });
+    const labels = chips.map((c) => c.label);
+    expect(labels).toContain('Break down by status');
+    expect(labels).toContain('Show errors');
+    expect(labels).toContain('Daily total');
+    expect(chips.length).toBe(3);
+  });
+
+  it('counter already-grouped by status → does not suggest status breakdown', () => {
+    const chips = suggestPivots({
+      query: 'sum by (status_code) (rate(http_requests_total[1m]))',
+      metricKind: 'counter',
+      summary: emptySummary('counter'),
+    });
+    expect(chips.find((c) => c.label === 'Break down by status')).toBeUndefined();
+  });
+
+  it('gauge not by instance → suggests top-5 + yesterday', () => {
+    const chips = suggestPivots({
+      query: 'node_memory_used_bytes',
+      metricKind: 'gauge',
+      summary: emptySummary('gauge'),
+    });
+    const labels = chips.map((c) => c.label);
+    expect(labels).toContain('Top 5 by instance');
+    expect(labels).toContain('Compare yesterday');
+  });
+
+  it('errors with path label → suggests group by endpoint + request rate', () => {
+    const chips = suggestPivots({
+      query: 'sum(rate(http_errors_total[1m])) by (path)',
+      metricKind: 'errors',
+      summary: emptySummary('errors'),
+    });
+    const labels = chips.map((c) => c.label);
+    expect(labels).toContain('Show request rate');
+    expect(labels).toContain('Group by endpoint');
+    expect(labels).toContain('Show top error messages');
+    expect(chips.length).toBe(3);
+  });
+
+  it('errors without path label → omits group-by-endpoint', () => {
+    const chips = suggestPivots({
+      query: 'sum(rate(http_5xx_total[1m]))',
+      metricKind: 'errors',
+      summary: emptySummary('errors'),
+    });
+    expect(chips.find((c) => c.label === 'Group by endpoint')).toBeUndefined();
+    expect(chips.find((c) => c.label === 'Show request rate')).toBeTruthy();
+  });
+
+  it('never exceeds 3 chips', () => {
+    const chips = suggestPivots({
+      query: 'sum(rate(http_requests_total[1m]))',
+      metricKind: 'counter',
+      summary: emptySummary('counter'),
+    });
+    expect(chips.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/common/src/utils/chart-pivots.ts
+++ b/packages/common/src/utils/chart-pivots.ts
@@ -1,0 +1,112 @@
+/**
+ * Pivot suggestions for the inline chart bubble — small "Show X" chips
+ * that, when clicked, send a follow-up prompt back to the agent.
+ *
+ * Backend-computed (vs. LLM-generated) so suggestions are deterministic,
+ * cheap, and ship without a round-trip. Rules per metric kind — see
+ * `suggestPivots` JSDoc. Max 3 chips.
+ */
+
+import type { ChartMetricKind, ChartSummary } from './chart-summary.js';
+
+export interface PivotSuggestion {
+  /** Chip text (short). */
+  label: string;
+  /** Prompt sent as a new chat message when the chip is clicked. */
+  prompt: string;
+}
+
+export interface SuggestPivotsArgs {
+  query: string;
+  metricKind: ChartMetricKind;
+  summary: ChartSummary;
+  /**
+   * Optional label hints the caller can pass in (e.g. parsed from the
+   * series). Currently only `path`/`route` is consulted (errors bucket).
+   */
+  hasLabels?: {
+    service?: string;
+    instance?: string;
+    method?: string;
+    status?: string;
+    path?: string;
+    route?: string;
+  };
+}
+
+const MAX_CHIPS = 3;
+
+/**
+ * Compute pivot chips for a chart given its query, kind, and summary.
+ *
+ * Rules:
+ * - latency: p50/p99 swap based on which quantile is in the query;
+ *   always suggest "Show errors".
+ * - counter: status breakdown when not already grouped by status;
+ *   error-rate; "today's total" when the query is rate-based.
+ * - gauge: top-5 by instance (when not already by-instance);
+ *   compare to yesterday.
+ * - errors: request rate; group by path/route (only when such a label
+ *   is in `hasLabels`); top error messages from logs.
+ *
+ * Bounded to `MAX_CHIPS` — earlier rules win.
+ */
+export function suggestPivots(args: SuggestPivotsArgs): PivotSuggestion[] {
+  const q = args.query.toLowerCase();
+  const chips: PivotSuggestion[] = [];
+
+  const push = (chip: PivotSuggestion): void => {
+    if (chips.length < MAX_CHIPS) chips.push(chip);
+  };
+
+  switch (args.metricKind) {
+    case 'latency': {
+      // Quantile swap suggestions.
+      if (/histogram_quantile\s*\(\s*0?\.5\b/.test(q)) {
+        push({ label: 'Show p99', prompt: 'Show p99 instead' });
+      } else if (/0\.99\b/.test(q)) {
+        push({ label: 'Show p50 + p99', prompt: 'Show p50 and p99 together' });
+      }
+      push({ label: 'Show errors', prompt: 'Show error rate for the same period' });
+      break;
+    }
+    case 'counter': {
+      // "Break down by status" when no obvious status grouping.
+      const hasStatusGrouping = /by\s*\([^)]*\b(status|status_code)\b[^)]*\)/.test(q)
+        || /\bstatus(?:_code)?\b\s*=/.test(q);
+      if (!hasStatusGrouping) {
+        push({ label: 'Break down by status', prompt: 'Break down by status_code label' });
+      }
+      push({ label: 'Show errors', prompt: 'Show error rate' });
+      // "Daily total" — only meaningful when query is rate-based.
+      if (/\brate\s*\(/.test(q)) {
+        push({ label: 'Daily total', prompt: 'What was the total for today?' });
+      }
+      break;
+    }
+    case 'gauge': {
+      // Top 5 by instance when not already by-instance.
+      const byInstance = /by\s*\([^)]*\binstance\b[^)]*\)/.test(q);
+      if (!byInstance) {
+        push({ label: 'Top 5 by instance', prompt: 'Show top 5 instances' });
+      }
+      push({ label: 'Compare yesterday', prompt: 'Compare to the same time yesterday' });
+      break;
+    }
+    case 'errors': {
+      push({ label: 'Show request rate', prompt: 'Show request rate for the same period' });
+      const hasPathLabel = !!(args.hasLabels?.path || args.hasLabels?.route)
+        || /\b(path|route)\b/.test(q);
+      if (hasPathLabel) {
+        push({ label: 'Group by endpoint', prompt: 'Break down errors by path/route' });
+      }
+      push({
+        label: 'Show top error messages',
+        prompt: 'What are the top 5 error messages from logs in this window?',
+      });
+      break;
+    }
+  }
+
+  return chips;
+}

--- a/packages/data-layer/src/repository/interfaces.ts
+++ b/packages/data-layer/src/repository/interfaces.ts
@@ -488,4 +488,13 @@ export interface IChatSessionEventRepository {
   listBySession(sessionId: string): MaybeAsync<ChatSessionEventRecord[]>;
   nextSeq(sessionId: string): MaybeAsync<number>;
   deleteBySession(sessionId: string): MaybeAsync<void>;
+  /**
+   * Find the most recent event of a given kind in a session (by seq desc).
+   * Used by metric_explore to inherit the prior chart's time range on
+   * follow-up questions. Returns `null` when none exist.
+   */
+  findLatestByKind(
+    sessionId: string,
+    kind: string,
+  ): MaybeAsync<ChatSessionEventRecord | null>;
 }

--- a/packages/data-layer/src/repository/postgres/chat-session-event.ts
+++ b/packages/data-layer/src/repository/postgres/chat-session-event.ts
@@ -1,4 +1,4 @@
-import { asc, eq, max } from 'drizzle-orm';
+import { and, asc, desc, eq, max } from 'drizzle-orm';
 import { chatSessionEvents } from '../../db/schema.js';
 import type {
   ChatSessionEventRecord,
@@ -51,5 +51,19 @@ export class PostgresChatSessionEventRepository implements IChatSessionEventRepo
 
   async deleteBySession(sessionId: string): Promise<void> {
     await this.db.delete(chatSessionEvents).where(eq(chatSessionEvents.sessionId, sessionId));
+  }
+
+  async findLatestByKind(
+    sessionId: string,
+    kind: string,
+  ): Promise<ChatSessionEventRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionEvents)
+      .where(and(eq(chatSessionEvents.sessionId, sessionId), eq(chatSessionEvents.kind, kind)))
+      .orderBy(desc(chatSessionEvents.seq))
+      .limit(1);
+    const row = rows[0];
+    return row ? rowToEvent(row) : null;
   }
 }

--- a/packages/data-layer/src/repository/sqlite/chat-session-event.ts
+++ b/packages/data-layer/src/repository/sqlite/chat-session-event.ts
@@ -1,4 +1,4 @@
-import { asc, eq, max } from 'drizzle-orm';
+import { and, asc, desc, eq, max } from 'drizzle-orm';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { chatSessionEvents } from '../../db/sqlite-schema.js';
 import type {
@@ -52,5 +52,19 @@ export class SqliteChatSessionEventRepository implements IChatSessionEventReposi
 
   async deleteBySession(sessionId: string): Promise<void> {
     await this.db.delete(chatSessionEvents).where(eq(chatSessionEvents.sessionId, sessionId));
+  }
+
+  async findLatestByKind(
+    sessionId: string,
+    kind: string,
+  ): Promise<ChatSessionEventRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(chatSessionEvents)
+      .where(and(eq(chatSessionEvents.sessionId, sessionId), eq(chatSessionEvents.kind, kind)))
+      .orderBy(desc(chatSessionEvents.seq))
+      .limit(1);
+    const row = rows[0];
+    return row ? rowToEvent(row) : null;
   }
 }

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -258,6 +258,7 @@ export default function ChatPanel({ events, isGenerating, onSendMessage, onStop,
                   metricKind={c.metricKind}
                   datasourceId={c.datasourceId}
                   pivotSuggestions={c.pivotSuggestions}
+                  warnings={c.warnings}
                   onSendMessage={onSendMessage}
                 />
               );

--- a/packages/web/src/components/InlineChartMessage.tsx
+++ b/packages/web/src/components/InlineChartMessage.tsx
@@ -26,11 +26,25 @@ interface Props {
   metricKind: ChartMetricKind;
   datasourceId: string;
   pivotSuggestions?: InlineChartPivotSuggestion[];
+  /** Optional notes from the backend (e.g. "Inherited time range…"). */
+  warnings?: string[];
   /** Optional callback when a pivot chip is clicked — caller sends this as a new chat message. */
   onSendMessage?: (prompt: string) => void;
-  /** Optional stub — opens the save-as-dashboard flow (PR-C). */
-  onSaveAsDashboard?: () => void;
 }
+
+interface SavePreviewMatch {
+  dashboardId: string;
+  title: string;
+  similarityPct: number;
+}
+
+type SaveStage =
+  | { kind: 'idle' }
+  | { kind: 'loading-preview' }
+  | { kind: 'preview'; matches: SavePreviewMatch[] }
+  | { kind: 'saving' }
+  | { kind: 'saved'; title: string; url: string }
+  | { kind: 'error'; message: string };
 
 interface QueryResponse {
   series: InlineChartSeries[];
@@ -123,8 +137,8 @@ export default function InlineChartMessage(props: Props): JSX.Element {
     metricKind,
     datasourceId,
     pivotSuggestions = [],
+    warnings,
     onSendMessage,
-    onSaveAsDashboard,
   } = props;
 
   const [query, setQuery] = useState(initialQuery);
@@ -140,6 +154,7 @@ export default function InlineChartMessage(props: Props): JSX.Element {
   const [menuOpen, setMenuOpen] = useState(false);
   const [rangeMenuOpen, setRangeMenuOpen] = useState(false);
   const [zoomed, setZoomed] = useState(false);
+  const [saveStage, setSaveStage] = useState<SaveStage>({ kind: 'idle' });
 
   // Sync props → state when SSE updates push a new payload with the same id.
   // The parent calls upsertInlineChart which replaces the event; React
@@ -266,8 +281,71 @@ export default function InlineChartMessage(props: Props): JSX.Element {
   );
 
   const onPivotClick = (p: InlineChartPivotSuggestion) => {
-    onSendMessage?.(p.label);
+    onSendMessage?.(p.prompt);
   };
+
+  // -- Save-as-dashboard flow --
+  const defaultTitle = useMemo(() => {
+    const date = new Date().toISOString().slice(0, 10);
+    return `${title} (${date})`;
+  }, [title]);
+
+  const beginSavePreview = useCallback(async () => {
+    setMenuOpen(false);
+    setSaveStage({ kind: 'loading-preview' });
+    try {
+      const { data, error: apiErr } = await apiClient.post<{ matches: SavePreviewMatch[] }>(
+        '/metrics/save-as-dashboard/preview',
+        { query },
+      );
+      if (apiErr) {
+        setSaveStage({ kind: 'error', message: apiErr.message });
+        return;
+      }
+      setSaveStage({ kind: 'preview', matches: data?.matches ?? [] });
+    } catch (err) {
+      setSaveStage({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [query]);
+
+  const doSave = useCallback(
+    async (addToExistingDashboardId?: string) => {
+      setSaveStage({ kind: 'saving' });
+      try {
+        const { data, error: apiErr } = await apiClient.post<{
+          dashboardId: string;
+          panelId: string;
+          url: string;
+        }>('/metrics/save-as-dashboard', {
+          title: defaultTitle,
+          query,
+          datasourceId,
+          metricKind,
+          ...(addToExistingDashboardId ? { addToExistingDashboardId } : {}),
+        });
+        if (apiErr) {
+          setSaveStage({ kind: 'error', message: apiErr.message });
+          return;
+        }
+        if (!data) {
+          setSaveStage({ kind: 'error', message: 'Empty response' });
+          return;
+        }
+        setSaveStage({ kind: 'saved', title: defaultTitle, url: data.url });
+      } catch (err) {
+        setSaveStage({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [defaultTitle, query, datasourceId, metricKind],
+  );
+
+  const cancelSave = useCallback(() => setSaveStage({ kind: 'idle' }), []);
 
   const onRunEditor = () => {
     const q = draftQuery.trim();
@@ -310,10 +388,8 @@ export default function InlineChartMessage(props: Props): JSX.Element {
                 Copy query
               </MenuItem>
               <MenuItem
-                disabled={!onSaveAsDashboard}
                 onClick={() => {
-                  setMenuOpen(false);
-                  onSaveAsDashboard?.();
+                  void beginSavePreview();
                 }}
               >
                 Save as dashboard
@@ -323,6 +399,16 @@ export default function InlineChartMessage(props: Props): JSX.Element {
           )}
         </div>
       </div>
+
+      {/* Warning notes (e.g. inherited time range) */}
+      {warnings && warnings.length > 0 && (
+        <div
+          className="px-3 py-1 bg-tertiary/10 text-on-surface-variant text-xs border-b border-outline-variant"
+          data-testid="chart-warnings"
+        >
+          {warnings.join(' · ')}
+        </div>
+      )}
 
       {/* Error banner */}
       {error && (
@@ -413,7 +499,7 @@ export default function InlineChartMessage(props: Props): JSX.Element {
           )}
         </div>
         {pivotSuggestions.map((p) => (
-          <Chip key={p.id} onClick={() => onPivotClick(p)}>{p.label}</Chip>
+          <Chip key={p.label} onClick={() => onPivotClick(p)}>{p.label}</Chip>
         ))}
         <div className="flex-1" />
         <button
@@ -425,6 +511,17 @@ export default function InlineChartMessage(props: Props): JSX.Element {
           {queryEditorExpanded ? '▲ Query' : '▼ Query'}
         </button>
       </div>
+
+      {/* Save-as-dashboard inline panel (PR-C). No modal — sits below action chips. */}
+      {saveStage.kind !== 'idle' && (
+        <SavePanel
+          stage={saveStage}
+          onSaveNew={() => void doSave()}
+          onAppend={(id) => void doSave(id)}
+          onCancel={cancelSave}
+          onDismissError={cancelSave}
+        />
+      )}
 
       {/* Query editor */}
       {queryEditorExpanded && (
@@ -490,6 +587,121 @@ function MenuItem({
     >
       {children}
     </button>
+  );
+}
+
+function SavePanel({
+  stage,
+  onSaveNew,
+  onAppend,
+  onCancel,
+  onDismissError,
+}: {
+  stage: SaveStage;
+  onSaveNew: () => void;
+  onAppend: (dashboardId: string) => void;
+  onCancel: () => void;
+  onDismissError: () => void;
+}): JSX.Element | null {
+  if (stage.kind === 'idle') return null;
+  if (stage.kind === 'loading-preview') {
+    return (
+      <div
+        className="px-3 py-2 border-t border-outline-variant text-xs text-on-surface-variant"
+        data-testid="save-panel"
+      >
+        Checking for similar dashboards…
+      </div>
+    );
+  }
+  if (stage.kind === 'saving') {
+    return (
+      <div
+        className="px-3 py-2 border-t border-outline-variant text-xs text-on-surface-variant"
+        data-testid="save-panel"
+      >
+        Saving…
+      </div>
+    );
+  }
+  if (stage.kind === 'saved') {
+    return (
+      <div
+        className="px-3 py-2 border-t border-outline-variant text-xs text-on-surface flex items-center gap-2"
+        data-testid="save-panel-saved"
+      >
+        <span>✓ Saved as &lsquo;{stage.title}&rsquo;.</span>
+        <a
+          className="underline text-primary hover:opacity-80"
+          href={stage.url}
+          data-testid="save-panel-open"
+        >
+          Open
+        </a>
+      </div>
+    );
+  }
+  if (stage.kind === 'error') {
+    return (
+      <div
+        className="px-3 py-2 border-t border-outline-variant text-xs text-error flex items-center gap-2"
+        data-testid="save-panel-error"
+      >
+        <span>Save failed: {stage.message}</span>
+        <button
+          type="button"
+          className="ml-auto px-2 py-0.5 rounded border border-outline-variant"
+          onClick={onDismissError}
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+  // Preview stage.
+  const top = stage.matches[0];
+  return (
+    <div
+      className="px-3 py-2 border-t border-outline-variant text-xs space-y-2"
+      data-testid="save-panel-preview"
+    >
+      <div className="font-medium text-on-surface">Save as dashboard?</div>
+      {top ? (
+        <div className="text-on-surface-variant">
+          Found &lsquo;{top.title}&rsquo; ({top.similarityPct}% similar).
+        </div>
+      ) : (
+        <div className="text-on-surface-variant">No similar dashboards found.</div>
+      )}
+      <div className="flex items-center gap-2">
+        {top && (
+          <button
+            type="button"
+            className="px-2 py-1 rounded border border-outline-variant hover:bg-surface text-on-surface"
+            onClick={() => onAppend(top.dashboardId)}
+            data-testid="save-panel-append"
+          >
+            Add to that dashboard
+          </button>
+        )}
+        <button
+          type="button"
+          className="px-2 py-1 rounded bg-primary text-on-primary hover:opacity-90"
+          onClick={onSaveNew}
+          data-testid="save-panel-save-new"
+        >
+          {top ? 'Save as new' : 'Save as new dashboard'}
+        </button>
+        <button
+          type="button"
+          className="px-2 py-1 rounded border border-outline-variant hover:bg-surface text-on-surface-variant"
+          onClick={onCancel}
+          data-testid="save-panel-cancel"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/packages/web/src/components/__tests__/InlineChartMessage.test.tsx
+++ b/packages/web/src/components/__tests__/InlineChartMessage.test.tsx
@@ -131,9 +131,14 @@ describe('parseInlineChartPayload', () => {
   it('drops malformed pivot suggestions', () => {
     const parsed = parseInlineChartPayload({
       ...goodPayload,
-      pivotSuggestions: [{ id: 'a', label: 'A' }, { id: '', label: 'bad' }, null, { id: 'b' }],
+      pivotSuggestions: [
+        { label: 'A', prompt: 'do A' },
+        { label: 'bad' },
+        null,
+        { prompt: 'no label' },
+      ],
     });
-    expect(parsed!.pivotSuggestions).toEqual([{ id: 'a', label: 'A' }]);
+    expect(parsed!.pivotSuggestions).toEqual([{ label: 'A', prompt: 'do A' }]);
   });
 
   it('falls back to gauge for an unknown metricKind', () => {
@@ -186,7 +191,7 @@ describe('InlineChartMessage SSR', () => {
   it('renders pivot chips when suggestions are present', () => {
     const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
       ...baseProps,
-      pivotSuggestions: [{ id: 'p1', label: 'by route' }],
+      pivotSuggestions: [{ label: 'by route', prompt: 'break by route' }],
     }));
     expect(html).toContain('by route');
   });
@@ -197,5 +202,30 @@ describe('InlineChartMessage SSR', () => {
     const html = renderToStaticMarkup(React.createElement(InlineChartMessage, baseProps));
     expect(html).toContain('Query');
     expect(html).toContain('data-testid="inline-chart-message"');
+  });
+
+  it('renders inherited-range warnings when present', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
+      ...baseProps,
+      warnings: ['Inherited time range from earlier chart (3 min ago)'],
+    }));
+    expect(html).toContain('Inherited time range');
+    expect(html).toContain('data-testid="chart-warnings"');
+  });
+
+  it('renders pivot chip text using the label field (prompt is sent on click)', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, {
+      ...baseProps,
+      pivotSuggestions: [{ label: 'Show p99', prompt: 'Show p99 instead' }],
+    }));
+    expect(html).toContain('Show p99');
+    // The prompt text is bound to the click handler, not rendered as content.
+    expect(html).not.toContain('Show p99 instead');
+  });
+
+  it('does not render a save panel by default', () => {
+    const html = renderToStaticMarkup(React.createElement(InlineChartMessage, baseProps));
+    expect(html).not.toContain('data-testid="save-panel-preview"');
+    expect(html).not.toContain('data-testid="save-panel-saved"');
   });
 });

--- a/packages/web/src/hooks/useDashboardChat.ts
+++ b/packages/web/src/hooks/useDashboardChat.ts
@@ -50,8 +50,9 @@ export interface InlineChartSeries {
 }
 
 export interface InlineChartPivotSuggestion {
-  id: string;
   label: string;
+  /** Prompt sent as a new chat message when the chip is clicked. */
+  prompt: string;
 }
 
 export interface InlineChartPayload {
@@ -69,6 +70,8 @@ export interface InlineChartPayload {
   series: InlineChartSeries[];
   summary: ChartSummary;
   pivotSuggestions: InlineChartPivotSuggestion[];
+  /** Optional notes from the backend (e.g. inherited time range). */
+  warnings?: string[];
 }
 
 /**
@@ -114,12 +117,16 @@ export function parseInlineChartPayload(
     .map((p) => {
       if (!p || typeof p !== 'object') return null;
       const obj = p as Record<string, unknown>;
-      const id = typeof obj.id === 'string' ? obj.id : '';
       const label = typeof obj.label === 'string' ? obj.label : '';
-      if (!id || !label) return null;
-      return { id, label };
+      const prompt = typeof obj.prompt === 'string' ? obj.prompt : '';
+      if (!label || !prompt) return null;
+      return { label, prompt };
     })
     .filter((p): p is InlineChartPivotSuggestion => p !== null);
+
+  const warnings = Array.isArray(raw.warnings)
+    ? (raw.warnings as unknown[]).filter((w): w is string => typeof w === 'string')
+    : undefined;
 
   return {
     id: deriveInlineChartId(query, datasourceId, start, end),
@@ -131,6 +138,7 @@ export function parseInlineChartPayload(
     series,
     summary,
     pivotSuggestions,
+    ...(warnings && warnings.length > 0 ? { warnings } : {}),
   };
 }
 


### PR DESCRIPTION
Final piece of the inline-chart trio. Builds on #211 (backend) + #212 (frontend bubble).

## 3 smart layers

### 1. TimeRange implicit context

When user follows up (\"what about p99?\", \"and the errors?\"), \`metric_explore\` automatically reuses the most-recent chart's timeRange — no friction.

- New \`IChatSessionEventRepository.findLatestByKind(sessionId, kind)\` (sqlite + postgres)
- \`ActionContext.recentEventLookup\` slim function threaded from chat-service
- Handler: if \`timeRangeHint\` missing/blank → look up most recent \`inline_chart\` event → inherit its timeRange
- If found but > 5 min old: still inherit but emit \`warnings: ["Inherited time range from earlier chart (N min ago)"]\` so user sees the note
- Tool-schema description tells the LLM this is OK

### 2. Pivot suggestions (max 3 chips per chart)

\`packages/common/src/utils/chart-pivots.ts\` — per-kind rules:

| Kind | Chips |
|---|---|
| latency | p50→Show p99 / p99→Show p50+p99 / always Show errors |
| counter | Break down by status (suppressed if already by-status) / Show errors / Daily total (if rate-based) |
| gauge | Top 5 by instance (suppressed if already by-instance) / Compare yesterday |
| errors | Show request rate / Group by endpoint (if path/route token) / Show top error messages |

Wired into \`metric_explore\` handler → SSE event → frontend chip click sends the chip's \`prompt\` as a new chat message.

### 3. Save as dashboard

Inline flow (no modal):

\`\`\`
[Save as dashboard]
  ↓ (calls /api/metrics/save-as-dashboard/preview)
┌────────────────────────────────────────┐
│ Save as dashboard?                      │
│ Found 'HTTP Service Health' (78%).      │
│ [Add to that]  [Save as new]  [Cancel] │
└────────────────────────────────────────┘
  ↓
✓ Saved. [Open]
\`\`\`

- Two REST endpoints: \`/preview\` (token-Jaccard 60% threshold) + \`/save-as-dashboard\` (create or append-panel)
- Append: new panel placed below existing rows, audited as \`DashboardUpdate\`
- Create: full dashboard with one panel, audited as \`DashboardCreate\`
- Tokens normalize PromQL: lowercase + whitespace strip + sort label selectors so order doesn't matter

## Field-name fixes between PR-A/PR-B/PR-C

| Field | Was | Now |
|---|---|---|
| \`pivotSuggestions\` shape | \`{id, label}\` (PR-B placeholder) | \`{label, prompt}\` |
| \`onSaveAsDashboard\` prop stub | exists, no-op | removed; inline panel handles it |
| \`warnings\` on \`inline_chart\` SSE | absent | added; rendered as small note row |

## Test plan

- [x] \`chart-pivots\` 8 tests (per-kind rule coverage)
- [x] \`metric-explore\` 5 tests (incl. timeRange inheritance + stale warning)
- [x] \`metrics-save-as-dashboard\` 9 tests (preview matches + create + append + audit)
- [x] \`InlineChartMessage\` +4 cases (pivot click + inline save-as-dashboard panel)
- [x] Full suite 2063/2063 pass (10 skipped postgres)
- [x] build clean
- [ ] CI green

## End of inline-chart trio

After this merges:
- User types "show me p50 latency" → agent renders interactive chart inline
- Drag to zoom; chips to pivot; PromQL editor for exact tweaks
- "What about p99?" → new chart with same time range (no user-typed range)
- "Save this" → matched against existing dashboards inline; 2 clicks to land
- Replay on chat reload: read persisted series; refresh on chip click