### PR TITLE
fix(web): wire Add Connector button to real POST /api/connectors

### DIFF
--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -6,6 +6,20 @@ import { llmBaseUrlPlaceholder } from '../constants/placeholders.js';
 import { LLM_PROVIDERS } from './setup/types.js';
 import type { LlmProvider, LlmConfig } from './setup/types.js';
 import { useAuth } from '../contexts/AuthContext.js';
+import type { ConnectorType } from '@agentic-obs/common';
+
+const CONNECTOR_TYPES: ConnectorType[] = [
+  'prometheus',
+  'victoria-metrics',
+  'loki',
+  'elasticsearch',
+  'clickhouse',
+  'tempo',
+  'jaeger',
+  'otel',
+  'kubernetes',
+  'github',
+];
 
 interface ModelInfo { id: string; name: string; provider: string; description?: string; }
 
@@ -334,6 +348,13 @@ function ConnectorsTab({ canWrite }: { canWrite: boolean }) {
   const [connectors, setConnectors] = useState<ConnectorRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formType, setFormType] = useState<ConnectorType>('prometheus');
+  const [formName, setFormName] = useState('');
+  const [formId, setFormId] = useState('');
+  const [formUrl, setFormUrl] = useState('');
+  const [formIsDefault, setFormIsDefault] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -349,6 +370,35 @@ function ConnectorsTab({ canWrite }: { canWrite: boolean }) {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+
+  const resetForm = () => {
+    setFormType('prometheus');
+    setFormName('');
+    setFormId('');
+    setFormUrl('');
+    setFormIsDefault(false);
+  };
+
+  const handleCreate = async () => {
+    setSubmitting(true);
+    setError(null);
+    const body: Record<string, unknown> = {
+      type: formType,
+      name: formName,
+      config: { url: formUrl },
+      isDefault: formIsDefault,
+    };
+    if (formId.trim()) body['id'] = formId.trim();
+    const res = await apiClient.post<{ connector: ConnectorRow }>('/connectors', body);
+    setSubmitting(false);
+    if (res.error) {
+      setError(res.error.message ?? 'Failed to create connector');
+      return;
+    }
+    setShowForm(false);
+    resetForm();
+    await load();
+  };
 
   return (
     <div className="space-y-5">
@@ -371,13 +421,83 @@ function ConnectorsTab({ canWrite }: { canWrite: boolean }) {
           type="button"
           disabled={!canWrite}
           className={btnPrimary}
-          onClick={() => setError('Connector creation will call POST /api/connectors once the backend route lands.')}
+          onClick={() => { setError(null); setShowForm((v) => !v); }}
         >
-          Add Connector
+          {showForm ? 'Cancel' : 'Add Connector'}
         </button>
       </div>
 
-      {!loading && connectors.length === 0 && !error && (
+      {showForm && (
+        <form
+          onSubmit={(e) => { e.preventDefault(); void handleCreate(); }}
+          className="rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface)] p-4 space-y-3"
+        >
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Type</label>
+            <select
+              value={formType}
+              onChange={(e) => setFormType(e.target.value as ConnectorType)}
+              className={selectCls}
+            >
+              {CONNECTOR_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Name</label>
+            <input
+              type="text"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              placeholder="e.g. Prod Prometheus"
+              className={inputCls}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">ID (optional)</label>
+            <input
+              type="text"
+              value={formId}
+              onChange={(e) => setFormId(e.target.value)}
+              placeholder="auto-generated if blank"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">URL</label>
+            <input
+              type="url"
+              value={formUrl}
+              onChange={(e) => setFormUrl(e.target.value)}
+              placeholder="http://prometheus.monitoring.svc:9090"
+              className={inputCls}
+              required
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-[var(--color-on-surface)]">
+            <input type="checkbox" checked={formIsDefault} onChange={(e) => setFormIsDefault(e.target.checked)} />
+            Set as default for this type
+          </label>
+          <p className="text-xs text-[var(--color-on-surface-variant)]">
+            Advanced config (auth headers, TLS, etc.): edit via Policies after creation.
+          </p>
+          <div className="flex justify-end gap-2 pt-2 border-t border-[var(--color-outline-variant)]/30">
+            <button
+              type="button"
+              onClick={() => { setShowForm(false); resetForm(); }}
+              className={btnSecondary}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className={btnPrimary} disabled={submitting || !formName || !formUrl}>
+              {submitting ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {!loading && connectors.length === 0 && !error && !showForm && (
         <div className="rounded-lg border border-dashed border-[var(--color-outline-variant)] p-6 text-sm text-[var(--color-on-surface-variant)]">
           No connectors yet.
         </div>


### PR DESCRIPTION
## Summary

The Add Connector button on the Settings > Connectors tab was a stub. Its `onClick` set a misleading error banner:

```tsx
onClick={() => setError('Connector creation will call POST /api/connectors once the backend route lands.')}
```

The backend route has actually been live the whole time — `packages/api-gateway/src/routes/connectors.ts:113` defines `router.post('/', ...)` with validation, conflict detection, and returns `{ connector }` on 201. The button was just never wired up.

This PR removes the stale stub and adds an inline form (no modal lib, no new abstractions) that POSTs to `/api/connectors` and refreshes the list on success.

### New form (inline section, matches existing `inputCls` / `btnPrimary` conventions)

```tsx
<form onSubmit={(e) => { e.preventDefault(); void handleCreate(); }} ...>
  <select value={formType} ...>{CONNECTOR_TYPES.map(...)}</select>
  <input value={formName} ... required />
  <input value={formId} ... />            {/* optional, auto-generated if blank */}
  <input type="url" value={formUrl} ... required />
  <input type="checkbox" checked={formIsDefault} ... /> Set as default
  <button type="submit">Create</button>
</form>
```

POST body: `{ type, name, config: { url }, isDefault, id? }` — `id` only sent when user supplied one (matches the route's optional handling). Config is intentionally url-only; advanced fields (auth headers, TLS) are flagged for follow-up via Policies, matching the shape of the seeded `dev/PROMETHEUS` row.

Error path: 4xx/5xx server `error.message` is shown in the existing error banner. Success: form closes, list reloads via the existing `load()` callback.

`ConnectorType` is imported from `@agentic-obs/common` and listed explicitly to populate the type dropdown.

## Test plan

- [x] `npm run build` in `packages/web` passes (tsc + vite).
- [ ] Manual: click Add Connector, fill type=prometheus / name=Local / url=http://localhost:9090, submit, see the new row appear.
- [ ] Manual: submit with duplicate id, confirm the 409 conflict message renders in the error banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connector creation form to the Connectors settings tab. Users can now add new connectors directly by specifying type, name, URL, and configuration options. The form displays submission progress and error messages for enhanced feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->