### PR TITLE
Fix confirmed code review issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pictures/
 .vscode/
 .idea/
 .codex
+internal-docs/
 
 # e2e testkit runtime state (cluster url, tokens, port-forward pid/log).
 tests/e2e/.state/*

--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
@@ -304,6 +304,26 @@ describe('dashboard handlers', () => {
       );
       expect(proposed).toBeDefined();
     });
+
+    it('emits a failed tool_result when remove fails', async () => {
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+      });
+      vi.mocked(ctx.actionExecutor.execute).mockRejectedValueOnce(new Error('store offline'));
+
+      const observation = await handleDashboardRemovePanels(ctx, { panelIds: ['p1'] });
+
+      expect(observation).toBe('Error: store offline');
+      expect(ctx.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_result',
+          tool: 'dashboard_remove_panels',
+          success: false,
+          summary: 'Error: store offline',
+        }),
+      );
+    });
   });
 
   describe('handleDashboardModifyPanel', () => {
@@ -345,6 +365,26 @@ describe('dashboard handlers', () => {
       expect(persisted[0]!.op.panelId).toBe('p1');
       expect(persisted[0]!.op.patch.title).toBe('Renamed');
     });
+
+    it('emits a failed tool_result when modify fails', async () => {
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+      });
+      vi.mocked(ctx.actionExecutor.execute).mockRejectedValueOnce(new Error('write failed'));
+
+      const observation = await handleDashboardModifyPanel(ctx, { panelId: 'p1', title: 'Renamed' });
+
+      expect(observation).toBe('Error: write failed');
+      expect(ctx.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_result',
+          tool: 'dashboard_modify_panel',
+          success: false,
+          summary: 'Error: write failed',
+        }),
+      );
+    });
   });
 
   describe('handleDashboardAddVariable', () => {
@@ -356,6 +396,26 @@ describe('dashboard handlers', () => {
       });
       expect(observation).toBe('Added variable $env.');
       expect(ctx.actionExecutor.execute).toHaveBeenCalled();
+    });
+
+    it('emits a failed tool_result when adding a variable fails', async () => {
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd1',
+        freshlyCreatedDashboards: new Set(['d1']),
+      });
+      vi.mocked(ctx.actionExecutor.execute).mockRejectedValueOnce(new Error('variable write failed'));
+
+      const observation = await handleDashboardAddVariable(ctx, { name: 'env', type: 'custom' });
+
+      expect(observation).toBe('Error: variable write failed');
+      expect(ctx.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_result',
+          tool: 'dashboard_add_variable',
+          success: false,
+          summary: 'Error: variable write failed',
+        }),
+      );
     });
 
     it('queues a pending change for variable additions on an existing dashboard', async () => {

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -81,6 +81,21 @@ async function queuePending(
   return change;
 }
 
+function formatToolError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function emitToolFailure(
+  ctx: ActionContext,
+  tool: string,
+  err: unknown,
+): string {
+  const msg = formatToolError(err);
+  const observationText = `Error: ${msg}`;
+  ctx.sendEvent({ type: 'tool_result', tool, summary: observationText, success: false });
+  return observationText;
+}
+
 // ---------------------------------------------------------------------------
 // Dashboard lifecycle
 // ---------------------------------------------------------------------------
@@ -467,34 +482,36 @@ export async function handleDashboardRemovePanels(
 
   ctx.sendEvent({ type: 'tool_call', tool: 'dashboard_remove_panels', args: { panelIds }, displayText: `Removing ${panelIds.length} panel(s)` });
 
-  // Task 09 — removing panels on a pre-existing (shared) dashboard goes to
-  // pendingChanges so the user reviews each removal before the dashboard is
-  // mutated. Freshly-created dashboards in this session apply directly.
-  if (!isFreshlyCreated(ctx, dashboardId)) {
-    const proposed: PendingDashboardChange[] = [];
-    for (const panelId of panelIds) {
-      const change = await queuePending(
-        ctx,
-        dashboardId,
-        { kind: 'remove_panel', panelId },
-        `Remove panel ${panelId}`,
-      );
-      proposed.push(change);
+  try {
+    // Task 09 — removing panels on a pre-existing (shared) dashboard goes to
+    // pendingChanges so the user reviews each removal before the dashboard is
+    // mutated. Freshly-created dashboards in this session apply directly.
+    if (!isFreshlyCreated(ctx, dashboardId)) {
+      for (const panelId of panelIds) {
+        await queuePending(
+          ctx,
+          dashboardId,
+          { kind: 'remove_panel', panelId },
+          `Remove panel ${panelId}`,
+        );
+      }
+      const observationText = `Proposed removal of ${panelIds.length} panel(s); pending user review.`;
+      ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_remove_panels', summary: observationText, success: true });
+      return observationText;
     }
-    const observationText = `Proposed removal of ${panelIds.length} panel(s); pending user review.`;
+
+    await ctx.actionExecutor.execute(dashboardId, [{ type: 'remove_panels', panelIds }]);
+
+    const observationText = `Removed ${panelIds.length} panel(s).`;
     ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_remove_panels', summary: observationText, success: true });
+    // Stream `panel_removed` per id so the live view drops them without F5.
+    for (const panelId of panelIds) {
+      ctx.sendEvent({ type: 'panel_removed', panelId } as never);
+    }
     return observationText;
+  } catch (err) {
+    return emitToolFailure(ctx, 'dashboard_remove_panels', err);
   }
-
-  await ctx.actionExecutor.execute(dashboardId, [{ type: 'remove_panels', panelIds }]);
-
-  const observationText = `Removed ${panelIds.length} panel(s).`;
-  ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_remove_panels', summary: observationText, success: true });
-  // Stream `panel_removed` per id so the live view drops them without F5.
-  for (const panelId of panelIds) {
-    ctx.sendEvent({ type: 'panel_removed', panelId } as never);
-  }
-  return observationText;
 }
 
 // TODO: migrate to withToolEventBoundary
@@ -527,27 +544,31 @@ export async function handleDashboardModifyPanel(
 
   ctx.sendEvent({ type: 'tool_call', tool: 'dashboard_modify_panel', args: { panelId, patch }, displayText: `Modifying panel ${panelId}` });
 
-  // Task 09 — modifying a panel on a pre-existing dashboard goes to
-  // pendingChanges (the dashboard may be shared; the user must accept).
-  if (!isFreshlyCreated(ctx, dashboardId)) {
-    await queuePending(
-      ctx,
-      dashboardId,
-      { kind: 'modify_panel', panelId, patch },
-      `Modify panel ${panelId}`,
-    );
-    const observationText = `Proposed modification of panel ${panelId}; pending user review.`;
+  try {
+    // Task 09 — modifying a panel on a pre-existing dashboard goes to
+    // pendingChanges (the dashboard may be shared; the user must accept).
+    if (!isFreshlyCreated(ctx, dashboardId)) {
+      await queuePending(
+        ctx,
+        dashboardId,
+        { kind: 'modify_panel', panelId, patch },
+        `Modify panel ${panelId}`,
+      );
+      const observationText = `Proposed modification of panel ${panelId}; pending user review.`;
+      ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_modify_panel', summary: observationText, success: true });
+      return observationText;
+    }
+
+    await ctx.actionExecutor.execute(dashboardId, [{ type: 'modify_panel', panelId, patch }]);
+
+    const observationText = `Modified panel ${panelId}.`;
     ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_modify_panel', summary: observationText, success: true });
+    // Stream `panel_modified` so the live view applies the patch without F5.
+    ctx.sendEvent({ type: 'panel_modified', panelId, patch } as never);
     return observationText;
+  } catch (err) {
+    return emitToolFailure(ctx, 'dashboard_modify_panel', err);
   }
-
-  await ctx.actionExecutor.execute(dashboardId, [{ type: 'modify_panel', panelId, patch }]);
-
-  const observationText = `Modified panel ${panelId}.`;
-  ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_modify_panel', summary: observationText, success: true });
-  // Stream `panel_modified` so the live view applies the patch without F5.
-  ctx.sendEvent({ type: 'panel_modified', panelId, patch } as never);
-  return observationText;
 }
 
 // TODO: migrate to withToolEventBoundary
@@ -571,26 +592,30 @@ export async function handleDashboardAddVariable(
 
   ctx.sendEvent({ type: 'tool_call', tool: 'dashboard_add_variable', args: { name: variable.name }, displayText: `Adding variable: $${variable.name}` });
 
-  // Task 09 — variable changes on a pre-existing dashboard route through
-  // pendingChanges. Variables affect every panel's query, so silently mutating
-  // a shared dashboard's variable set would be especially disruptive.
-  if (!isFreshlyCreated(ctx, dashboardId)) {
-    await queuePending(
-      ctx,
-      dashboardId,
-      { kind: 'add_variable', variable },
-      `Add variable $${variable.name}`,
-    );
-    const observationText = `Proposed variable $${variable.name}; pending user review.`;
+  try {
+    // Task 09 — variable changes on a pre-existing dashboard route through
+    // pendingChanges. Variables affect every panel's query, so silently mutating
+    // a shared dashboard's variable set would be especially disruptive.
+    if (!isFreshlyCreated(ctx, dashboardId)) {
+      await queuePending(
+        ctx,
+        dashboardId,
+        { kind: 'add_variable', variable },
+        `Add variable $${variable.name}`,
+      );
+      const observationText = `Proposed variable $${variable.name}; pending user review.`;
+      ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_variable', summary: observationText, success: true });
+      return observationText;
+    }
+
+    await ctx.actionExecutor.execute(dashboardId, [{ type: 'add_variable', variable }]);
+
+    const observationText = `Added variable $${variable.name}.`;
     ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_variable', summary: observationText, success: true });
     return observationText;
+  } catch (err) {
+    return emitToolFailure(ctx, 'dashboard_add_variable', err);
   }
-
-  await ctx.actionExecutor.execute(dashboardId, [{ type: 'add_variable', variable }]);
-
-  const observationText = `Added variable $${variable.name}.`;
-  ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_variable', summary: observationText, success: true });
-  return observationText;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
+++ b/packages/api-gateway/src/routes/alert-rules-investigate.test.ts
@@ -109,6 +109,16 @@ function makeApp(opts: {
   return app;
 }
 
+function makeRunner() {
+  const fakeOrchestrator = {
+    handleMessage: vi.fn(async () => 'done'),
+  } as unknown as Awaited<ReturnType<NonNullable<Parameters<typeof createAlertRulesRouter>[0]['runner']>['makeOrchestrator']>>;
+  return {
+    saTokens: { validateAndLookup: vi.fn() } as unknown as NonNullable<Parameters<typeof createAlertRulesRouter>[0]['runner']>['saTokens'],
+    makeOrchestrator: vi.fn(async () => fakeOrchestrator),
+  } as NonNullable<Parameters<typeof createAlertRulesRouter>[0]['runner']>;
+}
+
 describe('POST /api/alert-rules/:id/investigate', () => {
   it('passes the rule\'s workspaceId to investigationStore.create', async () => {
     const create = vi.fn(async (input: { workspaceId?: string }) => ({
@@ -119,6 +129,7 @@ describe('POST /api/alert-rules/:id/investigate', () => {
       rule: makeRule({ workspaceId: 'ws_team_a' }),
       identity: { userId: 'u1', orgId: 'ws_team_a', orgRole: 'Editor', isServerAdmin: false, authenticatedBy: 'session' },
       capturedCreate: create,
+      runner: makeRunner(),
     });
 
     const res = await request(app)
@@ -129,6 +140,26 @@ describe('POST /api/alert-rules/:id/investigate', () => {
     expect(res.body).toEqual({ investigationId: 'inv_1', existing: false });
     expect(create).toHaveBeenCalledTimes(1);
     expect((create.mock.calls[0] as unknown[])?.[0]).toMatchObject({ workspaceId: 'ws_team_a' });
+  });
+
+  it('rejects manual investigate when no background runner is configured', async () => {
+    const create = vi.fn(async () => ({ id: 'inv_not_created' }));
+    const app = makeApp({
+      rule: makeRule({ workspaceId: 'ws_team_a' }),
+      identity: { userId: 'u1', orgId: 'ws_team_a', orgRole: 'Editor', isServerAdmin: false, authenticatedBy: 'session' },
+      capturedCreate: create,
+    });
+
+    const res = await request(app)
+      .post('/api/alert-rules/r1/investigate')
+      .send({});
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatchObject({
+      code: 'NOT_CONFIGURED',
+      message: 'Background investigation runner not configured',
+    });
+    expect(create).not.toHaveBeenCalled();
   });
 
   it('spawns the background agent under the clicker\'s identity and advances investigation status', async () => {

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -636,6 +636,15 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
           return;
         }
 
+        if (!deps.runner) {
+          log.warn(
+            { ruleId: rule.id },
+            'manual investigate rejected: no background runner wired',
+          );
+          res.status(503).json({ error: { code: 'NOT_CONFIGURED', message: 'Background investigation runner not configured' } });
+          return;
+        }
+
         const identity = (req as AuthenticatedRequest).auth;
         if (!identity) {
           res.status(401).json({ error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } });
@@ -676,24 +685,17 @@ export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
         // investigation SSE stream; the agent advances status as it runs.
         // Errors are isolated — they're logged but don't fail the HTTP
         // response (Task C handles forced terminal-status fallback).
-        if (deps.runner) {
-          const runner = deps.runner;
-          void (async () => {
-            try {
-              await runBackgroundAgent(runner, { identity, message: question });
-            } catch (err) {
-              log.error(
-                { err: err instanceof Error ? err.message : String(err), ruleId: rule.id, investigationId: investigation.id },
-                'manual investigate: background agent failed',
-              );
-            }
-          })();
-        } else {
-          log.warn(
-            { ruleId: rule.id, investigationId: investigation.id },
-            'manual investigate: no background runner wired — investigation row created but no agent will run',
-          );
-        }
+        const runner = deps.runner;
+        void (async () => {
+          try {
+            await runBackgroundAgent(runner, { identity, message: question });
+          } catch (err) {
+            log.error(
+              { err: err instanceof Error ? err.message : String(err), ruleId: rule.id, investigationId: investigation.id },
+              'manual investigate: background agent failed',
+            );
+          }
+        })();
 
         res.json({ investigationId: investigation.id, existing: false });
       } catch (err) {

--- a/packages/api-gateway/src/services/org-service.ts
+++ b/packages/api-gateway/src/services/org-service.ts
@@ -41,9 +41,12 @@ import type {
   OrgUser,
 } from '@agentic-obs/common';
 import { AuditAction, ORG_ROLES } from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/server-utils/logging';
 import type { QueryClient } from '@agentic-obs/data-layer';
 import { seedRbacForOrg } from '@agentic-obs/data-layer';
 import type { AuditWriter } from '../auth/audit-writer.js';
+
+const log = createLogger('org-service');
 
 const DEFAULT_QUOTA_TARGETS = [
   'users',
@@ -286,10 +289,14 @@ export class OrgService {
     for (const table of ORG_SCOPED_TABLES) {
       try {
         await this.deps.db.run(sql.raw(`DELETE FROM ${table} WHERE org_id = '${id.replace(/'/g, "''")}'`));
-      } catch (_err) {
+      } catch (err) {
         // Some tables may not exist on older schemas or in mini integration
         // DBs. Best-effort — swallow and continue; the delete() API contract
         // is "cascades where possible".
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), orgId: id, table },
+          'org delete: failed to cleanup org-scoped table',
+        );
       }
     }
     // Reassign user.org_id for any user whose default org was this one —
@@ -335,8 +342,12 @@ export class OrgService {
     for (const t of cascadeTables) {
       try {
         await this.deps.db.run(sql.raw(`DELETE FROM ${t} WHERE org_id = '${sanitized}'`));
-      } catch (_err) {
+      } catch (err) {
         // Tables may not exist in some schemas; best-effort cascade.
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), orgId: id, table: t },
+          'org delete: failed to cleanup auth table',
+        );
       }
     }
 

--- a/packages/api-gateway/src/services/team-service.ts
+++ b/packages/api-gateway/src/services/team-service.ts
@@ -43,8 +43,11 @@ import {
   TEAM_MEMBER_PERMISSION_MEMBER,
   TEAM_MEMBER_PERMISSION_ADMIN,
 } from '@agentic-obs/common';
+import { createLogger } from '@agentic-obs/server-utils/logging';
 import type { QueryClient } from '@agentic-obs/data-layer';
 import type { AuditWriter } from '../auth/audit-writer.js';
+
+const log = createLogger('team-service');
 
 export class TeamServiceError extends Error {
   constructor(
@@ -229,9 +232,13 @@ export class TeamService {
       await this.deps.db.run(
         sql.raw(`DELETE FROM dashboard_acl WHERE team_id = '${sanitized}'`),
       );
-    } catch {
+    } catch (err) {
       // dashboard_acl may not exist in some mini integration DBs. Best-effort
       // cleanup — swallow and continue; team delete is still the contract.
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), orgId, teamId: id },
+        'team delete: failed to cleanup dashboard ACL rows',
+      );
     }
 
     await this.deps.teams.delete(id);


### PR DESCRIPTION
## Summary
- Return failed dashboard tool results for remove/modify/add-variable errors so the UI does not hang after a tool_call
- Reject manual alert investigations when no background runner is configured instead of creating inert investigation rows
- Log best-effort org/team cascade cleanup failures and keep internal docs ignored

## Notes
- Query scheduler changes were already present on latest main after rebase, so this PR keeps the main implementation and test coverage.

## Tests
- npm test -- --run packages/web/src/api/query-scheduler.test.ts packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts packages/api-gateway/src/routes/alert-rules-investigate.test.ts
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert rule investigation endpoints now properly return a 503 error when the background investigation runner is not configured.

* **Improvements**
  * Dashboard panel operations (add, modify, remove) now handle failures with consistent error reporting.
  * Organization and team deletion processes now emit detailed warning logs when resource cleanup encounters issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->