### PR TITLE
chore: P2 small TODOs — rebrand env vars + meta.ts org cleanup + team_approval

### DIFF
--- a/bin/start.ts
+++ b/bin/start.ts
@@ -86,7 +86,7 @@ async function main() {
   // `tsx bin/start.ts demo` — local-dev equivalent of `rounds demo`.
   // Sets the env var BEFORE the api-gateway child process inherits it.
   if (process.argv[2] === 'demo') {
-    process.env['OPENOBS_DEMO'] = '1';
+    process.env['ROUNDS_DEMO'] = '1';
     log('DEMO mode — fixture data, no credentials required.');
   }
 

--- a/packages/agent-core/src/agent/handlers/remediation-plan.ts
+++ b/packages/agent-core/src/agent/handlers/remediation-plan.ts
@@ -192,11 +192,15 @@ async function createPlanCommon(
         const targetNamespace = firstOpsStep
           ? (parseKubectlArgv((firstOpsStep.paramsJson as { argv: string[] }).argv).namespace ?? null)
           : null;
-        // TODO(approvals-multi-team): resolve requesterTeamId via ctx.
-        // Needs alertRule.investigation_id → folder → team chain wired
-        // through ctx (not currently exposed in agent-core). Tracked
-        // separately; null is the safe default — wildcard `approvals:*`
-        // grants still match.
+        // FIXME(teams): wire when teams feature lands. Resolving this
+        // needs the alertRule.investigation_id → folder → team chain
+        // threaded through ctx (not currently exposed in agent-core),
+        // and the org-wide "teams" concept itself isn't yet a real
+        // first-class object. `null` is the safe default everywhere it
+        // flows downstream (approval-router, publishing-approval-repo,
+        // action-center filters, scope.ts) — wildcard `approvals:*`
+        // grants still match, and team-scoped filters treat null as
+        // "no team". Not a real TODO; intentional placeholder.
         const requesterTeamId: string | null = null;
 
         const submitted = await ctx.approvalRequests.submit({

--- a/packages/api-gateway/src/routes/demo.ts
+++ b/packages/api-gateway/src/routes/demo.ts
@@ -1,4 +1,5 @@
-// Demo-mode routes — only mounted when OPENOBS_DEMO=1 is set in the env.
+// Demo-mode routes — only mounted when ROUNDS_DEMO=1 (or legacy
+// OPENOBS_DEMO=1) is set in the env.
 //
 // Goals:
 //   - Surface a public `GET /api/demo/status` so the web UI can render a

--- a/packages/api-gateway/src/routes/meta.ts
+++ b/packages/api-gateway/src/routes/meta.ts
@@ -61,6 +61,8 @@ export async function computeQualityMetrics(
   feedStoreInstance: IGatewayFeedStore,
   orgId: string,
 ): Promise<QualityMetrics> {
+  // Investigation.workspaceId is the legacy field name for what is now
+  // the org id (see data-layer types). Filter by it to scope to this org.
   const investigations = (await investigationStore.findAll())
     .filter((inv) => inv.workspaceId === orgId);
   const totalInvestigations = investigations.length;

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -315,13 +315,14 @@ export async function createApp(): Promise<Application> {
   } satisfies WebSocketGatewayDeps;
 
   // -- Demo mode (zero-credential preview) ------------------------------
-  // OPENOBS_DEMO=1 is the ONLY way to enable demo routes. The flag is
+  // ROUNDS_DEMO=1 is the ONLY way to enable demo routes. The flag is
   // read here, not inside the router module, so the router cannot be
-  // silently mounted by a stray import.
-  if (process.env['OPENOBS_DEMO'] === '1') {
+  // silently mounted by a stray import. Legacy OPENOBS_DEMO is still
+  // honored for back-compat with pre-rebrand configs.
+  if (process.env['ROUNDS_DEMO'] === '1' || process.env['OPENOBS_DEMO'] === '1') {
     const { createDemoRouter } = await import('./routes/demo.js');
     app.use('/api/demo', createDemoRouter());
-    log.info('OPENOBS_DEMO=1 — demo routes mounted at /api/demo');
+    log.info('demo routes mounted at /api/demo (ROUNDS_DEMO=1)');
   }
 
   // -- SPA fallback + 404 / error handlers (must be LAST) ---------------

--- a/packages/cli/bin/rounds.mjs
+++ b/packages/cli/bin/rounds.mjs
@@ -22,16 +22,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 
 // -- `rounds demo` subcommand -----------------------------------------
-// Zero-credential preview mode. Sets OPENOBS_DEMO=1 and uses an isolated
+// Zero-credential preview mode. Sets ROUNDS_DEMO=1 and uses an isolated
 // DATA_DIR so the demo never collides with a real install. The flag is
 // read by the api-gateway's createApp(); without it no demo routes are
-// mounted.
-//
-// TODO(rebrand): rename env var to ROUNDS_DEMO once api-gateway/server.ts is
-// updated in the env-var sweep wave. Doing both at once to avoid a window
-// where the launcher and the server disagree on the flag name.
+// mounted. The server also still honors legacy OPENOBS_DEMO=1 for
+// back-compat with pre-rebrand configs.
 if (args[0] === 'demo') {
-  process.env.OPENOBS_DEMO = '1';
+  process.env.ROUNDS_DEMO = '1';
   if (!process.env.DATA_DIR) {
     process.env.DATA_DIR = join(homedir(), '.rounds-demo');
   }


### PR DESCRIPTION
## Summary

Three independent P2 follow-ups from the internal CODE_REVIEW. Each is a small, surgical change.

### Fix 1 — `OPENOBS_DEMO` → `ROUNDS_DEMO` env var (with back-compat)

- `packages/cli/bin/rounds.mjs` now sets `ROUNDS_DEMO=1` and the `TODO(rebrand)` marker is removed.
- `packages/api-gateway/src/server.ts` accepts **either** `ROUNDS_DEMO=1` or the legacy `OPENOBS_DEMO=1` so pre-rebrand configs keep working.
- `bin/start.ts` and the demo route/test header comments updated for consistency.
- Only the `*_DEMO` flag was in scope — there are no other `OPENOBS_*` env vars in the CLI launcher.

### Fix 2 — `routes/meta.ts` workspace/org cleanup

Investigated thoroughly. The review's specifics (`workspaceCALL`, `scope_id:65,70,95`) do **not** exist in the file. The only `workspace` token in `meta.ts` is `inv.workspaceId === orgId` on line 65, which reads the **canonical Investigation field name** in the data-layer types (used throughout `packages/data-layer`). The route's response (`QualityMetrics`) contains zero `workspace*` keys.

Per the task constraint ("DON'T do a project-wide workspace→org rename"), no functional change. Added a one-line comment on the filter to make the legacy-field-name intent obvious to anyone scanning post-rebrand.

### Fix 3 — `team_approval` placeholder clarification

`packages/agent-core/src/agent/handlers/remediation-plan.ts` had `requesterTeamId: null` with `TODO(approvals-multi-team)`. **Admission: the teams concept isn't ready org-wide.** `ActionContext` exposes no team resolver, and the `alertRule → folder → team` chain isn't threaded into agent-core. So `null` stays.

Re-labeled the comment as `FIXME(teams): wire when teams feature lands` and documented that `null` is safe at every downstream consumer (`scope.ts` wildcards still match, `approval-router`, `publishing-approval-repository`, `action-center-filters` all handle null cleanly). This distinguishes a "blocked on missing feature" placeholder from a real near-term TODO.

## Verification

- `npx tsc --build` — only pre-existing unrelated `@vitejs/plugin-react` resolution error (present on `main`).
- `npx vitest run` for `routes/demo.test.ts`, `routes/meta.test.ts`, `agent-core/.../handlers/**`: 120 tests pass.

## Test plan

- [ ] CI green on the three touched packages (`cli`, `api-gateway`, `agent-core`).
- [ ] Manual: `rounds demo` still mounts `/api/demo/*` (now via `ROUNDS_DEMO=1`).
- [ ] Manual: existing installs with `OPENOBS_DEMO=1` set still enable demo mode.