### PR TITLE
fix(data-layer): stop swallowing JSON.parse errors in Postgres repositories

### DIFF
--- a/packages/data-layer/src/repository/postgres/alert-rule.ts
+++ b/packages/data-layer/src/repository/postgres/alert-rule.ts
@@ -1,4 +1,5 @@
 import { pgAll, pgRun } from './pg-helpers.js';
+import { createLogger } from '@agentic-obs/server-utils/logging';
 /**
  * AlertRuleRepository — SQLite-backed replacement for the in-memory
  * AlertRuleStore (W6 / T6.A3).
@@ -48,6 +49,8 @@ import type {
   AlertRuleFindAllOptions,
 } from '../interfaces.js';
 import { nowIso } from '../sqlite/instance-shared.js';
+
+const log = createLogger('alert-rule-repository');
 
 // -- Row shapes (snake_case, matches `SELECT *` output) ----------------
 
@@ -119,12 +122,25 @@ interface PolicyRow {
  * repo — we log nothing here (route layer will surface the problem) and
  * return the default shape so callers get a well-formed object.
  */
-function parseJsonOr<T>(raw: string | null | undefined, dflt: T): T {
+function parseJsonOr<T>(
+  raw: string | null | undefined,
+  dflt: T,
+  rowId: string,
+  column: string,
+): T {
   if (raw === null || raw === undefined || raw === '') return dflt;
   try {
     return JSON.parse(raw) as T;
-  } catch {
-    return dflt;
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in alert-rule row — refusing to return fallback',
+    );
+    throw new Error(
+      `[AlertRuleRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }
 
@@ -140,7 +156,7 @@ function stringifyJsonOrNull(value: unknown): string | null {
 // -- Row → domain mappers ---------------------------------------------
 
 function rowToRule(r: RuleRow): AlertRule {
-  const labels = parseJsonOr<Record<string, string> | null>(r.labels, null);
+  const labels = parseJsonOr<Record<string, string> | null>(r.labels, null, r.id, 'labels');
   const rule: AlertRule = {
     id: r.id,
     name: r.name,
@@ -150,7 +166,7 @@ function rowToRule(r: RuleRow): AlertRule {
       operator: '>',
       threshold: 0,
       forDurationSec: 0,
-    }),
+    }, r.id, 'condition'),
     evaluationIntervalSec: r.evaluation_interval_sec,
     severity: r.severity as AlertRule['severity'],
     state: r.state as AlertRuleState,
@@ -169,7 +185,7 @@ function rowToRule(r: RuleRow): AlertRule {
   if (r.workspace_id !== null) rule.workspaceId = r.workspace_id;
   if (r.last_evaluated_at !== null) rule.lastEvaluatedAt = r.last_evaluated_at;
   if (r.last_fired_at !== null) rule.lastFiredAt = r.last_fired_at;
-  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null);
+  const prov = parseJsonOr<ResourceProvenance | null>(r.provenance, null, r.id, 'provenance');
   if (prov) rule.provenance = prov;
   return rule;
 }
@@ -184,7 +200,7 @@ function rowToHistoryEntry(r: HistoryRow): AlertHistoryEntry {
     value: r.value,
     threshold: r.threshold,
     timestamp: r.timestamp,
-    labels: parseJsonOr<Record<string, string>>(r.labels, {}),
+    labels: parseJsonOr<Record<string, string>>(r.labels, {}, r.id, 'history.labels'),
   };
 }
 
@@ -198,7 +214,7 @@ function computeSilenceStatus(silence: { startsAt: string; endsAt: string }): Si
 function rowToSilence(r: SilenceRow): AlertSilence {
   const base = {
     id: r.id,
-    matchers: parseJsonOr<AlertSilence['matchers']>(r.matchers, []),
+    matchers: parseJsonOr<AlertSilence['matchers']>(r.matchers, [], r.id, 'silence.matchers'),
     startsAt: r.starts_at,
     endsAt: r.ends_at,
     comment: r.comment,
@@ -212,12 +228,12 @@ function rowToPolicy(r: PolicyRow): NotificationPolicy {
   const p: NotificationPolicy = {
     id: r.id,
     name: r.name,
-    matchers: parseJsonOr<NotificationPolicy['matchers']>(r.matchers, []),
-    channels: parseJsonOr<NotificationPolicy['channels']>(r.channels, []),
+    matchers: parseJsonOr<NotificationPolicy['matchers']>(r.matchers, [], r.id, 'policy.matchers'),
+    channels: parseJsonOr<NotificationPolicy['channels']>(r.channels, [], r.id, 'policy.channels'),
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
-  if (r.group_by !== null) p.groupBy = parseJsonOr<string[]>(r.group_by, []);
+  if (r.group_by !== null) p.groupBy = parseJsonOr<string[]>(r.group_by, [], r.id, 'policy.group_by');
   if (r.group_wait_sec !== null) p.groupWaitSec = r.group_wait_sec;
   if (r.group_interval_sec !== null) p.groupIntervalSec = r.group_interval_sec;
   if (r.repeat_interval_sec !== null) p.repeatIntervalSec = r.repeat_interval_sec;
@@ -313,7 +329,7 @@ export class AlertRuleRepository implements IAlertRuleRepository {
     if (filter.search) {
       const q = filter.search.toLowerCase();
       rows = rows.filter((r) => {
-        const labels = parseJsonOr<Record<string, string>>(r.labels, {});
+        const labels = parseJsonOr<Record<string, string>>(r.labels, {}, r.id, 'labels');
         return (
           r.name.toLowerCase().includes(q)
           || r.description.toLowerCase().includes(q)

--- a/packages/data-layer/src/repository/postgres/dashboard.ts
+++ b/packages/data-layer/src/repository/postgres/dashboard.ts
@@ -1,4 +1,5 @@
 import { pgAll, pgRun } from './pg-helpers.js';
+import { createLogger } from '@agentic-obs/server-utils/logging';
 /**
  * DashboardRepository — Postgres-backed dashboard store (W6 / T6.A1).
  *
@@ -45,6 +46,8 @@ import type {
   ResourceSource,
   ResourceProvenance,
 } from '@agentic-obs/common';
+
+const log = createLogger('dashboard-repository');
 // -- Row shape ---------------------------------------------------------
 
 interface DashboardRow {
@@ -76,14 +79,32 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function parseJsonArray<T>(raw: string | null | undefined, fallback: T[] = []): T[] {
-  if (raw === null || raw === undefined || raw === '') return fallback;
+function parseJsonArray<T>(raw: string | null | undefined, rowId: string, column: string): T[] {
+  if (raw === null || raw === undefined || raw === '') return [];
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as T[]) : fallback;
-  } catch {
-    return fallback;
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in dashboards row — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
+  if (!Array.isArray(parsed)) {
+    log.error(
+      { rowId, column, actualType: typeof parsed },
+      'dashboards JSON column is not an array — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] expected array in column "${column}" for row ${rowId}, got ${typeof parsed}`,
+    );
+  }
+  return parsed as T[];
 }
 
 function toBool(v: unknown): boolean {
@@ -95,14 +116,26 @@ function fromBool(v: boolean | undefined, dflt = false): number {
   return (v ?? dflt) ? 1 : 0;
 }
 
-function parseProvenance(raw: string | null): ResourceProvenance | undefined {
+function parseProvenance(raw: string | null, rowId: string): ResourceProvenance | undefined {
   if (raw === null || raw === undefined || raw === '') return undefined;
+  let parsed: unknown;
   try {
-    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    return parsed && typeof parsed === 'object' ? (parsed as ResourceProvenance) : undefined;
-  } catch {
-    return undefined;
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.error(
+      { rowId, column: 'provenance', err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in dashboards.provenance — refusing to return fallback',
+    );
+    throw new Error(
+      `[DashboardRepository] corrupt JSON in column "provenance" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`[DashboardRepository] expected object in column "provenance" for row ${rowId}`);
+  }
+  return parsed as ResourceProvenance;
 }
 
 function rowToDashboard(r: DashboardRow): Dashboard {
@@ -114,10 +147,10 @@ function rowToDashboard(r: DashboardRow): Dashboard {
     prompt: r.prompt,
     userId: r.user_id,
     status: r.status as DashboardStatus,
-    panels: parseJsonArray<PanelConfig>(r.panels, []),
-    variables: parseJsonArray<DashboardVariable>(r.variables, []),
+    panels: parseJsonArray<PanelConfig>(r.panels, r.id, 'panels'),
+    variables: parseJsonArray<DashboardVariable>(r.variables, r.id, 'variables'),
     refreshIntervalSec: r.refresh_interval_sec,
-    datasourceIds: parseJsonArray<string>(r.datasource_ids, []),
+    datasourceIds: parseJsonArray<string>(r.datasource_ids, r.id, 'datasource_ids'),
     useExistingMetrics: toBool(r.use_existing_metrics),
     source: (r.source ?? 'manual') as ResourceSource,
     createdAt: r.created_at,
@@ -128,7 +161,7 @@ function rowToDashboard(r: DashboardRow): Dashboard {
   if (r.version !== null) base.version = r.version;
   if (r.publish_status !== null) base.publishStatus = r.publish_status as PublishStatus;
   if (r.error !== null) base.error = r.error;
-  const prov = parseProvenance(r.provenance);
+  const prov = parseProvenance(r.provenance, r.id);
   if (prov) base.provenance = prov;
   return base;
 }
@@ -389,4 +422,3 @@ export class DashboardRepository implements IDashboardRepository {
     }
   }
 }
-

--- a/packages/data-layer/src/repository/postgres/investigation.ts
+++ b/packages/data-layer/src/repository/postgres/investigation.ts
@@ -1,4 +1,5 @@
 import { pgAll, pgRun } from './pg-helpers.js';
+import { createLogger } from '@agentic-obs/server-utils/logging';
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import type {
@@ -10,6 +11,8 @@ import type {
 } from '@agentic-obs/common';
 import type { ExplanationResult } from '@agentic-obs/common';
 import type { FollowUpRecord, FeedbackBody, StoredFeedback } from '../types/investigation.js';
+
+const log = createLogger('investigation-repository');
 
 // =====================================================================
 // Postgres implementation of the canonical investigation repository contract.
@@ -63,12 +66,25 @@ interface ConclusionRow {
 
 // -- JSON helpers -----------------------------------------------------
 
-function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+function parseJson<T>(
+  raw: string | null | undefined,
+  fallback: T,
+  rowId: string,
+  column: string,
+): T {
   if (raw === null || raw === undefined || raw === '') return fallback;
   try {
     return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
+  } catch (err) {
+    log.error(
+      { rowId, column, err: err instanceof Error ? err.message : String(err) },
+      'corrupt JSON in investigations row — refusing to return fallback',
+    );
+    throw new Error(
+      `[InvestigationRepository] corrupt JSON in column "${column}" for row ${rowId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }
 
@@ -94,13 +110,15 @@ function rowToInvestigationV6(r: InvestigationRow): Investigation {
         timeRange: { start: '', end: '' },
         goal: r.intent,
       },
+      r.id,
+      'structured_intent',
     ),
-    plan: parseJson<Investigation['plan']>(r.plan, emptyPlan()),
+    plan: parseJson<Investigation['plan']>(r.plan, emptyPlan(), r.id, 'plan'),
     status: r.status as Investigation['status'],
-    hypotheses: parseJson<Investigation['hypotheses']>(r.hypotheses, []),
-    actions: parseJson<Investigation['actions']>(r.actions, []),
-    evidence: parseJson<Investigation['evidence']>(r.evidence, []),
-    symptoms: parseJson<Investigation['symptoms']>(r.symptoms, []),
+    hypotheses: parseJson<Investigation['hypotheses']>(r.hypotheses, [], r.id, 'hypotheses'),
+    actions: parseJson<Investigation['actions']>(r.actions, [], r.id, 'actions'),
+    evidence: parseJson<Investigation['evidence']>(r.evidence, [], r.id, 'evidence'),
+    symptoms: parseJson<Investigation['symptoms']>(r.symptoms, [], r.id, 'symptoms'),
     ...(r.workspace_id ? { workspaceId: r.workspace_id } : {}),
     createdAt: r.created_at,
     updatedAt: r.updated_at,
@@ -130,11 +148,15 @@ function rowToFeedback(r: FeedbackRow): StoredFeedback {
   const hyp = parseJson<StoredFeedback['hypothesisFeedbacks'] | null>(
     r.hypothesis_feedbacks,
     null,
+    r.id,
+    'feedback.hypothesis_feedbacks',
   );
   if (hyp !== null) base.hypothesisFeedbacks = hyp;
   const act = parseJson<StoredFeedback['actionFeedbacks'] | null>(
     r.action_feedbacks,
     null,
+    r.id,
+    'feedback.action_feedbacks',
   );
   if (act !== null) base.actionFeedbacks = act;
   return base;
@@ -435,7 +457,12 @@ export class PostgresInvestigationRepository implements IInvestigationRepository
       SELECT * FROM investigation_conclusions WHERE investigation_id = ${id}
     `);
     if (rows.length === 0) return null;
-    return parseJson<ExplanationResult | null>(rows[0]!.conclusion, null);
+    return parseJson<ExplanationResult | null>(
+      rows[0]!.conclusion,
+      null,
+      rows[0]!.investigation_id,
+      'conclusion',
+    );
   }
 
   async setConclusion(id: string, conclusion: ExplanationResult): Promise<void> {


### PR DESCRIPTION
## What

Postgres-side parity for PR #220.

PR #220 stopped \`JSON.parse → catch → return fallback\` in the SQLite repositories (dashboard, investigation, alert-rule). The Postgres twins had the same bug — they were not touched by that PR.

This PR applies the same fix to the Postgres repos:

- \`postgres/alert-rule.ts\` — \`parseJsonOr\` for labels, condition, provenance, matchers, channels, group_by, etc.
- \`postgres/dashboard.ts\` — equivalent parse helpers
- \`postgres/investigation.ts\` — equivalent parse helpers

## Behavior change

Before: corrupt row in Postgres → silently returns \`threshold=0\` for an alert rule (would never fire correctly), empty plan for an investigation, empty panels for a dashboard — and the bad row stays invisible.

After: \`log.error\` with rowId + column context, throw with the same message shape as SQLite. Route-level error handlers don't need to special-case either backend.

## Verification

- \`tsc --build\` clean
- Same helper signatures as SQLite side, so callers symmetric