### PR TITLE
fix(home): render inline_chart in Home's chat block switch

### DIFF
--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import {
   ErrorMessage,
 } from '../components/chat/MessageComponents.js';
 import AgentActivityBlock from '../components/chat/AgentActivityBlock.js';
+import InlineChartMessage from '../components/InlineChartMessage.js';
 import { RoundsLogo } from '../components/RoundsLogo.js';
 
 // Types
@@ -410,6 +411,24 @@ export default function Home() {
                   <ErrorMessage
                     key={evt.id}
                     content={evt.content ?? 'An error occurred'}
+                  />
+                );
+              }
+              if (evt.kind === 'inline_chart' && evt.inlineChart) {
+                const c = evt.inlineChart;
+                return (
+                  <InlineChartMessage
+                    key={evt.id}
+                    id={c.id}
+                    initialQuery={c.query}
+                    initialTimeRange={c.timeRange}
+                    initialSeries={c.series}
+                    initialSummary={c.summary}
+                    metricKind={c.metricKind}
+                    datasourceId={c.datasourceId}
+                    pivotSuggestions={c.pivotSuggestions}
+                    warnings={c.warnings}
+                    onSendMessage={sendMessage}
                   />
                 );
               }


### PR DESCRIPTION
**Bug**: agent calls \`metric_explore\` → chart payload reaches state → Home's block-render returns null → no chart visible. Only the agent's text reply ("p50 延迟的图表已展示, 约 3014ms") shows up.

**Root cause**: Home has its own \`blocks.map\` switch (independent of \`ChatPanel\`) covering only \`error\` / user-message / assistant-message kinds. The \`inline_chart\` kind has no branch → falls through → returns null.

**Fix**: add the missing \`inline_chart\` branch, mirroring \`ChatPanel.tsx:248-264\` prop wiring exactly. Pivot chips call back into \`sendMessage\` for the "Show p99" follow-up flow.

## Test plan

- [x] build clean
- [ ] CI green
- [ ] Manual: ask "show me p50 http latency" → chart bubble appears under the agent's brief reply