### PR TITLE
feat(plans): resolve requesterTeamId from alert rule's folder permissions

### DIFF
--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -26,7 +26,7 @@ import {
   EventEmittingApprovalRepository,
   EventEmittingFeedRepository,
 } from '@agentic-obs/data-layer';
-import type { IFolderRepository } from '@agentic-obs/common';
+import { PermissionLevel, type IFolderRepository } from '@agentic-obs/common';
 import { healthRouter } from '../routes/health.js';
 import { sessionsRouter } from '../routes/sessions.js';
 import { metricsRouter } from '../routes/metrics.js';
@@ -53,6 +53,7 @@ import { authMiddleware } from '../middleware/auth.js';
 import { createOrgContextMiddleware } from '../middleware/org-context.js';
 import { SetupConfigService } from '../services/setup-config-service.js';
 import type { AccessControlService } from '../services/accesscontrol-service.js';
+import { ResourcePermissionService } from '../services/resource-permission-service.js';
 import type { AuthSubsystem } from '../auth/auth-manager.js';
 import type { AuthRepositories } from './auth-routes.js';
 import type { Persistence } from './persistence.js';
@@ -170,6 +171,16 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
   const eventApprovalStore = new EventEmittingApprovalRepository(repos.approvals);
   const eventAlertRuleStore = deps.eventAlertRuleStore
     ?? new EventEmittingAlertRuleRepository(repos.alertRules);
+  const rbacRepos = deps.persistence.rbacRepos;
+  const resourcePermissionService = new ResourcePermissionService({
+    roles: rbacRepos.roles,
+    permissions: rbacRepos.permissions,
+    userRoles: rbacRepos.userRoles,
+    teamRoles: rbacRepos.teamRoles,
+    folders: rbacRepos.folders,
+    users: authRepos.users,
+    teams: rbacRepos.teams,
+  });
 
   app.use('/api/investigations', createInvestigationRouter({
     store: repos.investigations,
@@ -208,6 +219,20 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     connectors: repos.connectors,
     ac: accessControl,
     audit: authSub.audit,
+    resolveRequesterTeamId: async (orgId, investigationId) => {
+      const { list } = await eventAlertRuleStore.findAll();
+      const rule = list.find((r) => r.investigationId === investigationId);
+      if (!rule?.folderUid) return null;
+      const entries = await resourcePermissionService.list(
+        orgId,
+        'alert.rules',
+        rule.folderUid,
+      );
+      const teamEntry =
+        entries.find((e) => e.teamId && e.permission >= PermissionLevel.Edit)
+        ?? entries.find((e) => e.teamId);
+      return teamEntry?.teamId ?? null;
+    },
   });
   app.use('/api/notifications', createNotificationsRouter({
     notificationStore: repos.notifications,

--- a/packages/api-gateway/src/app/plans-boot.ts
+++ b/packages/api-gateway/src/app/plans-boot.ts
@@ -41,6 +41,8 @@ export interface MountPlansDeps {
   ac: AccessControlSurface;
   /** Optional audit writer; one row per plan-step execution when wired. */
   audit?: import('../auth/audit-writer.js').AuditWriter;
+  /** Resolve the team that owns the investigation's alert/folder context. */
+  resolveRequesterTeamId?: (orgId: string, investigationId: string) => Promise<string | null>;
   /** Override for tests; defaults to env-backed `DefaultOpsSecretRefResolver`. */
   secretResolver?: OpsSecretRefResolver;
 }
@@ -97,6 +99,7 @@ export function mountPlans(deps: MountPlansDeps): void {
     approvals: deps.approvals,
     adapterFor,
     ...(deps.audit ? { audit: deps.audit } : {}),
+    ...(deps.resolveRequesterTeamId ? { resolveRequesterTeamId: deps.resolveRequesterTeamId } : {}),
   });
 
   deps.app.use('/api/plans', createPlansRouter({


### PR DESCRIPTION
## What

Wire up the team-resolution path that PR #226 left as a FIXME.

## Why

PR #226 explicitly noted: \`ActionContext exposes no team resolver, alertRule → folder → team chain isn't threaded into agent-core\`. Result: every approval request created via PlanExecutor had \`requesterTeamId: null\`, so the per-team approval scoping in the repository layer received no input.

## How

- \`mountDomainRoutes\` constructs a \`ResourcePermissionService\` from \`rbacRepos\` and passes a \`resolveRequesterTeamId(orgId, investigationId)\` closure to \`mountPlans\`.
- The closure: lookup alert rule by investigationId → walk to its folder via folderUid → list resource permissions on folder → pick first team with Edit (fallback: first team).
- \`mountPlans\` forwards it into \`createPlanExecutorService\`.
- When no rule / no folderUid / no team is found: returns \`null\` (downstream consumers all handle null safely).

## Verification

- \`tsc --build\` clean