### PR TITLE
fix(viz): chart zoom callback uses setSelect, not setScale — kills infinite re-query loop

### DIFF
--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -529,14 +529,22 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
       }
     };
 
-    const setScaleHook = (u: uPlot, scaleKey: string): void => {
-      if (scaleKey !== 'x') return;
+    // User-initiated zoom only: `setSelect` fires when the user releases a
+    // drag-selection on the chart. We deliberately avoid `setScale` here —
+    // `setScale` ALSO fires whenever uPlot re-derives the X scale from new
+    // data, which means feeding the chart fresh series after a re-query
+    // would re-fire the zoom callback → re-trigger the same fetch → infinite
+    // loop (observed: 240 queries/min until the rate limiter cut in).
+    // `setSelect` is keyed to user input, not data updates.
+    const setSelectHook = (u: uPlot): void => {
       const cb = onZoomRef.current;
       if (!cb) return;
-      const xScale = u.scales.x;
-      if (!xScale || xScale.min === undefined || xScale.max === undefined) return;
-      if (xScale.min === null || xScale.max === null) return;
-      cb(xScale.min, xScale.max);
+      const sel = u.select;
+      if (!sel || sel.width <= 0) return;
+      const fromMs = u.posToVal(sel.left, 'x');
+      const toMs = u.posToVal(sel.left + sel.width, 'x');
+      if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) return;
+      cb(fromMs, toMs);
     };
 
     const merged: uPlot.Options = {
@@ -564,9 +572,9 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
           ...((base.hooks?.setCursor as Array<(u: uPlot) => void> | undefined) ?? []),
           setCursor,
         ],
-        setScale: [
-          ...((base.hooks?.setScale as Array<(u: uPlot, k: string) => void> | undefined) ?? []),
-          setScaleHook,
+        setSelect: [
+          ...((base.hooks?.setSelect as Array<(u: uPlot) => void> | undefined) ?? []),
+          setSelectHook,
         ],
       },
       legend: { show: false },


### PR DESCRIPTION
**Bug**: chart bubble emits ~4 queries/sec until rate limiter (240/min) cuts in. Real infinite loop.

**Root cause**: TimeSeriesViz wired zoom callback into uPlot \`setScale\` hook. \`setScale\` fires on **every** X-scale change — including the one uPlot does automatically when fresh data is fed in after a re-query.

Trace:
1. Chart mounts → uPlot computes X scale → \`setScale\` fires → onZoom → \`runQuery\` → fetch
2. Fetch resolves → \`setSeries(data.series)\` → TimeSeriesViz re-renders → uPlot re-derives X scale → \`setScale\` fires AGAIN → onZoom → fetch
3. → loop

This loop existed since the chart shipped (PR #212). The earlier 30/min rate limit caught it after ~8 seconds, which I misdiagnosed as "30 is too low for normal use" and raised to 240 (#216). 240 just took longer to hit. **#216 is also a real improvement (drag bursts shouldn't get throttled) but doesn't fix the loop.**

**Fix**: switch from \`setScale\` to \`setSelect\` hook. \`setSelect\` fires only when the user releases a drag-select gesture — the actual "I want to zoom" signal. Data updates don't synthesize select regions, so the callback no longer chains.

Drag-to-zoom UX is preserved — \`cursor.drag.setScale: true\` still makes uPlot visually zoom on release.

## Test plan

- [x] 149/149 viz + InlineChartMessage tests pass
- [x] build clean
- [ ] CI green
- [ ] Manual: open chart → no banner appears spontaneously; drag-select on chart → zooms (one fetch); click "Last 6h" → one fetch