### PR TITLE
fix: scheduler slot-delay formula + Postgres boolean drift (Sprint 2)

### DIFF
--- a/packages/data-layer/src/repository/postgres/schema-applier.ts
+++ b/packages/data-layer/src/repository/postgres/schema-applier.ts
@@ -39,7 +39,39 @@ export async function applyPostgresSchema(db: DbClient): Promise<void> {
     for (const stmt of statements) {
       await tx.execute(sql.raw(stmt));
     }
+    // One-shot column-type fix for instances created when these columns were
+    // INTEGER NOT NULL DEFAULT 0. Drizzle declares them as boolean; the SQL
+    // type drift broke reads. The CREATE TABLE IF NOT EXISTS above does not
+    // alter existing columns, so retrofit type-by-type.
+    await fixLegacyBooleanColumns(tx);
   });
+}
+
+async function fixLegacyBooleanColumns(tx: {
+  execute: (q: ReturnType<typeof sql>) => Promise<unknown>;
+}): Promise<void> {
+  // (table, column) pairs whose Drizzle type is boolean but legacy SQL was INTEGER.
+  const targets: Array<[string, string]> = [
+    ['incidents', 'archived'],
+    ['feed_items', 'followed_up'],
+  ];
+  for (const [table, column] of targets) {
+    await tx.execute(sql.raw(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = '${table}' AND column_name = '${column}'
+            AND data_type = 'integer'
+        ) THEN
+          EXECUTE 'ALTER TABLE ${table} ALTER COLUMN ${column} DROP DEFAULT';
+          EXECUTE 'ALTER TABLE ${table} ALTER COLUMN ${column} TYPE BOOLEAN USING (${column} <> 0)';
+          EXECUTE 'ALTER TABLE ${table} ALTER COLUMN ${column} SET DEFAULT FALSE';
+        END IF;
+      END
+      $$;
+    `));
+  }
 }
 
 async function renameLegacyUserTable(tx: {

--- a/packages/data-layer/src/repository/postgres/schema.sql
+++ b/packages/data-layer/src/repository/postgres/schema.sql
@@ -475,7 +475,7 @@ CREATE TABLE IF NOT EXISTS incidents (
   timeline           TEXT NOT NULL DEFAULT '[]',
   assignee           TEXT,
   workspace_id       TEXT,
-  archived           INTEGER NOT NULL DEFAULT 0,
+  archived           BOOLEAN NOT NULL DEFAULT FALSE,
   resolved_at        TEXT,
   created_at         TEXT NOT NULL,
   updated_at         TEXT NOT NULL
@@ -497,7 +497,7 @@ CREATE TABLE IF NOT EXISTS feed_items (
   hypothesis_feedback TEXT,
   action_feedback     TEXT,
   investigation_id    TEXT,
-  followed_up         INTEGER NOT NULL DEFAULT 0,
+  followed_up         BOOLEAN NOT NULL DEFAULT FALSE,
   created_at          TEXT NOT NULL
 );
 

--- a/packages/web/src/api/query-scheduler.test.ts
+++ b/packages/web/src/api/query-scheduler.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for the slot-delay formula in QueryScheduler.
+ *
+ * Regression guard for Sprint 2 CODE_REVIEW: the previous formula hardcoded
+ * `staggerSpreadMs / 60` and ignored the supposed `slotsPerSec` guard,
+ * producing a fixed ~33 ms stride regardless of inputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeSlotDelayMs } from './query-scheduler.js';
+
+describe('computeSlotDelayMs', () => {
+  it('uses 1000 / slotsPerSec when a rate is configured', () => {
+    // slotsPerSec=2 → 500 ms stride. Slot 0 fires immediately, slot 1 at 500.
+    expect(computeSlotDelayMs({ slot: 0, slotsPerSec: 2, totalSlots: 60, spreadMs: 2000 })).toBe(0);
+    expect(computeSlotDelayMs({ slot: 1, slotsPerSec: 2, totalSlots: 60, spreadMs: 2000 })).toBe(
+      500,
+    );
+    expect(computeSlotDelayMs({ slot: 3, slotsPerSec: 2, totalSlots: 60, spreadMs: 2000 })).toBe(
+      1500,
+    );
+  });
+
+  it('falls back to spreadMs / totalSlots when no rate is configured', () => {
+    // 10 slots over a 2000 ms spread → 200 ms stride.
+    expect(computeSlotDelayMs({ slot: 0, slotsPerSec: 0, totalSlots: 10, spreadMs: 2000 })).toBe(0);
+    expect(computeSlotDelayMs({ slot: 1, slotsPerSec: 0, totalSlots: 10, spreadMs: 2000 })).toBe(
+      200,
+    );
+    expect(computeSlotDelayMs({ slot: 5, slotsPerSec: 0, totalSlots: 10, spreadMs: 2000 })).toBe(
+      1000,
+    );
+  });
+
+  it('returns 0 when neither a rate nor a slot budget is available', () => {
+    expect(computeSlotDelayMs({ slot: 4, slotsPerSec: 0, totalSlots: 0, spreadMs: 2000 })).toBe(0);
+  });
+});

--- a/packages/web/src/api/query-scheduler.ts
+++ b/packages/web/src/api/query-scheduler.ts
@@ -37,6 +37,29 @@ type QueueItem<T> = {
   reject: (reason: unknown) => void;
 };
 
+/**
+ * Pure helper for the slot-delay formula. Exported for tests.
+ *
+ * - If `slotsPerSec > 0`, the caller has a known rate budget — space slots at
+ *   `1000 / slotsPerSec` ms apart (e.g. 2 req/s → 500 ms apart).
+ * - Otherwise, spread `totalSlots` requests evenly across `spreadMs`
+ *   (e.g. 10 slots over 2000 ms → 200 ms apart).
+ *
+ * `slot` is the zero-based index of the request inside the burst. The returned
+ * delay is `slot * stride` so slot 0 fires immediately.
+ */
+export function computeSlotDelayMs(args: {
+  slot: number;
+  slotsPerSec: number;
+  totalSlots: number;
+  spreadMs: number;
+}): number {
+  const { slot, slotsPerSec, totalSlots, spreadMs } = args;
+  const stride =
+    slotsPerSec > 0 ? 1000 / slotsPerSec : totalSlots > 0 ? spreadMs / totalSlots : 0;
+  return slot * stride;
+}
+
 export class QueryScheduler {
   private maxConcurrent: number;
   private activeCount = 0;
@@ -52,14 +75,24 @@ export class QueryScheduler {
    */
   private staggerWindowMs: number;
   private staggerSpreadMs: number;
+  private slotsPerSec: number;
+  private maxExpectedSlots: number;
   private burstStartTime: number | null = null;
   private burstCount = 0;
   private staggerTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(maxConcurrent = 6, staggerWindowMs = 200, staggerSpreadMs = 2000) {
+  constructor(
+    maxConcurrent = 6,
+    staggerWindowMs = 200,
+    staggerSpreadMs = 2000,
+    slotsPerSec = 0,
+    maxExpectedSlots = 60,
+  ) {
     this.maxConcurrent = maxConcurrent;
     this.staggerWindowMs = staggerWindowMs;
     this.staggerSpreadMs = staggerSpreadMs;
+    this.slotsPerSec = slotsPerSec;
+    this.maxExpectedSlots = maxExpectedSlots;
   }
 
   /**
@@ -108,11 +141,15 @@ export class QueryScheduler {
       }
 
       const slot = this.burstCount++;
-      // Spread slots evenly: each slot is staggerSpreadMs / maxExpectedPanels apart.
-      // Using 50 ms per slot means 30 panels finish within 1.5 s and 60 panels within 3 s,
-      // well within the 600 req/min budget on the API gateway.
-      const slotsPerSec = Math.floor(this.staggerSpreadMs / 50);
-      const delay = slot * (slotsPerSec > 0 ? this.staggerSpreadMs / 60 : 0); // ~33 ms at default 2000 ms spread
+      // Either a configured per-second rate budget or an even spread across
+      // `maxExpectedSlots` over the `staggerSpreadMs` window. See
+      // `computeSlotDelayMs` for the formula.
+      const delay = computeSlotDelayMs({
+        slot,
+        slotsPerSec: this.slotsPerSec,
+        totalSlots: this.maxExpectedSlots,
+        spreadMs: this.staggerSpreadMs,
+      });
 
       const promise = new Promise<T>((resolve, reject) => {
         setTimeout(() => {


### PR DESCRIPTION
## Summary

Two narrow bugs called out in the Sprint 2 internal CODE_REVIEW.

---

### Bug A — `packages/web/src/api/query-scheduler.ts` slot-delay formula

The formula computed `slotsPerSec` but threw it away — `60` was hardcoded as a magic max-panel count, so the `slotsPerSec > 0` guard was actually selecting between a fixed `staggerSpreadMs / 60` stride and zero. The variable's name and the conditional were entirely decorative.

**Before:**
```ts
const slotsPerSec = Math.floor(this.staggerSpreadMs / 50);
const delay = slot * (slotsPerSec > 0 ? this.staggerSpreadMs / 60 : 0);
```

**After:**
```ts
const delay = computeSlotDelayMs({
  slot,
  slotsPerSec: this.slotsPerSec,
  totalSlots: this.maxExpectedSlots,
  spreadMs: this.staggerSpreadMs,
});
```

where the new pure helper is:
```ts
export function computeSlotDelayMs({ slot, slotsPerSec, totalSlots, spreadMs }) {
  const stride =
    slotsPerSec > 0 ? 1000 / slotsPerSec :
    totalSlots > 0  ? spreadMs / totalSlots : 0;
  return slot * stride;
}
```

`slotsPerSec` and `maxExpectedSlots` are new optional constructor params (defaults `0` and `60`) so the runtime path is unchanged at the singleton (`new QueryScheduler(4, 300, 4000)`) while the formula is now correct and parameterized. Tests cover both branches.

### Bug B — Postgres boolean drift

Drizzle TS schema (`packages/data-layer/src/repository/postgres/schema.ts`) declares `archived: boolean(...)...default(false)` on `incidents` and `followed_up: boolean(...)...default(false)` on `feed_items`, but `schema.sql` shipped them as `INTEGER NOT NULL DEFAULT 0`. Drizzle reads then return numbers (or fail typing) on the legacy type. No other table had this drift — `investigations.archived` is INTEGER in SQL but has no Drizzle definition, so it is intentionally left alone (surgical principle).

**Before (`schema.sql`):**
```sql
archived           INTEGER NOT NULL DEFAULT 0,   -- incidents
followed_up         INTEGER NOT NULL DEFAULT 0,  -- feed_items
```

**After:**
```sql
archived           BOOLEAN NOT NULL DEFAULT FALSE,
followed_up         BOOLEAN NOT NULL DEFAULT FALSE,
```

`schema.sql` is applied idempotently with `CREATE TABLE IF NOT EXISTS`, so existing databases would not get the new type for free. Following the existing `renameLegacyUserTable` pattern in `schema-applier.ts`, added a one-shot `fixLegacyBooleanColumns` step that runs `ALTER TABLE ... ALTER COLUMN ... TYPE BOOLEAN USING (col <> 0)` for each affected `(table, column)` when it is still `data_type = 'integer'`. Runs inside the same transaction as the schema apply.

SQLite schema is untouched — SQLite stores booleans as INTEGER 0/1, so there is no real drift there.

## Test plan
- [x] `npx vitest run packages/web/src/api/query-scheduler.test.ts` — 3/3 pass (slotsPerSec=2 → 500 ms; slotsPerSec=0, 10 slots, 2000 ms → 200 ms; degenerate 0)
- [x] `npm run typecheck` — clean
- [ ] On a fresh Postgres, confirm `incidents.archived` and `feed_items.followed_up` come up as `boolean`
- [ ] On an upgraded instance (pre-existing `INTEGER` columns), confirm the one-shot ALTER runs on startup and reads through Drizzle stop returning numbers