### PR TITLE
fix(data-layer): import IInvestigationRepository from @agentic-obs/common

### DIFF
--- a/packages/data-layer/src/repository/factory.ts
+++ b/packages/data-layer/src/repository/factory.ts
@@ -17,11 +17,11 @@ import type {
   IChatMessageRepository,
   IChatSessionEventRepository,
 } from './interfaces.js';
-import type { IInvestigationRepository as SqliteInvestigationRepositoryInterface } from './sqlite/investigation.js';
 import type {
   IDashboardRepository,
   IInstanceConfigRepository,
   INotificationChannelRepository,
+  IInvestigationRepository,
 } from '@agentic-obs/common';
 import type { IConnectorRepository } from './types/connector.js';
 import type {
@@ -89,7 +89,7 @@ import type { ILlmAuditRepository } from './sqlite/llm-audit-repository.js';
  * only want the gateway surface can consume them directly without casts.
  */
 export interface RepositoryBundle {
-  investigations: SqliteInvestigationRepositoryInterface & IGatewayInvestigationStore;
+  investigations: IInvestigationRepository & IGatewayInvestigationStore;
   incidents: IIncidentRepository & IGatewayIncidentStore;
   feedItems: IFeedItemRepository;
   approvals: IApprovalRequestRepository & IGatewayApprovalStore;


### PR DESCRIPTION
main `tsc --build` was failing:

```
factory.ts(20,15): error TS2724: '"./sqlite/investigation.js"' has no exported member named 'IInvestigationRepository'
```

`factory.ts` imported the alias from `./sqlite/investigation.js`, but that file only *imports* `IInvestigationRepository` from `@agentic-obs/common` — it doesn't re-export. A recent cleanup likely dropped the re-export.

The canonical `IInvestigationRepository` is in `@agentic-obs/common` (the SQLite + Postgres impls implement it). The local `./interfaces.ts` has a same-named but **different** interface with extra members (`findBySession`, `findByUser`, `restore`, `findArchived`, ...) that the impls do not satisfy — so importing from there errors too.

Fix: pull `IInvestigationRepository` from `@agentic-obs/common` alongside the other repo interfaces already imported from there.

```
npm run build  # now green
```