### PR TITLE
fix(api-gateway): wire setPipelineRunning into pipeline boot/shutdown so /ready reports correctly

### DIFF
--- a/packages/api-gateway/src/app/alerts-boot.ts
+++ b/packages/api-gateway/src/app/alerts-boot.ts
@@ -30,6 +30,7 @@ import {
   type ConsumerInvestigationStore,
 } from '../services/auto-investigation-consumer.js';
 import { LeaderLock } from '../services/leader-lock.js';
+import { setPipelineRunning } from '../routes/health.js';
 import {
   resolvePrometheusConnector,
   type PrometheusConnector,
@@ -273,6 +274,7 @@ export async function startAlerts(deps: MountAlertsDeps): Promise<{
   // Listener wiring is done — now safe to start the evaluator.
   await evaluator.start();
   log.info('alert evaluator started');
+  setPipelineRunning(true);
 
   return {
     evaluator,
@@ -280,6 +282,7 @@ export async function startAlerts(deps: MountAlertsDeps): Promise<{
     stop: () => {
       consumer?.stop();
       evaluator.stop();
+      setPipelineRunning(false);
     },
   };
 }

--- a/packages/api-gateway/src/routes/health.test.ts
+++ b/packages/api-gateway/src/routes/health.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for /api/health/ready — verifies setPipelineRunning toggles the
+ * proactive-pipeline check that drives the `degraded` vs `healthy` status.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { healthRouter, setPipelineRunning } from './health.js';
+
+function makeApp() {
+  const app = express();
+  app.use('/api/health', healthRouter);
+  return app;
+}
+
+describe('GET /api/health/ready', () => {
+  afterEach(() => {
+    setPipelineRunning(false);
+  });
+
+  it('returns degraded before setPipelineRunning(true) is called', async () => {
+    const res = await request(makeApp()).get('/api/health/ready');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('degraded');
+    expect(res.body.checks.proactive.status).toBe('fail');
+  });
+
+  it('returns healthy once setPipelineRunning(true) is called', async () => {
+    setPipelineRunning(true);
+    const res = await request(makeApp()).get('/api/health/ready');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('healthy');
+    expect(res.body.checks.proactive.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

`/api/health/ready` was permanently `degraded` because `setPipelineRunning(true)` in `packages/api-gateway/src/routes/health.ts` had **zero source callers** — only `dist/` copies. The proactive-pipeline boot path never marked itself ready.

- Call `setPipelineRunning(true)` in `startAlerts` right after `await evaluator.start()` succeeds.
- Call `setPipelineRunning(false)` in the returned `stop()` so a graceful shutdown reflects the transition.
- The `ALERT_EVALUATOR_ENABLED=false` early-return path leaves the flag `false` by design — that deployment has no proactive pipeline to be "ready".

## Before / After

Before (cold-started api-gateway, evaluator running):
```
$ curl -s localhost:3000/api/health/ready | jq
{
  "status": "degraded",
  "checks": {
    "db": { "status": "skip", "message": "No DB configured" },
    "redis": { "status": "skip", "message": "No Redis configured" },
    "proactive": { "status": "fail", "message": "Proactive pipeline not running" }
  },
  "timestamp": "..."
}
```

After:
```
$ curl -s localhost:3000/api/health/ready | jq
{
  "status": "healthy",
  "checks": {
    "db": { "status": "skip", "message": "No DB configured" },
    "redis": { "status": "skip", "message": "No Redis configured" },
    "proactive": { "status": "ok" }
  },
  "timestamp": "..."
}
```

## Test plan

- [x] New `packages/api-gateway/src/routes/health.test.ts`: `/ready` returns `degraded` before `setPipelineRunning(true)` and `healthy` after.
- [x] Existing `alerts-boot.test.ts` still passes (5/5).
- [x] `tsc --build packages/api-gateway` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health status endpoint now accurately reflects current pipeline operational state, returning healthy or degraded status accordingly

* **Tests**
  * Added test coverage for health check endpoint validation across different pipeline states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->