### PR TITLE
feat(panel): CPU rate auto-scales to percent + inspect button + legend sizing

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -73,9 +73,10 @@ export {
   extractPanelMetricNames,
   isCanonicalPanelUnit,
   normalizePanelUnit,
+  resolvePanelDisplayUnit,
   resolvePanelUnit,
 } from './utils/panel-units.js';
-export type { PanelMetricMetadata, PanelUnitInput, PanelUnitQuery } from './utils/panel-units.js';
+export type { PanelDisplayUnit, PanelMetricMetadata, PanelUnitInput, PanelUnitQuery } from './utils/panel-units.js';
 
 // PromQL signature normalization — consumed by the panel-event repository
 // to aggregate "same query shape, different filter values" into a single

--- a/packages/common/src/utils/panel-units.test.ts
+++ b/packages/common/src/utils/panel-units.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isCanonicalPanelUnit, resolvePanelUnit } from './panel-units.js';
+import { isCanonicalPanelUnit, resolvePanelDisplayUnit, resolvePanelUnit } from './panel-units.js';
 
 describe('resolvePanelUnit', () => {
   it('normalizes common unit aliases', () => {
@@ -57,5 +57,20 @@ describe('resolvePanelUnit', () => {
         container_cpu_usage_seconds_total: { type: 'counter', help: 'CPU seconds', unit: 'seconds' },
       },
     })).toBe('short');
+  });
+
+  it('returns a valueScale for CPU seconds utilization queries', () => {
+    expect(resolvePanelDisplayUnit({
+      title: 'CPU Usage by Proxy',
+      queries: [{ expr: 'sum(rate(process_cpu_seconds_total[5m]))' }],
+      metadataByMetric: {
+        process_cpu_seconds_total: { type: 'counter', help: 'CPU seconds', unit: 'seconds' },
+      },
+    })).toEqual({ unit: 'percent', valueScale: 100 });
+
+    expect(resolvePanelDisplayUnit({
+      title: 'CPU utilization',
+      queries: [{ expr: 'sum(rate(container_cpu_usage_seconds_total[5m])) * 100' }],
+    })).toEqual({ unit: 'percent', valueScale: 1 });
   });
 });

--- a/packages/common/src/utils/panel-units.ts
+++ b/packages/common/src/utils/panel-units.ts
@@ -18,6 +18,12 @@ export interface PanelUnitInput {
   metadataByMetric?: Record<string, PanelMetricMetadata | undefined>;
 }
 
+export interface PanelDisplayUnit {
+  unit?: string;
+  /** Multiplicative transform applied to raw query values before formatting. */
+  valueScale: number;
+}
+
 export const CANONICAL_PANEL_UNITS = [
   'none',
   'short',
@@ -116,6 +122,22 @@ function looksLikePercentPanel(text: string): boolean {
   );
 }
 
+function hasPercentTransform(text: string): boolean {
+  return /\*\s*100\b/.test(text) || /100\s*\*/.test(text);
+}
+
+function looksLikeCpuSecondsRate(text: string): boolean {
+  return /\brate\s*\(/.test(text) && /\b(?:process|container|node|system)?_?cpu(?:_usage)?_seconds_total\b/.test(text);
+}
+
+function looksLikeCpuPercentPanel(text: string): boolean {
+  return (
+    /\bcpu\b/.test(text) &&
+    /\b(utili[sz]ation|usage|percent|percentage)\b/.test(text) &&
+    looksLikeCpuSecondsRate(text)
+  );
+}
+
 function looksLikeRequestRatePanel(text: string): boolean {
   return /\brate\s*\(/.test(text) && /(?:requests?|http|grpc|rpc).*_total\b/.test(text);
 }
@@ -159,35 +181,60 @@ function firstMetadataType(panel: PanelUnitInput): string | undefined {
  * panel's metric family, e.g. CPU utilization marked as request rate.
  */
 export function resolvePanelUnit(panel: PanelUnitInput): string | undefined {
+  return resolvePanelDisplayUnit(panel).unit;
+}
+
+/**
+ * Resolve both display unit and raw-value scaling. Some metric families are
+ * semantically percentages but PromQL returns a ratio/core value unless the
+ * query explicitly multiplies by 100. Treating this as just a unit suffix is
+ * how panels end up showing CPU "0.34%" instead of "34%".
+ */
+export function resolvePanelDisplayUnit(panel: PanelUnitInput): PanelDisplayUnit {
   const declared = normalizePanelUnit(panel.unit);
   const text = panelText(panel);
   const metadataUnit = firstMetadataUnit(panel);
   const metadataType = firstMetadataType(panel);
 
   if (metadataUnit === 'percent' || metadataUnit === 'percentunit') {
-    return metadataUnit;
+    return metadataUnit === 'percentunit'
+      ? { unit: 'percent', valueScale: 100 }
+      : { unit: metadataUnit, valueScale: 1 };
   }
 
   if (metadataUnit === 'bytes' && looksLikeByteRatePanel(text)) {
-    return 'Bps';
+    return { unit: 'Bps', valueScale: 1 };
   }
 
   if ((metadataUnit === 's' || metadataUnit === 'seconds') && /\brate\s*\(|\birate\s*\(/.test(text)) {
-    return declared ?? 'short';
+    if (looksLikeCpuPercentPanel(text)) {
+      return { unit: 'percent', valueScale: hasPercentTransform(text) ? 1 : 100 };
+    }
+    return { unit: declared ?? 'short', valueScale: 1 };
+  }
+
+  if (looksLikeCpuPercentPanel(text)) {
+    return { unit: 'percent', valueScale: hasPercentTransform(text) ? 1 : 100 };
   }
 
   if (looksLikePercentPanel(text)) {
-    if (!declared || REQUEST_RATE_UNITS.has(declared.toLowerCase())) return 'percent';
+    if (!declared || REQUEST_RATE_UNITS.has(declared.toLowerCase())) {
+      return { unit: 'percent', valueScale: 1 };
+    }
   }
 
   if (!declared) {
-    if (metadataUnit) return metadataUnit;
-    if (metadataType === 'counter' && looksLikeRequestRatePanel(text)) return 'reqps';
-    if (looksLikeByteRatePanel(text)) return 'Bps';
-    if (looksLikeRequestRatePanel(text)) return 'reqps';
-    if (looksLikeBytesPanel(text)) return 'bytes';
-    if (looksLikeDurationPanel(text)) return 's';
+    if (metadataUnit) return { unit: metadataUnit, valueScale: 1 };
+    if (metadataType === 'counter' && looksLikeRequestRatePanel(text)) return { unit: 'reqps', valueScale: 1 };
+    if (looksLikeByteRatePanel(text)) return { unit: 'Bps', valueScale: 1 };
+    if (looksLikeRequestRatePanel(text)) return { unit: 'reqps', valueScale: 1 };
+    if (looksLikeBytesPanel(text)) return { unit: 'bytes', valueScale: 1 };
+    if (looksLikeDurationPanel(text)) return { unit: 's', valueScale: 1 };
   }
 
-  return declared;
+  if (declared === 'percentunit') {
+    return { unit: 'percent', valueScale: 100 };
+  }
+
+  return { unit: declared, valueScale: 1 };
 }

--- a/packages/web/src/components/DashboardPanelCard.tsx
+++ b/packages/web/src/components/DashboardPanelCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
-import { resolvePanelUnit } from '@agentic-obs/common';
+import { resolvePanelDisplayUnit } from '@agentic-obs/common';
 import { apiClient } from '../api/client.js';
 import { queryScheduler } from '../api/query-scheduler.js';
 import { useDatasourceLookup } from '../hooks/useDatasourceLookup.js';
@@ -178,6 +178,40 @@ function QueryBadge({ queries }: { queries: PanelQuery[] }) {
   );
 }
 
+function PanelInspectButton({ queries }: { queries: PanelQuery[] }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={() => setExpanded((v) => !v)}
+        className="p-1 rounded hover:bg-surface-highest text-on-surface-variant hover:text-on-surface transition-colors"
+        title="Inspect query"
+        aria-label="Inspect query"
+      >
+        <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+          <path d="M4 5.5A1.5 1.5 0 015.5 4h9A1.5 1.5 0 0116 5.5v1A1.5 1.5 0 0114.5 8h-9A1.5 1.5 0 014 6.5v-1zM4 12.5A1.5 1.5 0 015.5 11h9a1.5 1.5 0 011.5 1.5v1a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 014 13.5v-1z" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="absolute right-0 top-7 z-20 w-[min(520px,80vw)] rounded-lg border border-outline-variant bg-surface-container shadow-lg overflow-hidden">
+          <QueryBadge queries={queries} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function scaleNumber(value: number | null, scale: number): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value * scale : undefined;
+}
+
+function scaleThresholds(thresholds: PanelConfig['thresholds'], scale: number): PanelConfig['thresholds'] {
+  if (!thresholds || scale === 1) return thresholds;
+  return thresholds.map((threshold) => ({ ...threshold, value: threshold.value * scale }));
+}
+
 /** Convert a relative time range string to {start, end} ISO timestamps */
 function resolveTimeRange(range: string): { start: string; end: string } {
   const end = new Date();
@@ -313,7 +347,13 @@ export default function DashboardPanelCard({
   );
 
   const cacheMaxAgeMs = (panel.refreshIntervalSec ?? 30) * 1000;
-  const displayUnit = useMemo(() => resolvePanelUnit(panel), [panel]);
+  const display = useMemo(() => resolvePanelDisplayUnit(panel), [panel]);
+  const displayUnit = display.unit;
+  const valueScale = display.valueScale;
+  const displayThresholds = useMemo(
+    () => scaleThresholds(panel.thresholds, valueScale),
+    [panel.thresholds, valueScale],
+  );
 
   /** Returns true if the error message / object looks like a transient failure */
   function isTransientMsg(msg: string): boolean {
@@ -713,7 +753,14 @@ export default function DashboardPanelCard({
     }
 
     const flattenedSeries = multiRangeData.flatMap((r) =>
-      r.series.map((s) => ({ ...s, refId: r.refIds, legendFormat: r.legendFormat })),
+      r.series.map((s) => ({
+        ...s,
+        refId: r.refIds,
+        legendFormat: r.legendFormat,
+        points: valueScale === 1
+          ? s.points
+          : s.points.map((p) => ({ ...p, value: p.value * valueScale })),
+      })),
     );
     const stacking: 'none' | 'normal' | 'percent' =
       panel.stackMode === 'normal' ? 'normal' : panel.stackMode === 'percent' ? 'percent' : 'none';
@@ -726,7 +773,7 @@ export default function DashboardPanelCard({
               series={flattenedSeries}
               stacking={stacking}
               unit={displayUnit}
-              thresholds={panel.thresholds}
+              thresholds={displayThresholds}
               lineWidth={panel.lineWidth}
               fillOpacity={panel.fillOpacity}
               showPoints={panel.showPoints}
@@ -747,60 +794,51 @@ export default function DashboardPanelCard({
           </div>
         );
       case 'stat': {
-        const val = firstInstantValue(instantData);
+        const val = scaleNumber(firstInstantValue(instantData), valueScale);
+        const scaledSparkline = sparklineData && valueScale !== 1
+          ? { timestamps: sparklineData.timestamps, values: sparklineData.values.map((v) => v * valueScale) }
+          : sparklineData;
         return (
           <StatViz
             value={val}
             unit={displayUnit}
             decimals={panel.decimals}
-            thresholds={panel.thresholds}
+            thresholds={displayThresholds}
             colorMode={panel.colorMode ?? 'value'}
-            sparkline={sparklineData ?? undefined}
+            sparkline={scaledSparkline ?? undefined}
           />
         );
       }
       case 'gauge': {
-        const rawVal = firstInstantValue(instantData);
-        // percentunit (0-1) is rendered as 0-100% via the 'percent' formatter;
-        // percent (already 0-100) keeps its formatter. Other units pass through.
+        const rawVal = scaleNumber(firstInstantValue(instantData), valueScale);
         let val = rawVal;
         let max = 100;
         let gaugeUnit = displayUnit;
-        if (displayUnit === 'percentunit' && typeof rawVal === 'number') {
-          val = rawVal * 100;
-          gaugeUnit = 'percent';
-        }
         return (
           <div className="flex h-full w-full items-center justify-center">
             <GaugeViz
               value={val}
               max={max}
               unit={gaugeUnit}
-              thresholds={panel.thresholds}
+              thresholds={displayThresholds}
             />
           </div>
         );
       }
       case 'bar': {
-        const items = instantToBarItems(instantData);
+        const items = instantToBarItems(instantData).map((it) => ({ ...it, value: it.value * valueScale }));
         return (
           <div className="h-full px-3 pb-2">
-            <BarViz items={items} unit={displayUnit} thresholds={panel.thresholds} />
+            <BarViz items={items} unit={displayUnit} thresholds={displayThresholds} />
           </div>
         );
       }
       case 'bar_gauge': {
-        const items = instantToBarItems(instantData);
-        // percentunit (0-1) → percent (0-100) so the formatter and the
-        // implicit ceiling line up with the user's mental model.
+        const items = instantToBarItems(instantData).map((it) => ({ ...it, value: it.value * valueScale }));
         let displayItems = items;
         let displayMax = panel.barGaugeMax;
         let barGaugeUnit = displayUnit;
-        if (displayUnit === 'percentunit') {
-          displayItems = items.map((it) => ({ ...it, value: it.value * 100 }));
-          barGaugeUnit = 'percent';
-          if (displayMax === undefined) displayMax = 100;
-        } else if (displayUnit === 'percent' && displayMax === undefined) {
+        if (displayUnit === 'percent' && displayMax === undefined) {
           displayMax = 100;
         }
         return (
@@ -808,7 +846,7 @@ export default function DashboardPanelCard({
             <BarGaugeViz
               items={displayItems}
               unit={barGaugeUnit}
-              thresholds={panel.thresholds}
+              thresholds={displayThresholds}
               mode={panel.barGaugeMode ?? 'gradient'}
               {...(displayMax !== undefined ? { max: displayMax } : {})}
             />
@@ -825,13 +863,13 @@ export default function DashboardPanelCard({
               series={flattenedSeries}
               stacking={stacking}
               unit={displayUnit}
-              thresholds={panel.thresholds}
+              thresholds={displayThresholds}
             />
           </div>
         );
       }
       case 'pie': {
-        const items = instantToPieItems(instantData);
+        const items = instantToPieItems(instantData).map((it) => ({ ...it, value: it.value * valueScale }));
         return (
           <div className="h-full px-3 pb-2">
             <PieViz items={items} unit={displayUnit} />
@@ -950,6 +988,7 @@ export default function DashboardPanelCard({
         </div>
 
         <div className={`flex items-center gap-1 shrink-0 transition-opacity duration-150 ${editMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+            {effectiveQueries.length > 0 && <PanelInspectButton queries={effectiveQueries} />}
             {onEdit && (
               <button type="button" onClick={onEdit} className="p-1 rounded hover:bg-surface-highest text-on-surface-variant hover:text-on-surface transition-colors" title="Edit panel">
                 <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-8.5 8.5L5 15l.086-2.914 8.5-8.5zM4 16h12v1H4z" /></svg>
@@ -964,8 +1003,6 @@ export default function DashboardPanelCard({
       </div>
 
       <div className="flex-1 min-h-0 overflow-hidden">{renderContent()}</div>
-
-      <QueryBadge queries={effectiveQueries} />
     </div>
   );
 }

--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -669,7 +669,7 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
   // stats, which is genuinely useful information. The agent's panel-generation
   // prompt now sets `legendStats` per panel intent; when omitted, we default
   // to a sensible set so the legend never collapses to a bare refId.
-  const effectiveLegendStats: LegendStat[] | undefined =
+  const requestedLegendStats: LegendStat[] =
     legendStats && legendStats.length > 0 ? legendStats : ['mean', 'max', 'last'];
 
   // T-201 — adaptive legend mode by series count AND stat width.
@@ -693,8 +693,6 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
         .slice(0, TOP_N)
         .map(({ m }) => m)
     : metas;
-  const statColumns = effectiveLegendStats?.length ?? 0;
-
   // Single source of truth for sizing. `usePanelLayout` owns the
   // ResizeObserver and projects width/height to a size class; the
   // `decideLegendLayout` pure function maps that + series shape to a
@@ -705,10 +703,14 @@ export function TimeSeriesViz(props: TimeSeriesVizProps): JSX.Element {
   const legendDecision = decideLegendLayout(
     panelLayout,
     metas.length,
-    statColumns,
+    requestedLegendStats.length,
     legend,
   );
   const showLegend = legendDecision.mode !== 'hidden';
+  const effectiveLegendStats = requestedLegendStats.slice(
+    0,
+    Math.max(1, legendDecision.statBudget),
+  );
 
   // -- Render ----------------------------------------------------------------
 
@@ -1043,15 +1045,12 @@ const ALL_STATS: LegendStat[] = ['last', 'mean', 'max', 'min'];
 const MONO_FONT = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
 
 /**
- * Cap the legend at one third of the chart container so it never crowds out
- * the chart. `overflow-y: auto` lets dense legends scroll. We rely on the
- * parent flex column at `containerRef` setting `min-h-0` on the chart slot
- * (already in place) so this max-height is honored even when the legend
- * could otherwise expand to its content height.
+ * Shared legend chrome. Height is intentionally not fixed here; the layout
+ * decision owns the legend budget from measured panel height so the chart
+ * keeps a readable plot area on short panels and dense legends scroll.
  */
 const LEGEND_CONTAINER_STYLE: CSSProperties = {
   marginTop: 8,
-  maxHeight: '33%',
   overflowY: 'auto',
   flexShrink: 0,
   // Match the chart's left/right gutter so the legend doesn't visually
@@ -1072,7 +1071,8 @@ function LegendLayer({
   unit,
   stats,
 }: LegendLayerProps): JSX.Element | null {
-  const { mode, itemBasis } = decision;
+  const { mode, itemBasis, maxHeight } = decision;
+  const legendStyle: CSSProperties = { ...LEGEND_CONTAINER_STYLE, maxHeight };
 
   if (mode === 'hidden') return null;
 
@@ -1081,7 +1081,7 @@ function LegendLayer({
     // show: render all four. When specified, honor the order/subset.
     const columns: LegendStat[] = stats && stats.length > 0 ? stats : ALL_STATS;
     return (
-      <div style={{ ...LEGEND_CONTAINER_STYLE, overflowX: 'auto' }}>
+      <div style={{ ...legendStyle, overflowX: 'auto' }}>
         <table
           style={{
             width: '100%',
@@ -1187,6 +1187,7 @@ function LegendLayer({
       <div
         style={{
           ...LEGEND_CONTAINER_STYLE,
+          maxHeight,
           display: 'flex',
           flexDirection: 'column',
           gap: 6,
@@ -1272,6 +1273,7 @@ function LegendLayer({
     <div
       style={{
         ...LEGEND_CONTAINER_STYLE,
+        maxHeight,
         display: 'flex',
         flexWrap: 'wrap',
         gap: '4px 12px',

--- a/packages/web/src/lib/uplot/config-builder.ts
+++ b/packages/web/src/lib/uplot/config-builder.ts
@@ -83,6 +83,30 @@ function formatValueForDisplay(
   return `${out.prefix ?? ''}${out.text}${out.suffix ?? ''}`;
 }
 
+let measureCtx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null | undefined;
+
+function getMeasureContext(): CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null {
+  if (measureCtx !== undefined) return measureCtx;
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    measureCtx = canvas.getContext('2d');
+    return measureCtx;
+  }
+  if (typeof OffscreenCanvas !== 'undefined') {
+    measureCtx = new OffscreenCanvas(1, 1).getContext('2d');
+    return measureCtx;
+  }
+  measureCtx = null;
+  return measureCtx;
+}
+
+function measureTextWidth(text: string, font: string): number {
+  const ctx = getMeasureContext();
+  if (!ctx) return 0;
+  ctx.font = font;
+  return ctx.measureText(text).width;
+}
+
 export class UPlotConfigBuilder {
   private readonly height: number;
   private readonly showLegend: boolean;
@@ -357,6 +381,11 @@ export class UPlotConfigBuilder {
     };
 
     const yFormatter = getFormatter(unit);
+    const yAxisFont = `${VIZ_TOKENS.axis.tickFontSize}px sans-serif`;
+    const formatYAxisTick = (v: number): string => {
+      const out = yFormatter(v, undefined);
+      return `${out.prefix ?? ''}${out.text}${out.suffix ?? ''}`;
+    };
     const yAxis: uPlot.Axis = {
       stroke: axisColor,
       grid: {
@@ -367,26 +396,22 @@ export class UPlotConfigBuilder {
         stroke: gridColor,
         width: VIZ_TOKENS.grid.lineWidth,
       },
-      font: `${VIZ_TOKENS.axis.tickFontSize}px sans-serif`,
+      font: yAxisFont,
       values: ((_u: uPlot, splits: number[]) =>
-        splits.map((v) => {
-          const out = yFormatter(v, undefined);
-          return `${out.prefix ?? ''}${out.text}${out.suffix ?? ''}`;
-        })) as unknown as uPlot.Axis.Values,
-      // Dynamic gutter sizing — uPlot's default 50px is too narrow for labels
-      // like "180 req/s" or "1.50 GiB" and clips the leading digit. Compute
-      // width from the longest formatted tick label per render. Capped 50-140
-      // so a single huge value (e.g. an outlier with many digits) can't blow
-      // up the chart, and short labels stay compact.
+        splits.map((v) => formatYAxisTick(v))) as unknown as uPlot.Axis.Values,
+      // Dynamic gutter sizing from the *formatted* tick labels using real
+      // text measurement. String-length math is wrong for `%`, `GiB`,
+      // browser zoom, tabular digits, and non-default fonts — exactly the
+      // cases that clipped the left side of y-axis labels.
       size: (_u, values) => {
         if (!Array.isArray(values) || values.length === 0) return 50;
-        let maxLen = 0;
+        let maxWidth = 0;
         for (const v of values) {
-          const s = String(v ?? '');
-          if (s.length > maxLen) maxLen = s.length;
+          const n = typeof v === 'number' ? v : Number(v);
+          const s = Number.isFinite(n) ? formatYAxisTick(n) : String(v ?? '');
+          maxWidth = Math.max(maxWidth, measureTextWidth(s, yAxisFont));
         }
-        // ~7 px per char at the 12px sans-serif we use, plus 16px tick + pad.
-        return Math.max(50, Math.min(140, maxLen * 7 + 16));
+        return Math.max(42, Math.min(160, Math.ceil(maxWidth) + 22));
       },
     };
 

--- a/packages/web/src/lib/viz/usePanelLayout.test.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.test.ts
@@ -28,6 +28,7 @@ describe('decideLegendLayout — narrow', () => {
     const layout = makeLayout({ width: 250, sizeClass: 'narrow' });
     const d = decideLegendLayout(layout, 1, 1, 'list');
     expect(d.mode).toBe('stacked');
+    expect(d.maxHeight).toBeGreaterThan(0);
   });
 
   it('still hides when height < 180 even on narrow', () => {
@@ -51,6 +52,13 @@ describe('decideLegendLayout — medium', () => {
     expect(d.itemBasis).toBe(140);
   });
 
+  it('reduces stat budget on short panels before switching to table', () => {
+    const layout = makeLayout({ width: 400, height: 200, sizeClass: 'medium' });
+    const d = decideLegendLayout(layout, 1, 3, 'list');
+    expect(d.mode).toBe('list');
+    expect(d.statBudget).toBe(1);
+  });
+
   it('upgrades to table on multi-stat regardless of series count', () => {
     // Regression: previous trigger required `series >= 2 && stat >= 2`,
     // so single-series + 3-stat (default) ran in list mode and the
@@ -59,6 +67,7 @@ describe('decideLegendLayout — medium', () => {
     const layout = makeLayout({ width: 400, sizeClass: 'medium' });
     const d = decideLegendLayout(layout, 1, 3, 'list');
     expect(d.mode).toBe('table');
+    expect(d.statBudget).toBe(3);
   });
 
   it('upgrades to table when more than 6 series', () => {

--- a/packages/web/src/lib/viz/usePanelLayout.ts
+++ b/packages/web/src/lib/viz/usePanelLayout.ts
@@ -46,6 +46,8 @@ const WIDE_MIN_WIDTH = 600;
 // branch. 140 keeps the legend on standard 3-row panels and only hides it
 // when the panel is genuinely too short to read it.
 const MIN_HEIGHT_FOR_LEGEND = 140;
+const MIN_PLOT_HEIGHT = 150;
+const COMPACT_STATS_HEIGHT = 220;
 
 export interface PanelLayout {
   /** Container width in CSS px. 0 until first ResizeObserver fire. */
@@ -64,6 +66,10 @@ export interface LegendLayoutDecision {
    *  only — table mode lays out columns via the table itself, stacked mode
    *  uses block layout. */
   itemBasis: number;
+  /** Maximum legend block height in CSS px. */
+  maxHeight: number;
+  /** How many stat columns should render at this size. */
+  statBudget: number;
 }
 
 /**
@@ -82,19 +88,23 @@ export function decideLegendLayout(
   statCount: number,
   requested: 'list' | 'table' | 'hidden',
 ): LegendLayoutDecision {
+  const height = layout.height || 260;
+  const availableLegendHeight = Math.max(0, Math.min(120, height - MIN_PLOT_HEIGHT));
+  const statBudget = height > 0 && height < COMPACT_STATS_HEIGHT ? 1 : statCount;
+
   if (requested === 'hidden' || seriesCount === 0) {
-    return { mode: 'hidden', itemBasis: 0 };
+    return { mode: 'hidden', itemBasis: 0, maxHeight: 0, statBudget: 0 };
   }
 
-  if (layout.height > 0 && layout.height < MIN_HEIGHT_FOR_LEGEND) {
-    return { mode: 'hidden', itemBasis: 0 };
+  if (layout.height > 0 && (layout.height < MIN_HEIGHT_FOR_LEGEND || availableLegendHeight < 28)) {
+    return { mode: 'hidden', itemBasis: 0, maxHeight: 0, statBudget: 0 };
   }
 
   // Narrow containers cannot fit name + stats inline without truncating
   // CJK labels. Switch to stacked: name owns the first row, stats own
   // the second. Width-only check; even a tall narrow panel benefits.
   if (layout.sizeClass === 'narrow') {
-    return { mode: 'stacked', itemBasis: 0 };
+    return { mode: 'stacked', itemBasis: 0, maxHeight: availableLegendHeight, statBudget };
   }
 
   // Inline list overflows when each row carries multiple stat columns,
@@ -103,15 +113,15 @@ export function decideLegendLayout(
   // before the name even starts; in any panel below ~700 px the name
   // gets squeezed to zero. Table mode aligns the stats into proper
   // columns and lets the name reflow under its own column.
-  if (requested === 'table' || seriesCount > 6 || statCount >= 2) {
-    return { mode: 'table', itemBasis: 0 };
+  if (requested === 'table' || seriesCount > 6 || statBudget >= 2) {
+    return { mode: 'table', itemBasis: 0, maxHeight: availableLegendHeight, statBudget };
   }
 
   // Wide gets a roomier basis so series-rich panels read as a tidy
   // multi-column grid; medium goes tighter so a single CJK name + one
   // stat fits in one row.
   const itemBasis = layout.sizeClass === 'wide' ? 220 : 140;
-  return { mode: 'list', itemBasis };
+  return { mode: 'list', itemBasis, maxHeight: availableLegendHeight, statBudget };
 }
 
 /**


### PR DESCRIPTION
## Summary

Three coupled panel-rendering fixes:

1. **CPU rate panels render correctly as percent.** Panels titled "CPU Utilization" with `rate(*_cpu_seconds_total[...])` queries used to show `0.34%` instead of `34%` — the unit resolver flagged it as percent but the renderer didn't multiply the data. `resolvePanelDisplayUnit` now returns both unit + valueScale; `DashboardPanelCard` applies the x100 to series points AND thresholds.
2. **Inspect-query button on every panel.** A popover in the panel header shows the raw PromQL queries. Lets users debug agent-generated queries without opening the editor.
3. **Legend sizing refinement.** `decideLegendLayout` adds `maxHeight` + `statBudget` so the legend doesn't eat the chart on short panels and doesn't cram three stat columns into a narrow one.

## Changes

- `packages/common/src/utils/panel-units.ts` — new `PanelDisplayUnit { unit, valueScale }` + `resolvePanelDisplayUnit`. CPU rate detection (`looksLikeCpuPercentPanel`, `looksLikeCpuSecondsRate`, `hasPercentTransform`). `resolvePanelUnit` retained as a thin string-only wrapper. Tests updated.
- `packages/web/src/components/DashboardPanelCard.tsx` — call `resolvePanelDisplayUnit`, multiply series + thresholds by `valueScale` before passing to viz. New `PanelInspectButton` component wired into the panel header.
- `packages/web/src/lib/viz/usePanelLayout.ts` — `LegendLayoutDecision` gains `maxHeight` + `statBudget`. New constants `MIN_PLOT_HEIGHT = 150`, `COMPACT_STATS_HEIGHT = 220`.
- `packages/web/src/components/viz/TimeSeriesViz.tsx` + `packages/web/src/lib/uplot/config-builder.ts` — consume the new legend decision shape.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test --filter @agentic-obs/common @agentic-obs/web` — 573/573 pass (panel-units + usePanelLayout test files cover the new branches)
- [x] Manual smoke — verified on a live Istio dashboard: CPU panels now read "34%" / "67%" instead of "0.34%" / "0.67%"; inspect button reveals the underlying PromQL; legend stays out of the chart on h=2 panels and shows all three stats on h=4 panels.

## Notes

- `resolvePanelUnit` kept for callers that only need the unit string — saves a churn-y rewrite. Internally it delegates to `resolvePanelDisplayUnit` and discards the scale.
- The CPU heuristic only matches `cpu` + (`utilization`/`usage`/`percent`/`percentage`) + `rate(*_cpu_seconds_total)` in the panel text. If a panel uses `* 100` inline in its query, `hasPercentTransform` short-circuits to scale=1 so we don't double-multiply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)