### PR TITLE
fix(prompt): route 'show me a metric' to metric_explore

### DIFF
--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -45,10 +45,13 @@ function getSystemSection(): string {
 
 function getDoingTasksSection(): string {
   return `# Doing Tasks
-Requests fall into four shapes: build something (dashboard / alert), investigate something ("why is X"), analyze data ("what's happening with Y"), or open an existing resource ("show me X"). Pick the shape first, then follow the pattern.
+Requests fall into five shapes: build something (dashboard / alert), investigate something ("why is X"), analyze data ("what's happening with Y"), open an existing resource ("show me my dashboards"), or explore a metric value ("show me p50 latency"). Pick the shape first, then follow the pattern.
 
 ## Decision flow before any tool call
-1. **Open vs create** — "open X" / "show X" / "go to X" / "打开 X" / "看一下 X" means OPEN an existing resource. List first (dashboard_list / investigation_list / alert_rule_list) with a filter keyword, then navigate. Only create new if the search finds nothing AND the wording implies creation.
+1. **Disambiguate "show me"** — three variants, each goes to a different tool:
+   - **Metric value** — "show me p50 latency" / "what is the request rate" / "current CPU usage" / "现在的 p99 多少" → use \`metric_explore\`. It renders an interactive chart inline in chat. Do NOT use \`metrics_query\` / \`metrics_range_query\` for these — the user must see a chart, not a markdown table. Don't describe the chart's contents in your reply afterward; the chart is the answer.
+   - **Existing resource** — "open the ingress dashboard" / "show me my investigations" / "打开 X" → list first (\`dashboard_list\` / \`investigation_list\` / \`alert_rule_list\`) with a filter keyword, then navigate.
+   - **Create** — only when wording clearly implies a new persistent artifact ("create a dashboard for…", "build an alert that…"). Never default to create when the user might mean show.
 2. **Which connector** — every metrics/logs/changes call requires an explicit \`sourceId\`. Call \`connectors_list\` first. If multiple same-signal connectors exist and the user's intent is ambiguous, ask which one before querying.
 3. **Ops connector first** — cluster/Kubernetes questions require a configured Ops connector. If no connector is configured, say it is not connected; do not invent a cluster. Read-only commands may run through \`ops_run_command\` with \`intent="read"\`; write/mutating commands must use \`intent="propose"\` so the connector returns an approval/proposal unless an approved execution is explicitly being run.
 4. **Read before mutate** — mutation tools (dashboard_create / add_panels / modify_panel / alert_rule_write / investigation_add_section) need prerequisites verified. Before removing panels, check panel IDs from Dashboard State. Before creating alerts, discover/query/validate the metric and pass a complete structured \`spec\`; alert_rule_write does not generate the rule for you.
@@ -103,7 +106,8 @@ function getActionsSection(): string {
 Carefully consider the reversibility and blast radius of each tool call before invoking it. The tools below are categorized by how much can go wrong if you call them at the wrong moment.
 
 ## Reversible / low-cost — call freely when they help
-- \`metrics_query\` / \`metrics_range_query\` / \`metrics_discover\` / \`metrics_validate\` / \`logs_search\` / \`changes_list_recent\` / \`web_search\` / \`alert_rule_history\` — pure reads. No state change, no operator-visible side effect.
+- \`metric_explore\` — primary surface for "show me / what is / how is" a metric. Renders an interactive chart inline in chat; the user can zoom, change time range, and pivot via chips without further tool calls. Cheap read.
+- \`metrics_query\` / \`metrics_range_query\` / \`metrics_discover\` / \`metrics_validate\` / \`logs_search\` / \`changes_list_recent\` / \`web_search\` / \`alert_rule_history\` — pure reads. No state change, no operator-visible side effect. Use these for internal analysis (e.g. inside an investigation), NOT to answer a user "show me" question — for that, \`metric_explore\` is the right tool.
 - \`investigation_create\` / \`investigation_add_section\` — accumulate a draft report in agent memory. Nothing is persisted to the operator-visible workspace until \`investigation_complete\` writes the final row.
 - \`remediation_plan_create\` / \`remediation_plan_create_rescue\` — create a plan record in \`pending_approval\` status. NO cluster mutations happen until a human opens the approval and clicks Approve. Treat creating a plan like saving a draft for review.
 - \`ops_run_command\` with \`intent="read"\` — kubectl get/describe/logs against an attached connector; no cluster state change.
@@ -157,14 +161,31 @@ User: "Create a monitoring dashboard for our new Redis deployment"
   4. final reply (plain text): "Created Redis dashboard with 3 panels. Expects metrics from redis_exporter — deploy it alongside Redis."
 </example>
 
+## Showing a metric value (ad-hoc chart)
+<example>
+User: "Show me p50 http request latency"
+  1. connectors_list(signalType: "metrics") → id: prom-prod
+  2. metric_explore(query: "histogram_quantile(0.5, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency", datasourceId: "prom-prod")
+     → emits inline chart; returns one-line summary
+  3. final reply (plain text): one short sentence acknowledging the chart appeared and what it showed at a glance. NEVER describe the chart's values in detail — the chart is the answer.
+</example>
+
+<example>
+User (follow-up in same session): "What about p99?"
+  1. metric_explore(query: "histogram_quantile(0.99, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency")
+     ← omit timeRangeHint so the handler inherits the previous chart's time window automatically.
+  2. final reply: one sentence connecting the new chart to the prior one (e.g. "p99 sits roughly 5x p50 over the same window").
+</example>
+
 ## Explaining / Analyzing Panel Data
 <example>
-User: "Analyze the request rate by handler data"
+User: "Analyze the request rate by handler data" (within an investigation or a panel-analysis flow)
   1. connectors_list(signalType: "metrics") → id: prom-prod
   2. metrics_query(sourceId: "prom-prod", query: "topk(5, sum(rate(http_requests_total[5m])) by (handler))")
      → /api/v1/query: 2.3, /api/v1/label: 1.1, /metrics: 0.8, ...
   3. final reply (plain text): "Top 5 handlers by traffic: /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic stable, no anomalies."
 </example>
+Use \`metrics_query\` here (not \`metric_explore\`) because the caller wants a numeric breakdown, not an interactive chart. For a plain "show me X" question from the user, prefer \`metric_explore\`.
 
 ## Modifying Panels
 <example>


### PR DESCRIPTION
**Bug**: user said \"show me p50 http request latency\" → agent ran \`metrics_query\` and replied with a markdown table. The inline chart feature (#211/#212/#213) shipped but the LLM didn't pick the right tool.

**Root cause**: tool schema alone can't override the existing system-prompt language. Original Decision flow #1 lumped \"show me\" into the *open existing resource* branch (\"show X means OPEN\"), which the LLM applied to metric questions too.

## Changes (style-matched to existing prompt structure)

1. **Intro**: 4 shapes → 5 (added \"explore a metric value\")
2. **Decision flow #1**: rewritten as \"Disambiguate 'show me'\" with three explicit branches (metric value → \`metric_explore\` / existing resource → list+navigate / create). Direct prohibition: \"Do NOT use \`metrics_query\` / \`metrics_range_query\` for these — the user must see a chart, not a markdown table.\"
3. **Actions / Reversible**: \`metric_explore\` promoted to first bullet with what-it-does note. \`metrics_query\` bullet now ends \"use these for internal analysis (e.g. inside an investigation), NOT to answer a user show-me question.\"
4. **Examples**: two new examples (\"Showing a metric value\" + follow-up showing timeRange inheritance) before the existing \"Analyzing Panel Data\" example. That existing example gets a footer line clarifying when to use \`metrics_query\` vs \`metric_explore\`.

## Test plan

- [x] 22/22 \`orchestrator-prompt\` tests pass
- [x] build clean
- [ ] CI green
- [ ] Manual: ask \"show me p50 http latency\" → chart bubble appears (not text)