### PR TITLE
feat(demo): expose pod CPU + node + kube-state metrics (production-grade)

### DIFF
--- a/demo/rounds-demo.yaml
+++ b/demo/rounds-demo.yaml
@@ -27,6 +27,14 @@ rules:
   - apiGroups: [""]
     resources: [pods, services, endpoints]
     verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [nodes, nodes/metrics]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [nodes/proxy]
+    verbs: [get]
+  - nonResourceURLs: ["/metrics"]
+    verbs: [get]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -74,6 +82,60 @@ data:
             target_label: app
           - source_labels: [__meta_kubernetes_pod_name]
             target_label: pod
+
+      - job_name: kubernetes-cadvisor
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+
+      - job_name: kubernetes-kubelet
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+
+      - job_name: kubernetes-kubelet-resource
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/resource
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -213,5 +275,206 @@ spec:
               while true; do
                 wget -q -O- http://nginx.rounds-demo/ >/dev/null
                 wget -q -O- http://nginx.rounds-demo/error >/dev/null 2>&1 || true
+                wget -q -O- http://example-app.rounds-demo:8080/ >/dev/null 2>&1 || true
+                wget -q -O- http://example-app.rounds-demo:8080/err >/dev/null 2>&1 || true
                 sleep 0.5
               done
+---
+# -- kube-state-metrics --------------------------------------------------
+# Cluster-level object state: pod phase, deployment replicas, container
+# restarts, etc. Scraped via pod annotations.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics-rounds-demo
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - serviceaccounts
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: [list, watch]
+  - apiGroups: [apps]
+    resources: [statefulsets, daemonsets, deployments, replicasets]
+    verbs: [list, watch]
+  - apiGroups: [batch]
+    resources: [cronjobs, jobs]
+    verbs: [list, watch]
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [list, watch]
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies, ingresses]
+    verbs: [list, watch]
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses, volumeattachments]
+    verbs: [list, watch]
+  - apiGroups: [certificates.k8s.io]
+    resources: [certificatesigningrequests]
+    verbs: [list, watch]
+  - apiGroups: [policy]
+    resources: [poddisruptionbudgets]
+    verbs: [list, watch]
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [mutatingwebhookconfigurations, validatingwebhookconfigurations]
+    verbs: [list, watch]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics-rounds-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics-rounds-demo
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: rounds-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: kube-state-metrics}
+  template:
+    metadata:
+      labels: {app: kube-state-metrics}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+            - name: telemetry
+              containerPort: 8081
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-demo
+spec:
+  selector: {app: kube-state-metrics}
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: 8080
+---
+# -- node-exporter -------------------------------------------------------
+# Host-level CPU/memory/disk/network metrics. DaemonSet, one per node.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: rounds-demo
+spec:
+  selector:
+    matchLabels: {app: node-exporter}
+  template:
+    metadata:
+      labels: {app: node-exporter}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+        prometheus.io/path: "/metrics"
+    spec:
+      hostPID: true
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.8.2
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+          ports:
+            - containerPort: 9100
+              name: metrics
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath: {path: /proc}
+        - name: sys
+          hostPath: {path: /sys}
+        - name: root
+          hostPath: {path: /}
+---
+# -- prometheus-example-app ----------------------------------------------
+# Tiny ready-made app emitting http_requests_total + duration histogram.
+# Gives dashboards real RED metrics out of the box.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: rounds-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: example-app}
+  template:
+    metadata:
+      labels: {app: example-app}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: app
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-app
+  namespace: rounds-demo
+spec:
+  selector: {app: example-app}
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
## Summary

Brings the Rounds demo cluster up to the metric surface a real production cluster exposes. Before: only nginx + nginx-prometheus-exporter scraped via pod annotations. After: pod-level resource usage, node host metrics, cluster object state, and real RED metrics from a sample app — all wired up in a single `demo/rounds-demo.yaml`.

## New scrape targets

- **kube-state-metrics** (Deployment + Service + RBAC, image `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0`) — pod phase, restart counts, deployment replica status, HPA state, etc. Scraped via pod annotation on `:8080/metrics`.
- **node-exporter** (DaemonSet, image `quay.io/prometheus/node-exporter:v1.8.2`, `hostPID` + `hostNetwork`, `/proc` `/sys` `/` mounted read-only) — host CPU / memory / filesystem / network. Scraped via pod annotation on `:9100/metrics`.
- **cAdvisor via kubelet proxy** (new `kubernetes-cadvisor` job, `role: node` SD, `__metrics_path__` rewritten to `/api/v1/nodes/<node>/proxy/metrics/cadvisor`, in-cluster bearer token + CA) — per-container CPU / memory / network / disk.
- **kubelet `/metrics`** (`kubernetes-kubelet` job) and **kubelet `/metrics/resource`** (`kubernetes-kubelet-resource` job) — kubelet runtime metrics + the lightweight per-pod resource summary.
- **prometheus-example-app** (Deployment x2 + Service, `quay.io/brancz/prometheus-example-app:v0.5.0`) — emits `http_requests_total{status,path}` + `http_request_duration_seconds_bucket` for ready-made RED dashboards. The existing load generator now also hits this service.

RBAC: the Prometheus `ClusterRole` gains `nodes`, `nodes/proxy`, `nodes/metrics` and the `/metrics` non-resource URL so the new jobs can authenticate against kubelet via the API server proxy. kube-state-metrics gets its own minimal `ClusterRole` covering the resources it reflects.

Existing nginx + load-generator setup is untouched.

## Example PromQL queries Rounds users can now run

- `rate(container_cpu_usage_seconds_total{namespace="rounds-demo",container!="POD",container!=""}[1m])` — per-container CPU rate (cAdvisor).
- `container_memory_working_set_bytes{namespace="rounds-demo",container!=""}` — per-container working set (cAdvisor).
- `kube_pod_status_phase{namespace="rounds-demo",phase="Running"}` — pod phase counts (kube-state-metrics).
- `sum by (status) (rate(http_requests_total[1m]))` — request rate split by status (example-app, RED).
- `1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)` — node memory pressure (node-exporter).

## Test plan

- [x] `kubectl apply --dry-run=client -f demo/rounds-demo.yaml` succeeds.
- [x] `kubectl apply -f demo/rounds-demo.yaml` on local kind cluster — all 8 pods Running.
- [x] Port-forward `:9090/api/v1/targets` shows all 4 jobs (`rounds-demo-pods`, `kubernetes-cadvisor`, `kubernetes-kubelet`, `kubernetes-kubelet-resource`) `up`.
- [x] All 5 example queries above return non-empty results against the live cluster.