### PR TITLE
fix(metrics): raise inline-chart rate limit 30→240/min

### DIFF
--- a/packages/api-gateway/src/routes/metrics-query.test.ts
+++ b/packages/api-gateway/src/routes/metrics-query.test.ts
@@ -161,8 +161,8 @@ describe('POST /api/metrics/query', () => {
       now: () => t,
     });
 
-    // 30 allowed — burn them all.
-    for (let i = 0; i < 30; i++) {
+    // 240 allowed — burn them all.
+    for (let i = 0; i < 240; i++) {
       const res = await request(app)
         .post('/api/metrics/query')
         .send({ query: 'up', timeRange: { relative: '1h' } });

--- a/packages/api-gateway/src/routes/metrics-query.ts
+++ b/packages/api-gateway/src/routes/metrics-query.ts
@@ -8,7 +8,7 @@
  *
  * Auth: requires `connectors:query` permission on the datasource (Rounds'
  * closest analog to "metrics:read" — see packages/common/src/rbac/actions.ts).
- * Rate limit: 30 queries/min per user per datasource (in-memory token bucket).
+ * Rate limit: 240 queries/min per user per datasource (in-memory token bucket).
  */
 
 import { Router } from 'express';
@@ -49,12 +49,17 @@ export interface MetricsQueryRouterDeps {
 }
 
 // -- Rate limit (per user per datasource, in-memory token bucket) ----------
-// 30 queries/min — same shape as a simple sliding window. We keep it
-// in-memory because the surface is "throwaway exploration in chat"; a
-// per-process counter is fine. If we ever need cross-replica coherence we
-// can swap in the Redis bucket the connector-test surface uses.
+// 240 queries/min — at one every 0.25s this is way past human pacing for
+// drag-zoom / chip-switch / chip-pivot bursts, but still catches a runaway
+// browser bug or a leaked retry loop. Per-process is fine since the
+// surface is "throwaway exploration in chat" and multi-replica setups can
+// migrate to the Redis bucket later.
+//
+// History: initial value was 30/min, which a real user hit in 15s by
+// clicking through a few time-range chips. The chart UI is designed for
+// fast iteration; the limit must not be felt by humans.
 
-const RATE_LIMIT_PER_MIN = 30;
+const RATE_LIMIT_PER_MIN = 240;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
 interface BucketEntry {


### PR DESCRIPTION
**Bug**: user hit "Rate limit exceeded: 30/min per datasource" banner after a few interactions on a chart (drag zoom + chip clicks). 30/min was the initial estimate ("way more than humans can use") — wrong.

**Fix**: bump to 240/min (= 4/s). Past human pacing for any plausible burst; still catches runaway browser bugs / leaked retry loops.

Per-user per-datasource scope unchanged. In-memory bucket unchanged. Single-replica today; Redis migration is the path when we go multi-replica.

## Test plan

- [x] 5/5 metrics-query tests pass (test updated for new 240 threshold)
- [x] build clean
- [ ] CI green
- [ ] Manual: chart + 10+ chip clicks should not hit the banner