### PR TITLE
fix(metric-explore): short-circuit with summary when query returns no data

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/metric-explore.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/metric-explore.test.ts
@@ -10,7 +10,11 @@ import { makeFakeActionContext } from '../_test-helpers.js';
 import { AdapterRegistry } from '../../../adapters/registry.js';
 import type { ActionContext } from '../_context.js';
 
-function makeAdapters(rangeQuery = vi.fn().mockResolvedValue([])): AdapterRegistry {
+const NON_EMPTY_SERIES = [
+  { metric: { __name__: 'up' }, values: [[1, '1'], [2, '2']] },
+];
+
+function makeAdapters(rangeQuery = vi.fn().mockResolvedValue(NON_EMPTY_SERIES)): AdapterRegistry {
   const reg = new AdapterRegistry();
   reg.register({
     info: { id: 'prom', name: 'prom', type: 'prometheus', signalType: 'metrics' },
@@ -89,7 +93,7 @@ describe('handleMetricExplore — timeRange inheritance', () => {
     vi.useRealTimers();
   });
 
-  it('falls back to default 1h when no prior chart and no hint', async () => {
+  it('uses the default 1h range when no prior chart and no hint are available', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
     const lookup = vi.fn().mockResolvedValue(null);
@@ -107,6 +111,31 @@ describe('handleMetricExplore — timeRange inheritance', () => {
       new Date(inlineChart.timeRange.end).getTime() -
       new Date(inlineChart.timeRange.start).getTime();
     expect(span).toBe(60 * 60_000);
+    vi.useRealTimers();
+  });
+
+  it('does not emit an inline chart when the query returns no samples', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    const ctx = makeFakeActionContext({
+      adapters: makeAdapters(vi.fn().mockResolvedValue([])),
+      allConnectors: [{ id: 'prom', type: 'prometheus' } as never],
+    });
+    const observation = await handleMetricExplore(ctx, {
+      query: 'rate(process_cpu_seconds_total{job="istio-sidecars"}[5m])',
+      timeRangeHint: '1h',
+    });
+
+    const events = (ctx.sendEvent as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0]);
+    expect(events.some((e) => e?.type === 'inline_chart')).toBe(false);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'tool_result',
+      tool: 'metric_explore',
+      success: true,
+      summary: expect.stringContaining('No data returned'),
+    }));
+    expect(observation).toContain('No data returned');
     vi.useRealTimers();
   });
 

--- a/packages/agent-core/src/agent/handlers/metric-explore.ts
+++ b/packages/agent-core/src/agent/handlers/metric-explore.ts
@@ -125,6 +125,14 @@ const VALID_KINDS: ReadonlySet<ChartMetricKind> = new Set([
   'latency', 'counter', 'gauge', 'errors',
 ]);
 
+function hasFiniteSamples(
+  series: Array<{ values: Array<[number, string]> }>,
+): boolean {
+  return series.some((s) =>
+    s.values.some(([, raw]) => Number.isFinite(Number.parseFloat(raw))),
+  );
+}
+
 /** Resolve the metrics datasource id — explicit > session pin > primary. */
 function resolveDatasourceId(
   ctx: ActionContext,
@@ -226,6 +234,37 @@ export async function handleMetricExplore(
 
   try {
     const series = await adapter.rangeQuery(query, range.start, range.end, step);
+    if (!hasFiniteSamples(series)) {
+      const summary = `No data returned for query "${query}" in the selected time range.`;
+
+      if (ctx.auditWriter) {
+        void ctx.auditWriter({
+          action: AuditAction.MetricsQuery,
+          actorType: 'user',
+          actorId: ctx.identity.userId,
+          targetType: 'connector',
+          targetId: datasourceId,
+          outcome: 'success',
+          metadata: {
+            orgId: ctx.identity.orgId,
+            query: query.slice(0, 500),
+            step,
+            source: 'agent_tool',
+            sessionId: ctx.sessionId,
+            noData: true,
+          },
+        });
+      }
+
+      ctx.sendEvent({
+        type: 'tool_result',
+        tool: 'metric_explore',
+        summary,
+        success: true,
+      });
+      return summary;
+    }
+
     const summary = summarizeChart(series, kind);
     const pivotSuggestions = suggestPivots({ query, metricKind: kind, summary });
 


### PR DESCRIPTION
## Symptom

User asks AI for some metric → AI calls \`metric_explore\` → \`rangeQuery\` returns either an empty array or a series with all-NaN values (metric not being scraped, label filter no match, time range too narrow). Current code still calls \`summarizeChart\` on empty input, emits an \`inline_chart\` event for an empty series. User sees a blank panel and the LLM proceeds to hallucinate analysis on nothing.

## Fix

Detect \"no finite samples\" before summarization. On hit:

- Audit log with \`noData: true\`
- Emit \`tool_result\` event (not \`inline_chart\`) with a one-line \"no data\" summary
- Return the summary string to the LLM so the next ReAct step can widen the range, try a different query, or admit the metric isn't available

## Why it matters

Without this signal the agent thinks the query worked, summarizes a blank chart as if it had data, and the user reads invented numbers. This is the most common cause of \"AI looks confident but is wrong\" feedback.

## Verification

- Unit tests added for both branches
- \`tsc --build\` + agent-core vitest clean