### PR TITLE
fix(agent-core): wire remediation_plan_create + folder_create end-to-end

### DIFF
--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -37,6 +37,8 @@ agentRegistry.register({
     // applies a 'rearrange' action internally for layout). Until a real
     // handler lands, keep it out of the LLM-facing tool surface.
     'dashboard_add_variable', 'dashboard_set_title',
+    // Folder lifecycle
+    'folder_create', 'folder_list',
     // Investigation lifecycle
     'investigation_create', 'investigation_list',
     'investigation_add_section',
@@ -54,6 +56,8 @@ agentRegistry.register({
     'changes_list_recent',
     // Kubernetes / Ops integrations (requires configured connector + RBAC)
     'ops_run_command',
+    // Remediation plans — proposal only; PlanExecutorService runs approved steps
+    'remediation_plan_create', 'remediation_plan_create_rescue',
     // Knowledge
     'web_search',
     // Alert rules
@@ -66,6 +70,8 @@ agentRegistry.register({
     'setting_get', 'setting_set',
     // Lazy tool loading — fetches deferred schemas on demand
     'tool_search',
+    // Clarifying question — terminal tool handled inside ReActLoop
+    'ask_user',
   ],
   inputKinds: ['dashboard'],
   outputKinds: ['dashboard', 'panel', 'dashboard_variable', 'investigation_report', 'alert_rule'],

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -29,6 +29,8 @@ export type AgentToolName =
   | 'changes_list_recent'
   // Kubernetes / Ops integrations
   | 'ops_run_command'
+  // Remediation plans (proposal-only; PlanExecutorService runs approved steps)
+  | 'remediation_plan_create' | 'remediation_plan_create_rescue'
   // Connector discovery (always-allowed, no RBAC)
   | 'connectors_list' | 'connectors_suggest' | 'connectors_pin' | 'connectors_unpin'
   // Connector-model setup and allowlisted org settings
@@ -39,7 +41,9 @@ export type AgentToolName =
   | 'web_search' | 'llm.complete'
   | 'verifier.run'
   // Lazy tool loading (fetches deferred-tool schemas on demand)
-  | 'tool_search';
+  | 'tool_search'
+  // Clarifying question — terminal tool handled inside ReActLoop
+  | 'ask_user';
 
 export type ArtifactKind =
   | 'dashboard' | 'panel' | 'dashboard_variable'

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -180,6 +180,24 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
   'changes_list_recent': () =>
     ac.eval('investigations:read', 'investigations:*'),
 
+  // -- Remediation plans (proposal only) ----------------------------------
+  // A plan is a write proposal attached to an investigation; the per-step
+  // kubectl run is re-gated at execution time by PlanExecutorService via
+  // ops_run_command. Here we mirror investigation_add_section — the proposer
+  // must have investigations:write on the parent investigation. Rescue plans
+  // share the gate because they belong to the same investigation as the
+  // primary plan they pair with.
+  'remediation_plan_create': (args: Record<string, unknown>) =>
+    ac.eval(
+      'investigations:write',
+      `investigations:uid:${String(args.investigationId ?? '*')}`,
+    ),
+  'remediation_plan_create_rescue': (args: Record<string, unknown>) =>
+    ac.eval(
+      'investigations:write',
+      `investigations:uid:${String(args.investigationId ?? '*')}`,
+    ),
+
   // -- Kubernetes / Ops integrations --------------------------------------
   'ops_run_command': (args: Record<string, unknown>) =>
     ac.any(

--- a/packages/agent-core/src/agent/tool-schema-registry.test.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { TOOL_REGISTRY } from './tool-schema-registry.js';
+import { agentRegistry } from './agent-registry.js';
+import { TOOL_PERMS, UNGATED_TOOLS } from './tool-permissions.js';
 
 describe('tool-schema-registry', () => {
   // Provider compatibility: OpenAI / Anthropic / Gemini / DeepSeek / Mistral
@@ -55,5 +57,66 @@ describe('tool-schema-registry', () => {
       .filter(([, entry]) => 'extendedPrompt' in entry)
       .map(([name]) => name);
     expect(offenders).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------
+  // End-to-end reachability invariants. Until these passed, several tools
+  // (remediation_plan_create, folder_create/_list, ask_user) had a handler
+  // wired but were silently absent from the model's tool surface because
+  // they weren't listed in any agent's allowedTools. The invariants below
+  // catch that drift at startup-time CI rather than at user-facing failure.
+  // ---------------------------------------------------------------------
+  it('every TOOL_REGISTRY tool is referenced by at least one agent allowedTools', () => {
+    const referenced = new Set<string>();
+    for (const def of agentRegistry.getAll()) {
+      for (const tool of def.allowedTools) referenced.add(tool);
+    }
+    const orphans = Object.keys(TOOL_REGISTRY).filter((name) => !referenced.has(name));
+    expect(orphans).toEqual([]);
+  });
+
+  it('every TOOL_PERMS entry is referenced by at least one agent allowedTools', () => {
+    const referenced = new Set<string>();
+    for (const def of agentRegistry.getAll()) {
+      for (const tool of def.allowedTools) referenced.add(tool);
+    }
+    const orphans = Object.keys(TOOL_PERMS).filter((name) => {
+      if (referenced.has(name)) return false;
+      // dashboard_rearrange has a TOOL_PERMS entry but is intentionally not
+      // in any agent allowedTools (no handler exists yet — see comment in
+      // agent-registry.ts). Skip it explicitly so the invariant doesn't
+      // flag a known carve-out.
+      if (name === 'dashboard_rearrange') return false;
+      return true;
+    });
+    expect(orphans).toEqual([]);
+  });
+
+  it('every non-internal allowedTools entry has a TOOL_REGISTRY schema', () => {
+    // NON_LLM_TOOLS in tool-schema-registry.ts are internal (llm.complete,
+    // verifier.run) and intentionally have no schema. Everything else MUST.
+    const INTERNAL = new Set<string>(['llm.complete', 'verifier.run']);
+    const missing: { agent: string; tool: string }[] = [];
+    for (const def of agentRegistry.getAll()) {
+      for (const tool of def.allowedTools) {
+        if (INTERNAL.has(tool)) continue;
+        if (!TOOL_REGISTRY[tool]) missing.push({ agent: def.type, tool });
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every non-internal allowedTools entry is gated or ungated (no silent unknown_tool deny)', () => {
+    const INTERNAL = new Set<string>(['llm.complete', 'verifier.run']);
+    const ungated: { agent: string; tool: string }[] = [];
+    for (const def of agentRegistry.getAll()) {
+      for (const tool of def.allowedTools) {
+        if (INTERNAL.has(tool)) continue;
+        if (UNGATED_TOOLS.has(tool)) continue;
+        if (TOOL_PERMS[tool]) continue;
+        ungated.push({ agent: def.type, tool });
+      }
+    }
+    expect(ungated).toEqual([]);
   });
 });

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -578,6 +578,43 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   },
 
   // -------------------------------------------------------------------------
+  // Folder lifecycle — organize dashboards/alerts. The handler runs against
+  // the configured folder backend (Grafana-shaped today).
+  // -------------------------------------------------------------------------
+  'folder_create': {
+    category: 'deferred',
+    schema: {
+      name: 'folder_create',
+      description:
+        'Create a folder for organizing dashboards or alert rules. Returns the new folder uid. Use ONLY when the user explicitly asks to create a folder; do NOT pre-create folders for dashboard_create / alert_rule_write (those default to wildcard / "alerts" when folderUid is omitted).',
+      input_schema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', description: 'Folder title shown in the UI' },
+          parentUid: { type: 'string', description: 'Optional parent folder uid for nested folders. Omit for top-level.' },
+        },
+        required: ['title'],
+      },
+    },
+  },
+  'folder_list': {
+    category: 'deferred',
+    schema: {
+      name: 'folder_list',
+      description:
+        'List folders. Use when the user asks "what folders exist" or to discover a folderUid to pass into dashboard_create / alert_rule_write.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          parentUid: { type: 'string', description: 'Optional parent uid to list children of one folder. Omit for top-level.' },
+          limit: { type: 'integer', description: 'Maximum rows to return (default 50)' },
+        },
+        required: [],
+      },
+    },
+  },
+
+  // -------------------------------------------------------------------------
   // Investigation lifecycle
   // -------------------------------------------------------------------------
   'investigation_create': {


### PR DESCRIPTION
## Summary

A handful of agent tools were registered in some layers but missing from others, so they never reached the LLM:

- `remediation_plan_create` / `remediation_plan_create_rescue` — handler + runner case + schema present, but absent from `AgentToolName`, orchestrator `allowedTools`, and `TOOL_PERMS`.
- `folder_create` / `folder_list` — handler + runner case + `TOOL_PERMS` present, but absent from `TOOL_REGISTRY` (schema) and orchestrator `allowedTools`.
- `ask_user` — schema present and treated as terminal by `ReActLoop`, but absent from orchestrator `allowedTools` so layer-1 denied it on every call.

Fix is surgical: add the missing entries in each layer and a startup-time catalog invariant test that fails CI on the next drift.

## Registration matrix

| Tool | TOOL_REGISTRY | allowedTools | runner case | TOOL_PERMS / UNGATED | AgentToolName |
|---|---|---|---|---|---|
| `remediation_plan_create` (before) | yes | **no** | yes | **no** | **no** |
| `remediation_plan_create` (after) | yes | yes | yes | yes (`investigations:write`) | yes |
| `remediation_plan_create_rescue` (before) | yes | **no** | yes | **no** | **no** |
| `remediation_plan_create_rescue` (after) | yes | yes | yes | yes (`investigations:write`) | yes |
| `folder_create` (before) | **no** | **no** | yes | yes | yes |
| `folder_create` (after) | yes | yes | yes | yes | yes |
| `folder_list` (before) | **no** | **no** | yes | yes | yes |
| `folder_list` (after) | yes | yes | yes | yes | yes |
| `ask_user` (before) | yes | **no** | terminal in ReActLoop | UNGATED | **no** |
| `ask_user` (after) | yes | yes | terminal in ReActLoop | UNGATED | yes |

The `remediation_plan_create` permission scope mirrors `investigation_add_section` because a plan attaches to an investigation; execution-time gating of the kubectl steps is unchanged (PlanExecutorService re-checks ops perms per step).

## Test plan
- [x] `npm run build` — green
- [x] `npx vitest run` — 2067 tests pass, 10 skipped
- [x] New invariants in `tool-schema-registry.test.ts`:
  - every `TOOL_REGISTRY` tool is referenced by some agent `allowedTools`
  - every `TOOL_PERMS` entry is referenced by some agent `allowedTools` (with `dashboard_rearrange` carve-out — handler not yet implemented)
  - every non-internal `allowedTools` entry has a schema in `TOOL_REGISTRY`
  - every non-internal `allowedTools` entry is either in `TOOL_PERMS` or `UNGATED_TOOLS` (catches the silent `agent:unknown_tool` deny-sentinel path)