### PR TITLE
fix(data-layer,agent-core): stop swallowing parse/guardrail errors silently

### DIFF
--- a/packages/data-layer/src/repository/sqlite/alert-rule.test.ts
+++ b/packages/data-layer/src/repository/sqlite/alert-rule.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { createTestDb } from '../../test-support/test-db.js';
 import { AlertRuleRepository } from './alert-rule.js';
@@ -374,6 +375,16 @@ describe('AlertRuleRepository', () => {
       expect(await repo.deletePolicy(p.id)).toBe(true);
       expect(await repo.findPolicyById(p.id)).toBeUndefined();
       expect(await repo.deletePolicy(p.id)).toBe(false);
+    });
+  });
+
+  // P1 — corrupt JSON columns must throw (was silently returning a default
+  // condition with threshold=0, which silently disarmed the alert).
+  describe('corrupt JSON guard', () => {
+    it('findById throws when the condition column is corrupt instead of returning threshold=0', async () => {
+      const rule = await repo.create(sampleInput());
+      db.run(sql`UPDATE alert_rules SET condition = ${'{not json'} WHERE id = ${rule.id}`);
+      await expect(repo.findById(rule.id)).rejects.toThrow(/corrupt JSON in column "condition"/);
     });
   });
 });

--- a/packages/data-layer/src/repository/sqlite/alert-rule.ts
+++ b/packages/data-layer/src/repository/sqlite/alert-rule.ts
@@ -32,6 +32,7 @@
 
 import { sql, type SQL } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
+import { createLogger } from '@agentic-obs/common/logging';
 import type {
   AlertRule,
   AlertRuleState,
@@ -48,6 +49,8 @@ import type {
 } from '../interfaces.js';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { nowIso } from './instance-shared.js';
+
+const log = createLogger('alert-rule-repository');
 
 // -- Row shapes (snake_case, matches `SELECT *` output) ----------------
 
@@ -115,16 +118,30 @@ interface PolicyRow {
 // -- JSON helpers -----------------------------------------------------
 
 /**
- * Parse a JSON column with a fallback. A corrupt row must not wedge the
- * repo — we log nothing here (route layer will surface the problem) and
- * return the default shape so callers get a well-formed object.
+ * Parse a JSON column. Corrupt rows are surfaced — silent fallback masked
+ * production data corruption (e.g. an unparseable `condition` would have
+ * returned threshold=0, silently disarming the alert). We log the row id +
+ * column and re-throw so the route layer fails loud.
  */
-function parseJsonOr<T>(raw: string | null | undefined, dflt: T): T {
+function parseJsonOr<T>(
+  raw: string | null | undefined,
+  dflt: T,
+  rowId: string,
+  column: string,
+): T {
   if (raw === null || raw === undefined || raw === '') return dflt;
   try {
     return JSON.parse(raw) as T;
-  } catch {
-    return dflt;
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in alert-rule row — refusing to return fallback',
+    );
+    throw new Error(
+      `[AlertRuleRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }
 
@@ -140,7 +157,7 @@ function stringifyJsonOrNull(value: unknown): string | null {
 // -- Row → domain mappers ---------------------------------------------
 
 function rowToRule(r: RuleRow): AlertRule {
-  const labels = parseJsonOr<Record<string, string> | null>(r.labels, null);
+  const labels = parseJsonOr<Record<string, string> | null>(r.labels, null, r.id, 'labels');
   const rule: AlertRule = {
     id: r.id,
     name: r.name,
@@ -150,7 +167,7 @@ function rowToRule(r: RuleRow): AlertRule {
       operator: '>',
       threshold: 0,
       forDurationSec: 0,
-    }),
+    }, r.id, 'condition'),
     evaluationIntervalSec: r.evaluation_interval_sec,
     severity: r.severity as AlertRule['severity'],
     state: r.state as AlertRuleState,
@@ -169,7 +186,7 @@ function rowToRule(r: RuleRow): AlertRule {
   if (r.workspace_id !== null) rule.workspaceId = r.workspace_id;
   if (r.last_evaluated_at !== null) rule.lastEvaluatedAt = r.last_evaluated_at;
   if (r.last_fired_at !== null) rule.lastFiredAt = r.last_fired_at;
-  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null);
+  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null, r.id, 'provenance');
   if (prov) rule.provenance = prov;
   return rule;
 }
@@ -184,7 +201,7 @@ function rowToHistoryEntry(r: HistoryRow): AlertHistoryEntry {
     value: r.value,
     threshold: r.threshold,
     timestamp: r.timestamp,
-    labels: parseJsonOr<Record<string, string>>(r.labels, {}),
+    labels: parseJsonOr<Record<string, string>>(r.labels, {}, r.id, 'history.labels'),
   };
 }
 
@@ -198,7 +215,7 @@ function computeSilenceStatus(silence: { startsAt: string; endsAt: string }): Si
 function rowToSilence(r: SilenceRow): AlertSilence {
   const base = {
     id: r.id,
-    matchers: parseJsonOr<AlertSilence['matchers']>(r.matchers, []),
+    matchers: parseJsonOr<AlertSilence['matchers']>(r.matchers, [], r.id, 'silence.matchers'),
     startsAt: r.starts_at,
     endsAt: r.ends_at,
     comment: r.comment,
@@ -212,12 +229,12 @@ function rowToPolicy(r: PolicyRow): NotificationPolicy {
   const p: NotificationPolicy = {
     id: r.id,
     name: r.name,
-    matchers: parseJsonOr<NotificationPolicy['matchers']>(r.matchers, []),
-    channels: parseJsonOr<NotificationPolicy['channels']>(r.channels, []),
+    matchers: parseJsonOr<NotificationPolicy['matchers']>(r.matchers, [], r.id, 'policy.matchers'),
+    channels: parseJsonOr<NotificationPolicy['channels']>(r.channels, [], r.id, 'policy.channels'),
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
-  if (r.group_by !== null) p.groupBy = parseJsonOr<string[]>(r.group_by, []);
+  if (r.group_by !== null) p.groupBy = parseJsonOr<string[]>(r.group_by, [], r.id, 'policy.group_by');
   if (r.group_wait_sec !== null) p.groupWaitSec = r.group_wait_sec;
   if (r.group_interval_sec !== null) p.groupIntervalSec = r.group_interval_sec;
   if (r.repeat_interval_sec !== null) p.repeatIntervalSec = r.repeat_interval_sec;
@@ -313,7 +330,7 @@ export class AlertRuleRepository implements IAlertRuleRepository {
     if (filter.search) {
       const q = filter.search.toLowerCase();
       rows = rows.filter((r) => {
-        const labels = parseJsonOr<Record<string, string>>(r.labels, {});
+        const labels = parseJsonOr<Record<string, string>>(r.labels, {}, r.id, 'labels');
         return (
           r.name.toLowerCase().includes(q)
           || r.description.toLowerCase().includes(q)

--- a/packages/data-layer/src/repository/sqlite/dashboard.test.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { createTestDb } from '../../test-support/test-db.js';
 import { DashboardRepository } from './dashboard.js';
@@ -333,5 +334,16 @@ describe('DashboardRepository', () => {
     await expect(repo.loadJSON('not an array')).resolves.toBeUndefined();
     await expect(repo.loadJSON({ id: 'x' })).resolves.toBeUndefined();
     expect(await repo.size()).toBe(0);
+  });
+
+  // P1 — corrupt JSON columns must NOT be silently replaced with an empty
+  // fallback. A corrupt `panels` field used to return [], hiding the data
+  // corruption from operators. The repo now throws with the row id.
+  it('findById() throws when a JSON column is corrupt instead of returning a default dashboard', async () => {
+    const d = await repo.create({
+      title: 't', description: 'd', prompt: 'p', userId: 'u', datasourceIds: [],
+    });
+    db.run(sql`UPDATE dashboards SET panels = ${'{not json'} WHERE id = ${d.id}`);
+    await expect(repo.findById(d.id)).rejects.toThrow(/corrupt JSON in column "panels"/);
   });
 });

--- a/packages/data-layer/src/repository/sqlite/dashboard.ts
+++ b/packages/data-layer/src/repository/sqlite/dashboard.ts
@@ -31,6 +31,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
+import { createLogger } from '@agentic-obs/common/logging';
 import type {
   Dashboard,
   DashboardStatus,
@@ -45,6 +46,8 @@ import type {
   ResourceProvenance,
 } from '@agentic-obs/common';
 import type { SqliteClient } from '../../db/sqlite-client.js';
+
+const log = createLogger('dashboard-repository');
 
 // -- Row shape ---------------------------------------------------------
 
@@ -77,14 +80,32 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function parseJsonArray<T>(raw: string | null | undefined, fallback: T[] = []): T[] {
-  if (raw === null || raw === undefined || raw === '') return fallback;
+function parseJsonArray<T>(raw: string | null | undefined, rowId: string, column: string): T[] {
+  if (raw === null || raw === undefined || raw === '') return [];
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as T[]) : fallback;
-  } catch {
-    return fallback;
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in dashboards row — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
+  if (!Array.isArray(parsed)) {
+    log.error(
+      { rowId, column, actualType: typeof parsed },
+      'dashboards JSON column is not an array — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] expected array in column "${column}" for row ${rowId}, got ${typeof parsed}`,
+    );
+  }
+  return parsed as T[];
 }
 
 function toBool(v: unknown): boolean {
@@ -96,14 +117,23 @@ function fromBool(v: boolean | undefined, dflt = false): number {
   return (v ?? dflt) ? 1 : 0;
 }
 
-function parseProvenance(raw: string | null): ResourceProvenance | undefined {
+function parseProvenance(raw: string | null, rowId: string): ResourceProvenance | undefined {
   if (raw === null || raw === undefined || raw === '') return undefined;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as ResourceProvenance) : undefined;
-  } catch {
-    return undefined;
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.error(
+      { rowId, column: 'provenance', err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in dashboards.provenance — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] corrupt JSON in column "provenance" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
+  return parsed && typeof parsed === 'object' ? (parsed as ResourceProvenance) : undefined;
 }
 
 function rowToDashboard(r: DashboardRow): Dashboard {
@@ -115,10 +145,10 @@ function rowToDashboard(r: DashboardRow): Dashboard {
     prompt: r.prompt,
     userId: r.user_id,
     status: r.status as DashboardStatus,
-    panels: parseJsonArray<PanelConfig>(r.panels, []),
-    variables: parseJsonArray<DashboardVariable>(r.variables, []),
+    panels: parseJsonArray<PanelConfig>(r.panels, r.id, 'panels'),
+    variables: parseJsonArray<DashboardVariable>(r.variables, r.id, 'variables'),
     refreshIntervalSec: r.refresh_interval_sec,
-    datasourceIds: parseJsonArray<string>(r.datasource_ids, []),
+    datasourceIds: parseJsonArray<string>(r.datasource_ids, r.id, 'datasource_ids'),
     useExistingMetrics: toBool(r.use_existing_metrics),
     source: (r.source ?? 'manual') as ResourceSource,
     createdAt: r.created_at,
@@ -129,7 +159,7 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
-  const prov = parseProvenance(r.provenance);
+  const prov = parseProvenance(r.provenance, r.id);
   if (prov) base.provenance = prov;
   return base;
 }

--- a/packages/data-layer/src/repository/sqlite/investigation.test.ts
+++ b/packages/data-layer/src/repository/sqlite/investigation.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import { createTestDb } from '../../test-support/test-db.js';
 import { InvestigationRepository } from './investigation.js';
@@ -387,6 +388,16 @@ describe('InvestigationRepository (W6/T6.A2)', () => {
       await repo.archive(inv.id);
       expect(await repo.delete(inv.id)).toBe(true);
       expect(await repo.findById(inv.id)).toBeNull();
+    });
+  });
+
+  // P1 — corrupt JSON columns must throw (was silently returning a default
+  // shape like emptyPlan() / []), which hid data corruption from operators.
+  describe('corrupt JSON guard', () => {
+    it('findById throws when the plan column is corrupt instead of returning emptyPlan()', async () => {
+      const inv = await repo.create({ question: 'q', sessionId: 's', userId: 'u' });
+      db.run(sql`UPDATE investigations SET plan = ${'{not json'} WHERE id = ${inv.id}`);
+      await expect(repo.findById(inv.id)).rejects.toThrow(/corrupt JSON in column "plan"/);
     });
   });
 });

--- a/packages/data-layer/src/repository/sqlite/investigation.ts
+++ b/packages/data-layer/src/repository/sqlite/investigation.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
+import { createLogger } from '@agentic-obs/common/logging';
 import type {
   Investigation,
   InvestigationStatus,
@@ -9,6 +10,8 @@ import type {
 import type { ExplanationResult } from '@agentic-obs/common';
 import type { SqliteClient } from '../../db/sqlite-client.js';
 import type { FollowUpRecord, FeedbackBody, StoredFeedback } from '../types/investigation.js';
+
+const log = createLogger('investigation-repository');
 
 // =====================================================================
 // W6 / T6.A2 — Investigation store → SQLite repository
@@ -131,12 +134,25 @@ interface ConclusionRow {
 
 // -- JSON helpers -----------------------------------------------------
 
-function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+function parseJson<T>(
+  raw: string | null | undefined,
+  fallback: T,
+  rowId: string,
+  column: string,
+): T {
   if (raw === null || raw === undefined || raw === '') return fallback;
   try {
     return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in investigations row — refusing to return fallback',
+    );
+    throw new Error(
+      `[InvestigationRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }
 
@@ -162,13 +178,15 @@ function rowToInvestigationV6(r: InvestigationRow): Investigation {
         timeRange: { start: '', end: '' },
         goal: r.intent,
       },
+      r.id,
+      'structured_intent',
     ),
-    plan: parseJson<Investigation['plan']>(r.plan, emptyPlan()),
+    plan: parseJson<Investigation['plan']>(r.plan, emptyPlan(), r.id, 'plan'),
     status: r.status as Investigation['status'],
-    hypotheses: parseJson<Investigation['hypotheses']>(r.hypotheses, []),
-    actions: parseJson<Investigation['actions']>(r.actions, []),
-    evidence: parseJson<Investigation['evidence']>(r.evidence, []),
-    symptoms: parseJson<Investigation['symptoms']>(r.symptoms, []),
+    hypotheses: parseJson<Investigation['hypotheses']>(r.hypotheses, [], r.id, 'hypotheses'),
+    actions: parseJson<Investigation['actions']>(r.actions, [], r.id, 'actions'),
+    evidence: parseJson<Investigation['evidence']>(r.evidence, [], r.id, 'evidence'),
+    symptoms: parseJson<Investigation['symptoms']>(r.symptoms, [], r.id, 'symptoms'),
     ...(r.workspace_id ? { workspaceId: r.workspace_id } : {}),
     createdAt: r.created_at,
     updatedAt: r.updated_at,
@@ -198,11 +216,15 @@ function rowToFeedback(r: FeedbackRow): StoredFeedback {
   const hyp = parseJson<StoredFeedback['hypothesisFeedbacks'] | null>(
     r.hypothesis_feedbacks,
     null,
+    r.id,
+    'hypothesis_feedbacks',
   );
   if (hyp !== null) base.hypothesisFeedbacks = hyp;
   const act = parseJson<StoredFeedback['actionFeedbacks'] | null>(
     r.action_feedbacks,
     null,
+    r.id,
+    'action_feedbacks',
   );
   if (act !== null) base.actionFeedbacks = act;
   return base;
@@ -503,7 +525,12 @@ export class InvestigationRepository implements IInvestigationRepository {
       SELECT * FROM investigation_conclusions WHERE investigation_id = ${id}
     `);
     if (rows.length === 0) return null;
-    return parseJson<ExplanationResult | null>(rows[0]!.conclusion, null);
+    return parseJson<ExplanationResult | null>(
+      rows[0]!.conclusion,
+      null,
+      rows[0]!.investigation_id,
+      'conclusion',
+    );
   }
 
   async setConclusion(id: string, conclusion: ExplanationResult): Promise<void> {


### PR DESCRIPTION
## Summary

P1 fix from the internal CODE_REVIEW. Several SQLite repos and one agent handler were wrapping `JSON.parse` in `try { ... } catch { return fallback }`, hiding data corruption from operators. Most damning: a corrupt `alert_rules.condition` would silently become `threshold=0`, disarming the alert.

This change keeps the helpers' shape, but on parse failure now logs a structured line (`{ rowId, column, err }`) via the existing `createLogger` and rethrows. Route layer behavior on bad rows changes from "wrong data, no signal" to "5xx with a clear log".

## Per-file changes

| File | Swallow → New behavior |
|---|---|
| `packages/data-layer/src/repository/sqlite/dashboard.ts` | `parseJsonArray` / `parseProvenance` no longer return `[]` / `undefined` on corrupt JSON — log + throw with row id + column. |
| `packages/data-layer/src/repository/sqlite/investigation.ts` | `parseJson` no longer returns `emptyPlan()` / `[]` / `null` on corrupt JSON. Affected columns: `structured_intent`, `plan`, `hypotheses`, `actions`, `evidence`, `symptoms`, `conclusion`, `hypothesis_feedbacks`, `action_feedbacks`. |
| `packages/data-layer/src/repository/sqlite/alert-rule.ts` | `parseJsonOr` no longer returns the default `{ threshold: 0, operator: '>', ... }` for a corrupt `condition`. Same for `labels`, `provenance`, `matchers`, `channels`, `group_by`. |

## NOT changed (intentional — flagged in review but verified safe)

- **`packages/data-layer/src/repository/connector-shared.ts:25-29` (`parseJson`)** — Review claimed this "truly swallows." It doesn't: `JSON.parse(raw)` is not wrapped in `try/catch`, so corrupt JSON already throws naturally. No fix needed.
- **`packages/agent-core/src/agent/handlers/alert.ts:62-77` (`evalAlertRuleWrite`)** — Review claimed this is "fail-open." Reading the function fully: on `getFolderUid` failure, `folderUid = null`, which builds the scope `folders:uid:*`. A wildcard scope check requires an org-wide grant, so a user with only a folder-level grant is **denied**, not allowed. This is fail-CLOSED, and the existing comment "an unknown folder means 'require an org-wide grant' rather than silently widening" is accurate.

## Test plan

- [x] One unit test per touched repo file feeds corrupt JSON via raw `UPDATE` and asserts the repo throws with the column name in the message.
- [x] `npm run test -- --run packages/data-layer` — 380 passed (was 377; +3 regression tests).
- [x] `npm run test -- --run packages/agent-core` — 238 passed (no related changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)