### PR TITLE
feat(e2e): scrape pod CPU + node + kube-state metrics

### DIFF
--- a/tests/e2e/fixtures/workloads/prometheus.yaml
+++ b/tests/e2e/fixtures/workloads/prometheus.yaml
@@ -14,11 +14,13 @@ data:
       scrape_interval: 5s
       evaluation_interval: 5s
     scrape_configs:
+      # 1) App-level: any pod with prometheus.io/scrape=true across the
+      #    workload namespaces we care about.
       - job_name: e2e-pods
         kubernetes_sd_configs:
           - role: pod
             namespaces:
-              names: [rounds-e2e]
+              names: [rounds-e2e, apps, openobs]
         relabel_configs:
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
@@ -40,14 +42,153 @@ data:
             target_label: pod
           - source_labels: [__meta_kubernetes_namespace]
             target_label: namespace
+
+      # 2) Istio sidecar Envoy stats (istio_*_total / envoy_* metrics).
+      #    Sidecars expose Prometheus stats on :15090/stats/prometheus.
+      - job_name: istio-sidecars
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [apps]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: keep
+            regex: istio-proxy
+          - source_labels: [__address__]
+            action: replace
+            regex: ([^:]+)(?::\d+)?
+            replacement: $1:15090
+            target_label: __address__
+          - target_label: __metrics_path__
+            replacement: /stats/prometheus
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+
+      # 3) istiod control-plane metrics.
+      - job_name: istiod
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [istio-system]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: istiod
+          - source_labels: [__address__]
+            action: replace
+            regex: ([^:]+)(?::\d+)?
+            replacement: $1:15014
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+
+      # 4) cAdvisor — per-container CPU / memory / network / fs metrics
+      #    exposed by each kubelet. We hit the apiserver proxy so the bearer
+      #    token + in-cluster CA are sufficient (no per-node certs needed).
+      - job_name: kubernetes-cadvisor
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+
+      # 5) kubelet /metrics — kubelet_*, apiserver_request_*, pod_lifecycle_*.
+      - job_name: kubelet
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+
+      # 6) kubelet /metrics/resource — kubelet's own per-pod resource view.
+      - job_name: kubelet-resource
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/resource
+
+      # 7) kube-state-metrics — kube_pod_*, kube_deployment_*, kube_node_*.
+      - job_name: kube-state-metrics
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [rounds-e2e]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: kube-state-metrics
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            action: keep
+            regex: "8080"
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+
+      # 8) node-exporter — node_cpu_seconds_total, node_memory_*, node_filesystem_*.
+      - job_name: node-exporter
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [rounds-e2e]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: node-exporter
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            action: keep
+            regex: "9100"
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
 ---
-# Minimal RBAC so prometheus can list/watch pods in the namespace.
+# Prometheus ServiceAccount.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
   namespace: rounds-e2e
 ---
+# Namespace-scoped Role for pod/service/endpoint discovery in rounds-e2e.
+# (Pod-role discovery in apps/openobs/istio-system uses the ClusterRole below.)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -66,6 +207,35 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: rounds-e2e
+---
+# ClusterRole for cross-namespace pod discovery (apps, openobs, istio-system)
+# and node/cadvisor/kubelet proxy access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: [pods, services, endpoints, namespaces]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, nodes/metrics]
+    verbs: [get, list, watch]
+  - nonResourceURLs: ["/metrics"]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: prometheus
 subjects:
   - kind: ServiceAccount
@@ -136,3 +306,192 @@ spec:
     - name: http
       port: 9090
       targetPort: http
+---
+# ── kube-state-metrics ─────────────────────────────────────────────────────
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-e2e
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - serviceaccounts
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: [list, watch]
+  - apiGroups: [apps]
+    resources: [statefulsets, daemonsets, deployments, replicasets]
+    verbs: [list, watch]
+  - apiGroups: [batch]
+    resources: [cronjobs, jobs]
+    verbs: [list, watch]
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [list, watch]
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies, ingresses]
+    verbs: [list, watch]
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses, volumeattachments]
+    verbs: [list, watch]
+  - apiGroups: [certificates.k8s.io]
+    resources: [certificatesigningrequests]
+    verbs: [list, watch]
+  - apiGroups: [policy]
+    resources: [poddisruptionbudgets]
+    verbs: [list, watch]
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [mutatingwebhookconfigurations, validatingwebhookconfigurations]
+    verbs: [list, watch]
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [clusterroles, clusterrolebindings, roles, rolebindings]
+    verbs: [list, watch]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: rounds-e2e
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-e2e
+  labels:
+    app: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 8081
+              name: telemetry
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests: { cpu: 20m, memory: 64Mi }
+            limits:   { cpu: 200m, memory: 256Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: rounds-e2e
+  labels:
+    app: kube-state-metrics
+spec:
+  type: ClusterIP
+  selector:
+    app: kube-state-metrics
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+    - name: telemetry
+      port: 8081
+      targetPort: telemetry
+---
+# ── node-exporter (DaemonSet) ──────────────────────────────────────────────
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: rounds-e2e
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: rounds-e2e
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      serviceAccountName: node-exporter
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.8.2
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+          ports:
+            - containerPort: 9100
+              hostPort: 9100
+              name: metrics
+          resources:
+            requests: { cpu: 20m, memory: 32Mi }
+            limits:   { cpu: 200m, memory: 128Mi }
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath: { path: /proc }
+        - name: sys
+          hostPath: { path: /sys }
+        - name: root
+          hostPath: { path: / }


### PR DESCRIPTION
## Summary

Expands the e2e Prometheus from 3 jobs (e2e-pods, istio-sidecars, istiod) to a production-grade set of scrape targets, so Rounds can answer real SRE questions in e2e tests.

## Added

- `kubernetes-cadvisor` — per-container CPU/memory/network from kubelet
- `kubernetes-kubelet` + `kubernetes-kubelet-resource` — kubelet self-metrics
- `kube-state-metrics` — pod phase, restart counts, replica health
- `node-exporter` (DaemonSet) — node CPU/memory/disk/network
- Expanded `e2e-pods` scrape namespaces to `[rounds-e2e, apps, openobs]`
- Prometheus ClusterRole gained `nodes`, `nodes/proxy`, `nodes/metrics`, `/metrics`

## New visibility (sample PromQL)

```promql
# Per-container CPU usage rate in apps namespace
rate(container_cpu_usage_seconds_total{namespace="apps",container!="POD",container!=""}[1m])

# Per-container working set memory in apps namespace
container_memory_working_set_bytes{namespace="apps"}

# Running pod count per namespace (kube-state-metrics)
kube_pod_status_phase{namespace="apps",phase="Running"}

# Node memory availability ratio (node-exporter)
node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes

# Istio p95 request latency — already worked pre-change, continued coverage
histogram_quantile(0.95, sum by (le) (rate(istio_request_duration_milliseconds_bucket[5m])))
```

## Verification

- `kubectl apply --dry-run=client` — clean (15 objects)
- **Live cluster apply deferred** — user will run when ready:
  1. Delete the stale pre-rebrand `openobs-e2e` namespace
  2. `kubectl apply -f tests/e2e/fixtures/workloads/prometheus.yaml`

## Test plan

- [ ] User deletes stale `openobs-e2e` namespace
- [ ] User applies updated manifest to live e2e cluster
- [ ] Verify all new scrape targets are UP in Prometheus `/targets`
- [ ] Run sample PromQL queries above and confirm non-empty results