### PR TITLE
fix(release): give npm tarball a distinct filename so attach-assets works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,8 +193,14 @@ jobs:
           path: out/
 
       - name: Rename npm release asset
+        # The helm chart packs as `rounds-<version>.tgz`; if we rename the
+        # npm tarball to the same `rounds-<version>.tgz` softprops/action-
+        # gh-release tries to upload both with the same filename — the
+        # second one fails with "Not Found" trying to UPDATE an asset that
+        # the first POST is still creating. Suffix `-cli` so the two
+        # artifacts have distinct release-asset names.
         run: |
-          mv out/npm/syntropize-rounds-*.tgz "out/npm/rounds-${{ needs.package.outputs.version }}.tgz"
+          mv out/npm/syntropize-rounds-*.tgz "out/npm/rounds-cli-${{ needs.package.outputs.version }}.tgz"
 
       - uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

v0.0.8 release attach-assets job failed because the helm chart and the npm tarball were being renamed to the same filename (\`rounds-<version>.tgz\`), causing softprops/action-gh-release to try and UPDATE an asset that didn't exist yet (the first POST was still settling). Phantom 404, job failed, both assets ended up missing from the release.

Manually re-uploaded the assets for v0.0.8 with \`gh release upload\` so the release page is whole. This PR patches the workflow so the next release doesn't trip on the same collision.

## Changes

- \`Rename npm release asset\` step now produces \`rounds-cli-<version>.tgz\` instead of \`rounds-<version>.tgz\`. The two release assets become \`rounds-X.Y.Z.tgz\` (helm chart) and \`rounds-cli-X.Y.Z.tgz\` (npm CLI) — distinct names, no upload race.

## Test plan

- [x] Read the v0.0.8 attach-assets job log; confirmed the failure mode is exactly two artifacts colliding on the same upload name
- [x] v0.0.8 assets re-uploaded manually; release page now shows both \`rounds-0.0.8.tgz\` and \`rounds-cli-0.0.8.tgz\`
- [ ] Verify on next release tag that both assets attach without error