### PR TITLE
Compact agent activity tool rendering

### DIFF
--- a/packages/web/src/components/chat/AgentActivityBlock.tsx
+++ b/packages/web/src/components/chat/AgentActivityBlock.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { ChatEvent } from '../../hooks/useDashboardChat.js';
-import { buildSteps, buildToolCalls } from './event-processing.js';
-import type { ToolCallCard } from './event-processing.js';
+import { buildSteps, buildToolActivityGroups } from './event-processing.js';
+import type { ToolActivityGroup, ToolCallCard } from './event-processing.js';
 
 // Icons
 
@@ -144,6 +144,49 @@ export function ToolCallCardView({ card }: { card: ToolCallCard }) {
   );
 }
 
+function ToolActivityRow({ group }: { group: ToolActivityGroup }) {
+  const detail = group.output ?? group.summary ?? '';
+  const shownDetail = detail.length > OUTPUT_PREVIEW_CHARS
+    ? `${detail.slice(0, OUTPUT_PREVIEW_CHARS)}…`
+    : detail;
+
+  return (
+    <div data-tool-activity-row data-tool={group.tool} className="py-1.5">
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="w-4 shrink-0 flex items-center justify-center">
+          <StatusIcon status={group.status} />
+        </div>
+        <span className="text-xs font-medium text-on-surface truncate">
+          {group.label}
+        </span>
+        {group.count > 1 && (
+          <span
+            data-testid="tool-activity-count"
+            className="text-[10px] text-on-surface-variant/70 tabular-nums shrink-0"
+          >
+            x{group.count}
+          </span>
+        )}
+        <span className="ml-auto text-[10px] font-mono text-on-surface-variant/60 truncate max-w-[11rem]">
+          {group.tool}
+        </span>
+        {typeof group.durationMs === 'number' && (
+          <span className="text-[10px] text-on-surface-variant/60 shrink-0 tabular-nums">
+            {group.durationMs >= 1000
+              ? `${(group.durationMs / 1000).toFixed(1)}s`
+              : `${group.durationMs}ms`}
+          </span>
+        )}
+      </div>
+      {shownDetail && (
+        <div className="ml-6 mt-0.5 text-[11px] font-mono text-on-surface-variant/80 truncate">
+          {shownDetail}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Collapsible agent activity block
 
 export default function AgentActivityBlock({
@@ -175,7 +218,7 @@ export default function AgentActivityBlock({
   };
 
   const { steps, preStatus } = useMemo(() => buildSteps(events), [events]);
-  const cards = useMemo(() => buildToolCalls(events), [events]);
+  const activityGroups = useMemo(() => buildToolActivityGroups(events), [events]);
 
   // Summary for collapsed state — phase-grouped (steps), so 5 metrics_query
   // events still summarize as one "Querying metrics" phase rather than 5.
@@ -231,14 +274,14 @@ export default function AgentActivityBlock({
             className="overflow-hidden"
           >
             <div className="mt-1 px-3 pb-2 border-l border-outline-variant">
-              {preStatus && cards.length === 0 && (
+              {preStatus && activityGroups.length === 0 && (
                 <div className="flex items-center gap-2 py-1.5">
                   <span className="w-2 h-2 rounded-full bg-primary animate-pulse shrink-0" />
                   <span className="text-xs text-on-surface-variant">{preStatus}</span>
                 </div>
               )}
-              {cards.map((card) => (
-                <ToolCallCardView key={card.id} card={card} />
+              {activityGroups.map((group) => (
+                <ToolActivityRow key={group.id} group={group} />
               ))}
             </div>
           </motion.div>

--- a/packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx
+++ b/packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import AgentActivityBlock, { ToolCallCardView } from '../AgentActivityBlock.js';
 import {
+  buildToolActivityGroups,
   buildToolCalls,
   groupEvents,
   liveAgentBlockId,
@@ -40,7 +41,7 @@ function makeResultEvent(idx: number, content = 'ok'): ChatEvent {
 }
 
 describe('buildToolCalls', () => {
-  it('produces one card per tool_call (no phase merging)', () => {
+  it('keeps one audit record per tool_call', () => {
     const events: ChatEvent[] = [];
     for (let i = 0; i < 5; i++) {
       events.push(makeToolCallEvent(i, { sourceId: 'prom', query: `up{i="${i}"}` }));
@@ -85,8 +86,37 @@ describe('buildToolCalls', () => {
   });
 });
 
+describe('buildToolActivityGroups', () => {
+  it('collapses repeated calls in the same phase into one visible activity', () => {
+    const events: ChatEvent[] = [];
+    for (let i = 0; i < 5; i++) {
+      events.push(makeToolCallEvent(i));
+      events.push(makeResultEvent(i, `result ${i}`));
+    }
+
+    const groups = buildToolActivityGroups(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe('Querying metrics');
+    expect(groups[0]?.count).toBe(5);
+    expect(groups[0]?.status).toBe('done');
+    expect(groups[0]?.summary).toBe('result 4');
+  });
+
+  it('keeps the grouped activity running while any call is pending', () => {
+    const groups = buildToolActivityGroups([
+      makeToolCallEvent(0),
+      makeResultEvent(0),
+      makeToolCallEvent(1),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.count).toBe(2);
+    expect(groups[0]?.status).toBe('running');
+  });
+});
+
 describe('ToolCallCardView', () => {
-  it('renders five distinct cards for five metrics_query events', () => {
+  it('still supports explicit per-call detail rendering', () => {
     const events: ChatEvent[] = [];
     for (let i = 0; i < 5; i++) {
       events.push(makeToolCallEvent(i));
@@ -165,6 +195,22 @@ describe('AgentActivityBlock aria-expanded', () => {
     const events: ChatEvent[] = [makeToolCallEvent(0), makeResultEvent(0)];
     const html = renderToStaticMarkup(<AgentActivityBlock events={events} isLive={false} />);
     expect(html).toContain('aria-expanded="false"');
+  });
+});
+
+describe('AgentActivityBlock activity rendering', () => {
+  it('renders repeated tool calls as one in-place activity row', () => {
+    const events: ChatEvent[] = [];
+    for (let i = 0; i < 5; i++) {
+      events.push(makeToolCallEvent(i));
+      events.push(makeResultEvent(i, `result ${i}`));
+    }
+
+    const html = renderToStaticMarkup(<AgentActivityBlock events={events} isLive={true} />);
+    const rows = html.match(/data-tool-activity-row/g) ?? [];
+    expect(rows).toHaveLength(1);
+    expect(html).toContain('x5');
+    expect(html).not.toContain('data-tool-call-card');
   });
 });
 

--- a/packages/web/src/components/chat/event-processing.ts
+++ b/packages/web/src/components/chat/event-processing.ts
@@ -90,6 +90,21 @@ export interface ToolCallCard {
   durationMs?: number;
 }
 
+export interface ToolActivityGroup {
+  id: string;
+  phase: string;
+  tool: string;
+  label: string;
+  status: ToolCallCard['status'];
+  count: number;
+  params?: Record<string, unknown>;
+  output?: string;
+  summary?: string;
+  evidenceId?: string;
+  cost?: number;
+  durationMs?: number;
+}
+
 export const USER_VISIBLE_TOOLS = new Set([
   // Orchestrator-level actions
   'generate_dashboard',
@@ -379,11 +394,11 @@ export function buildSteps(events: ChatEvent[]): { steps: StepRow[]; preStatus: 
 }
 
 /**
- * Build one card per user-visible tool_call event. Each card pairs to the
- * NEXT matching tool_result for the same tool name (FIFO within a tool).
+ * Build one data object per user-visible tool_call event. Each card pairs to
+ * the NEXT matching tool_result for the same tool name (FIFO within a tool).
  *
- * This is intentionally per-call (not phase-merged) so users see every step
- * the agent ran — five `metrics_query` calls produce five cards.
+ * The chat UI should group these for display; this lower-level shape stays
+ * per-call so audit/debug surfaces can still inspect exact tool activity.
  */
 export function buildToolCalls(events: ChatEvent[]): ToolCallCard[] {
   const cards: ToolCallCard[] = [];
@@ -429,4 +444,54 @@ export function buildToolCalls(events: ChatEvent[]): ToolCallCard[] {
   }
 
   return cards;
+}
+
+export function buildToolActivityGroups(events: ChatEvent[]): ToolActivityGroup[] {
+  const groups: ToolActivityGroup[] = [];
+  const byPhase = new Map<string, ToolActivityGroup>();
+
+  for (const card of buildToolCalls(events)) {
+    const phase = phaseOf(card.tool);
+    const existing = byPhase.get(phase);
+    if (!existing) {
+      const group: ToolActivityGroup = {
+        id: card.id,
+        phase,
+        tool: card.tool,
+        label: TOOL_LABELS[phase] ?? card.label,
+        status: card.status,
+        count: 1,
+        ...(card.params ? { params: card.params } : {}),
+        ...(card.output ? { output: card.output } : {}),
+        ...(card.summary ? { summary: card.summary } : {}),
+        ...(card.evidenceId ? { evidenceId: card.evidenceId } : {}),
+        ...(typeof card.cost === 'number' ? { cost: card.cost } : {}),
+        ...(typeof card.durationMs === 'number' ? { durationMs: card.durationMs } : {}),
+      };
+      groups.push(group);
+      byPhase.set(phase, group);
+      continue;
+    }
+
+    existing.count += 1;
+    existing.tool = card.tool;
+    existing.label = TOOL_LABELS[phase] ?? card.label;
+    if (card.status === 'running') {
+      existing.status = 'running';
+    } else if (card.status === 'error' && existing.status !== 'running') {
+      existing.status = 'error';
+    } else if (existing.status !== 'running' && existing.status !== 'error') {
+      existing.status = 'done';
+    }
+    if (card.params) existing.params = card.params;
+    if (card.output) existing.output = card.output;
+    if (card.summary) existing.summary = card.summary;
+    if (card.evidenceId) existing.evidenceId = card.evidenceId;
+    if (typeof card.cost === 'number') existing.cost = (existing.cost ?? 0) + card.cost;
+    if (typeof card.durationMs === 'number') {
+      existing.durationMs = (existing.durationMs ?? 0) + card.durationMs;
+    }
+  }
+
+  return groups;
 }


### PR DESCRIPTION
## Summary
- group repeated tool calls into compact in-place activity rows in chat
- keep per-call tool records available for detail/audit surfaces
- update activity tests to cover grouped rendering

## Tests
- npm test -- --run packages/web/src/components/chat/__tests__/AgentActivityBlock.test.tsx
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Agent activities in the chat interface are now consolidated into grouped rows when repeated tool operations occur, rather than displayed as individual entries. Each group displays the operation count, aggregated status, duration, and summary information. This reduces visual clutter and improves clarity when agents perform multiple operations.

* **Tests**
  * Added comprehensive test coverage for the new grouped activity display functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->