### PR TITLE
feat(ops): background-agent confirmation bypass + approver-attributed audit

### DIFF
--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
@@ -395,6 +395,31 @@ describe('dashboard handlers', () => {
       expect(persisted[0]!.op.patch.title).toBe('Renamed');
     });
 
+    it('rejects null required panel fields before creating a pending change', async () => {
+      const appendPendingChanges = vi.fn().mockResolvedValue(undefined);
+      const ctx = makeFakeActionContext({
+        activeDashboardId: 'd-shared',
+        store: {
+          findById: vi.fn(),
+          update: vi.fn(),
+          updatePanels: vi.fn(),
+          updateVariables: vi.fn(),
+          appendPendingChanges,
+        } as never,
+      });
+
+      const observation = await handleDashboardModifyPanel(ctx, {
+        panelId: 'p1',
+        title: null,
+        visualization: null,
+        queries: [{ refId: 'A', expr: 'up', datasourceId: 'ds-1' }],
+      });
+
+      expect(observation).toMatch(/title must be a string/);
+      expect(ctx.actionExecutor.execute).not.toHaveBeenCalled();
+      expect(appendPendingChanges).not.toHaveBeenCalled();
+    });
+
     it('emits a failed tool_result when modify fails', async () => {
       const ctx = makeFakeActionContext({
         activeDashboardId: 'd1',

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -14,6 +14,18 @@ import {
 } from './verify-gate.js';
 
 const log = createLogger('dashboard-handler');
+const PANEL_VISUALIZATION_VALUES = new Set([
+  'time_series',
+  'stat',
+  'table',
+  'gauge',
+  'bar',
+  'bar_gauge',
+  'heatmap',
+  'pie',
+  'histogram',
+  'status_timeline',
+]);
 
 /**
  * Best-effort `updateStatus` write. On failure we log a structured warning
@@ -185,6 +197,19 @@ function maybeEnum<K extends string, T extends string>(
 ): Partial<Record<K, T>> {
   const picked = pickEnum(value, allowed);
   return picked === undefined ? {} : ({ [key]: picked } as Partial<Record<K, T>>);
+}
+
+function validatePanelPatch(patch: Record<string, unknown>): string | null {
+  if (Object.prototype.hasOwnProperty.call(patch, 'title') && typeof patch.title !== 'string') {
+    return 'Error: dashboard_modify_panel title must be a string when provided. Omit title to keep the current title.';
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(patch, 'visualization') &&
+    (typeof patch.visualization !== 'string' || !PANEL_VISUALIZATION_VALUES.has(patch.visualization))
+  ) {
+    return 'Error: dashboard_modify_panel visualization must be a valid visualization string when provided. Omit visualization to keep the current visualization.';
+  }
+  return null;
 }
 
 async function fetchPanelMetadata(
@@ -918,6 +943,9 @@ export async function handleDashboardModifyPanel(
   if (!panelId) return 'Error: "panelId" is required.';
   const patch = { ...args } as Record<string, unknown>;
   delete patch.panelId;
+
+  const patchError = validatePanelPatch(patch);
+  if (patchError) return patchError;
 
   // If the patch replaces the queries list, every replacement query must
   // carry datasourceId — same strict contract as add_panels. Patches that

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -355,6 +355,7 @@ export class OrchestratorAgent {
       permissionEscalationContact: this.deps.permissionEscalationContact,
       opsConnectors: this.deps.opsConnectors,
       allowedTools: this.agentDef.allowedTools,
+      agentType: this.agentDef.type,
     })
 
     try {

--- a/packages/agent-core/src/agent/orchestrator-alert-helpers.ts
+++ b/packages/agent-core/src/agent/orchestrator-alert-helpers.ts
@@ -37,16 +37,22 @@ export function getStructuredAlertRuleContext(
   return null
 }
 
-export function buildStructuredAlertHistory(history: DashboardMessage[]): string {
+export function buildStructuredAlertHistory(
+  history: DashboardMessage[],
+  currentAlertRules: AlertRuleSummary[] = [],
+): string {
   const entries: string[] = []
+  const currentRuleIds = new Set(currentAlertRules.map((rule) => rule.id))
 
   for (const message of history.slice(-10)) {
     const actions = message.actions ?? []
     for (const action of actions) {
       if (action.type === 'create_alert_rule') {
+        if (!currentRuleIds.has(action.ruleId)) continue
         entries.push(`- Assistant created alert [${action.ruleId}] "${action.name}" (${action.severity}) - ${action.query} ${action.operator} ${action.threshold}`)
       }
       else if (action.type === 'modify_alert_rule') {
+        if (!currentRuleIds.has(action.ruleId)) continue
         entries.push(`- Assistant modified alert [${action.ruleId}] with patch ${JSON.stringify(action.patch)}`)
       }
       else if (action.type === 'delete_alert_rule') {

--- a/packages/agent-core/src/agent/orchestrator-prompt.test.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.test.ts
@@ -232,6 +232,103 @@ describe('per-tool behavior guidance is now inlined into schema descriptions', (
   });
 });
 
+describe('buildSystemPrompt — alert history reflects current store', () => {
+  it('does not surface deleted alert creations as current recoverable rules', () => {
+    const history: DashboardMessage[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Created old alert.',
+        timestamp: '2026-04-18T00:00:00.000Z',
+        actions: [
+          {
+            type: 'create_alert_rule',
+            ruleId: 'old_alert',
+            name: 'Proxy Down',
+            severity: 'high',
+            query: 'envoy_server_live',
+            operator: '==',
+            threshold: 0,
+            forDurationSec: 300,
+            evaluationIntervalSec: 60,
+          },
+        ],
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: 'Deleted old alert.',
+        timestamp: '2026-04-18T00:01:00.000Z',
+        actions: [
+          {
+            type: 'delete_alert_rule',
+            ruleId: 'old_alert',
+            name: 'Proxy Down',
+          },
+        ],
+      },
+    ] as DashboardMessage[];
+
+    const prompt = buildSystemPrompt(null, history, [], null, [], {
+      hasPrometheus: false,
+      now: '2026-04-18T00:02:00.000Z',
+    });
+
+    expect(prompt).not.toContain('Assistant created alert [old_alert]');
+    expect(prompt).toContain('Assistant deleted alert [old_alert] "Proxy Down"');
+    expect(prompt).toContain('deleted entries are not candidates to recreate');
+  });
+
+  it('keeps created alert history when the rule still exists', () => {
+    const history: DashboardMessage[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: 'Created current alert.',
+        timestamp: '2026-04-18T00:00:00.000Z',
+        actions: [
+          {
+            type: 'create_alert_rule',
+            ruleId: 'current_alert',
+            name: 'Proxy Memory Pressure',
+            severity: 'medium',
+            query: 'envoy_server_memory_allocated / envoy_server_memory_heap_size',
+            operator: '>',
+            threshold: 0.85,
+            forDurationSec: 300,
+            evaluationIntervalSec: 60,
+          },
+        ],
+      },
+    ] as DashboardMessage[];
+
+    const prompt = buildSystemPrompt(
+      null,
+      history,
+      [{
+        id: 'current_alert',
+        name: 'Proxy Memory Pressure',
+        severity: 'medium',
+        condition: {
+          query: 'envoy_server_memory_allocated / envoy_server_memory_heap_size',
+          operator: '>',
+          threshold: 0.85,
+        },
+      }],
+      null,
+      [],
+      {
+        hasPrometheus: false,
+        now: '2026-04-18T00:02:00.000Z',
+      },
+    );
+
+    expect(prompt).toContain('Assistant created alert [current_alert]');
+    expect(prompt).toContain('# Alert Rules');
+    expect(prompt).toContain('Proxy Memory Pressure');
+  });
+});
+
 describe('buildSystemPrompt — deferred tools listing', () => {
   it('omits the <deferred-tools> block when allowedTools is not provided', () => {
     const prompt = buildSystemPrompt(null, [], [], null, [], {

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -1,6 +1,7 @@
 import type { Dashboard, DashboardMessage, Identity } from '@agentic-obs/common'
 import type { AlertRuleSummary } from './orchestrator-alert-helpers.js'
 import type { ConnectorConfig, OpsConnectorConfig } from './types.js'
+import type { AgentType } from './agent-types.js'
 import { buildStructuredAlertHistory } from './orchestrator-alert-helpers.js'
 import { TOOL_REGISTRY, deferredToolNamesForAgent } from './tool-schema-registry.js'
 
@@ -507,9 +508,9 @@ function getAlertRulesSection(
   if (alertRules.length > 0) {
     parts.push(`\n# Alert Rules\n${alertRules.map((r) => `- [${r.id}] "${r.name}" (${r.severity}) — ${(r.condition as Record<string, unknown>).query ?? ''} ${(r.condition as Record<string, unknown>).operator ?? ''} ${(r.condition as Record<string, unknown>).threshold ?? ''}`).join('\n')}`)
   }
-  const structuredAlertHistory = buildStructuredAlertHistory(history)
+  const structuredAlertHistory = buildStructuredAlertHistory(history, alertRules)
   if (structuredAlertHistory) {
-    parts.push(`\n# Alert History\n${structuredAlertHistory}`)
+    parts.push(`\n# Alert History\nHistorical alert actions. Created/modified entries are included only when the rule still exists in the current alert store; deleted entries are not candidates to recreate unless the user explicitly asks.\n${structuredAlertHistory}`)
   }
   if (activeAlertRule) {
     parts.push(`\n# Active Alert\n[${activeAlertRule.id}] "${activeAlertRule.name}" (${activeAlertRule.severity}). If user says "it"/"this alert"/"change it", means this one.`)
@@ -611,6 +612,14 @@ export interface SystemPromptOptions {
    * context (e.g. some unit tests) don't need it.
    */
   allowedTools?: readonly string[]
+  /**
+   * Agent registry type for the current run. When set to
+   * `'background_orchestrator'` we append the read-only-shell contract
+   * that pairs with the ops_run_command confirmation bypass — the runner
+   * trusts the agent not to issue writes inside `kubectl exec` or
+   * non-kubectl shells, so the contract must be explicit in the prompt.
+   */
+  agentType?: AgentType
 }
 
 /**
@@ -678,6 +687,32 @@ function getRoleHint(orgRole: string | undefined): string {
   return ''
 }
 
+/**
+ * Read-only shell contract for background agents. Pairs with the
+ * `readOnlyAgentBypass` flag on KubectlOpsCommandRunner: the runner skips
+ * confirmation for surface-read-shaped commands (`curl`, `jq`,
+ * `kubectl exec ... -- ps/cat/...`) so background investigations don't
+ * stall on a confirmation card no one will click. That bypass is only
+ * safe if the agent honors the contract below.
+ *
+ * The runner still hard-blocks `delete`/`drain`/`rm`/`mkfs` and explicit
+ * write verbs (`apply`/`create`/`patch`/...) — even with bypass on, those
+ * always confirm. This section is about the cases the regex CAN'T see:
+ * inner commands inside `kubectl exec` and arbitrary shell invocations.
+ */
+function getBackgroundShellContractSection(agentType: AgentType | undefined): string {
+  if (agentType !== 'background_orchestrator') return ''
+  return `## Read-only shell contract (background runs)
+
+You're running in the background — no human is at the keyboard to approve commands. The runner auto-approves read-shaped \`ops_run_command\` calls for you so investigations don't stall. In exchange, you MUST keep every shell invocation read-only.
+
+- \`kubectl exec ... -- <inner>\` — the inner command must be read-only: \`ps\`, \`cat\`, \`ls\`, \`netstat\`, \`ss\`, \`pidstat\`, \`curl http://localhost:.../...\` (GET), \`/usr/local/bin/pilot-agent request GET ...\` (Istio config dump). Never \`sh -c '...mutation...'\`, \`rm\`, \`kill\`, \`pkill\`, \`iptables\`, \`sysctl\`, \`echo > /etc/...\`, \`mount\`, \`tc\`, package installs, or anything that changes container/process/network state.
+- Non-kubectl shell (\`curl\`, \`jq\`, \`grep\`, \`awk\`, pipe chains) — read-only: GET requests, parsing, filtering. No \`curl -X POST/PUT/PATCH/DELETE\`, no \`curl ... | sh\`, no writes to host paths.
+- Real mutations (scale a deployment, patch a config, restart a pod, run helm) — STOP and emit a \`remediation_plan_create\` proposal instead. Humans gate execution; never try to bypass with a creatively-shaped \`exec\`.
+
+The runner audit-logs every command. If you violate this contract the operator sees it post-hoc and the bypass gets revoked.`
+}
+
 export function buildSystemPrompt(
   dashboard: Dashboard | null,
   history: DashboardMessage[],
@@ -710,6 +745,7 @@ export function buildSystemPrompt(
     getSystemSection(),
     getDoingTasksSection(),
     getActionsSection(options?.allowedTools?.includes('remediation_plan_create') === true),
+    getBackgroundShellContractSection(options?.agentType),
     getExamplesSection(),
     getQueryKnowledgeSection(),
     getKnowledgeBaseSection(),

--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -99,9 +99,18 @@ export function buildBackgroundOrchestratorFactory(
     const opsConnectors = connectors
       .filter((c) => c.type === 'kubernetes')
       .map(connectorToOpsConfig);
+    // Background investigations run with no human at the keyboard. The
+    // ops_run_command confirmation gate would block them indefinitely on any
+    // command that the surface classifier flags as 'ask' (curl probes,
+    // kubectl exec for sidecar inspection, …). Enable the read-shaped bypass
+    // for background agents only — interactive chat keeps the confirmation
+    // card so the operator can review writes themselves.
+    const effectiveAgentType = agentType ?? 'background_orchestrator';
     const opsCommandRunner = new KubectlOpsCommandRunner({
       connectors: deps.persistence.repos.connectors,
       orgId: identity.orgId,
+      readOnlyAgentBypass: effectiveAgentType === 'background_orchestrator',
+      ...(deps.audit ? { audit: deps.audit } : {}),
     });
 
     return createAgentRunner({
@@ -126,7 +135,7 @@ export function buildBackgroundOrchestratorFactory(
       identity,
       accessControl: deps.accessControl,
       ...(deps.audit ? { auditWriter: deps.audit } : {}),
-      agentType: agentType ?? 'background_orchestrator',
+      agentType: effectiveAgentType,
     }, `bg_${randomUUID()}`);
   };
 }

--- a/packages/api-gateway/src/routes/ops-command-confirmations.ts
+++ b/packages/api-gateway/src/routes/ops-command-confirmations.ts
@@ -31,8 +31,15 @@ export function createOpsCommandConfirmationsRouter(
           res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
           return;
         }
+        // Same-org scoping is enforced; the legacy userId-equality check is
+        // intentionally NOT applied here. Background investigation agents
+        // create confirmations under a service-account identity, so no
+        // human could ever approve them under the old rule. RBAC below
+        // (OpsCommandsRun on the connector OR InstanceConfigWrite) is the
+        // real gate — anyone with that permission in the same org may
+        // approve, and audit attribution records exactly who clicked.
         const confirmation = getOpsCommandConfirmation(req.params['id'] ?? '');
-        if (!confirmation || confirmation.orgId !== auth.orgId || confirmation.userId !== auth.userId) {
+        if (!confirmation || confirmation.orgId !== auth.orgId) {
           res.status(404).json({ error: { code: 'NOT_FOUND', message: 'confirmation not found' } });
           return;
         }
@@ -51,7 +58,7 @@ export function createOpsCommandConfirmationsRouter(
           res.status(403).json({ error: { code: 'FORBIDDEN', message: 'permission denied' } });
           return;
         }
-        resolveOpsCommandConfirmation(confirmation.id, 'executed');
+        resolveOpsCommandConfirmation(confirmation.id, 'executed', { userId: auth.userId });
         res.json({ confirmation: getOpsCommandConfirmation(confirmation.id) });
       } catch (err) {
         next(err);
@@ -69,8 +76,10 @@ export function createOpsCommandConfirmationsRouter(
           res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'authentication required' } });
           return;
         }
+        // Same-org scoping only — see the /execute handler for why the
+        // userId-equality check is intentionally omitted.
         const confirmation = getOpsCommandConfirmation(req.params['id'] ?? '');
-        if (!confirmation || confirmation.orgId !== auth.orgId || confirmation.userId !== auth.userId) {
+        if (!confirmation || confirmation.orgId !== auth.orgId) {
           res.status(404).json({ error: { code: 'NOT_FOUND', message: 'confirmation not found' } });
           return;
         }
@@ -78,7 +87,7 @@ export function createOpsCommandConfirmationsRouter(
           res.status(409).json({ error: { code: 'CONFLICT', message: `confirmation is ${confirmation.status}` } });
           return;
         }
-        resolveOpsCommandConfirmation(confirmation.id, 'rejected');
+        resolveOpsCommandConfirmation(confirmation.id, 'rejected', { userId: auth.userId });
         res.json({ confirmation: getOpsCommandConfirmation(confirmation.id) });
       } catch (err) {
         next(err);

--- a/packages/api-gateway/src/routes/pending-changes.test.ts
+++ b/packages/api-gateway/src/routes/pending-changes.test.ts
@@ -185,6 +185,31 @@ describe('pending-changes router', () => {
     expect(repo.resolve).toHaveBeenCalledWith('org_main', 'pc-1', 'accepted', 'user_1');
   });
 
+  it('POST accept rejects a proposal that would corrupt required panel fields', async () => {
+    const row = mockPending({
+      changeKind: 'modify_panel',
+      afterJson: { id: 'p-1', title: null, visualization: null },
+    });
+    const dash = mockDashboard();
+    const repo = {
+      getById: vi.fn(async () => row),
+      resolve: vi.fn(),
+    } as unknown as IPendingChangeRepository;
+    const updatePanels = vi.fn();
+    const dashboards = {
+      findById: vi.fn(async () => dash),
+      updatePanels,
+    } as unknown as IGatewayDashboardStore;
+    const app = makeApp({ repo, dashboards });
+
+    const res = await request(app).post('/api/dashboards/d-1/pending-changes/pc-1/accept').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PENDING_CHANGE');
+    expect(updatePanels).not.toHaveBeenCalled();
+    expect(repo.resolve).not.toHaveBeenCalled();
+  });
+
   it('POST accept 404s for unknown change id', async () => {
     const repo = {
       getById: vi.fn(async () => null),

--- a/packages/api-gateway/src/routes/pending-changes.ts
+++ b/packages/api-gateway/src/routes/pending-changes.ts
@@ -29,6 +29,25 @@ import { getOrgId } from '../middleware/workspace-context.js';
 import { createLogger } from '@agentic-obs/server-utils/logging';
 
 const log = createLogger('pending-changes-routes');
+const PANEL_VISUALIZATION_VALUES = new Set([
+  'time_series',
+  'stat',
+  'table',
+  'gauge',
+  'bar',
+  'bar_gauge',
+  'heatmap',
+  'pie',
+  'histogram',
+  'status_timeline',
+]);
+
+class InvalidPendingChangeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidPendingChangeError';
+  }
+}
 
 export interface PendingChangesRouterDeps {
   pendingChanges: IPendingChangeRepository;
@@ -48,6 +67,21 @@ function resolveOrgId(req: Request): string {
 function actorId(req: Request): string {
   const a = (req as AuthenticatedRequest).auth;
   return a?.userId ?? 'anonymous';
+}
+
+function assertValidPanel(panel: PanelConfig): void {
+  if (typeof panel.id !== 'string' || panel.id.trim() === '') {
+    throw new InvalidPendingChangeError('panel id is required');
+  }
+  if (typeof panel.title !== 'string' || panel.title.trim() === '') {
+    throw new InvalidPendingChangeError(`panel ${panel.id} has invalid title`);
+  }
+  if (
+    typeof panel.visualization !== 'string' ||
+    !PANEL_VISUALIZATION_VALUES.has(panel.visualization)
+  ) {
+    throw new InvalidPendingChangeError(`panel ${panel.id} has invalid visualization`);
+  }
 }
 
 /**
@@ -71,6 +105,7 @@ async function applyChange(
     case 'modify_panel': {
       const after = change.afterJson as PanelConfig;
       const panels = dash.panels.map((p) => (p.id === after.id ? { ...p, ...after } : p));
+      for (const panel of panels) assertValidPanel(panel);
       return (await store.updatePanels(change.dashboardId, panels)) ?? null;
     }
     case 'add_panel': {
@@ -78,6 +113,7 @@ async function applyChange(
       // If the row stored a config without an id (the handler passed the raw
       // proposed panel), mint one at apply time.
       const panel: PanelConfig = after.id ? after : { ...after, id: cryptoRandomId() };
+      assertValidPanel(panel);
       return (await store.updatePanels(change.dashboardId, [...dash.panels, panel])) ?? null;
     }
     case 'remove_panel': {
@@ -216,8 +252,11 @@ export function createPendingChangesRouter(deps: PendingChangesRouterDeps): Expr
             { changeId, dashboardId: id, err: err instanceof Error ? err.message : String(err) },
             'apply pending change failed',
           );
-          res.status(500).json({
-            error: { code: 'APPLY_FAILED', message: err instanceof Error ? err.message : 'apply failed' },
+          res.status(err instanceof InvalidPendingChangeError ? 400 : 500).json({
+            error: {
+              code: err instanceof InvalidPendingChangeError ? 'INVALID_PENDING_CHANGE' : 'APPLY_FAILED',
+              message: err instanceof Error ? err.message : 'apply failed',
+            },
           });
           return;
         }

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -440,6 +440,7 @@ export class ChatService {
       ? new KubectlOpsCommandRunner({
           connectors: this.deps.connectorRepo,
           orgId: identity.orgId,
+          ...(this.deps.auditWriter ? { audit: this.deps.auditWriter } : {}),
         })
       : undefined;
     // GitHub tool runner: read-only VCS surface (github_list_repos /

--- a/packages/api-gateway/src/services/ops-command-runner.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner.test.ts
@@ -11,6 +11,7 @@ import type { IConnectorRepository } from '@agentic-obs/data-layer';
 import {
   KubectlOpsCommandRunner,
   connectorToOpsConfig,
+  isAgentReadSafeCommand,
   resolveOpsCommandConfirmation,
   type OpsCommandConfirmation,
 } from './ops-command-runner.js';
@@ -463,4 +464,127 @@ describe('KubectlOpsCommandRunner.runCommand — connector policy gate', () => {
     expect(r.success).toBe(false);
     expect(r.observation).toContain('Blocked by connector policy');
   });
+});
+
+describe('isAgentReadSafeCommand — background investigation bypass classifier', () => {
+  // Pairs with KubectlOpsCommandRunner.readOnlyAgentBypass. The runner skips
+  // the confirmation card for commands this classifier flags as read-safe
+  // BY SURFACE SHAPE — agent honesty about inner intent is the prompt's job.
+  // The cases below pin down "what does 'read-safe' mean to the runner".
+
+  it('flags `kubectl exec` as read-safe — agent contract limits inner cmds', () => {
+    // The whole point of the bypass: investigation agents need exec to look
+    // inside sidecars (`ps`, `netstat`, dump envoy admin). The classifier
+    // can't parse the inner command, so it trusts the prompt contract here.
+    expect(isAgentReadSafeCommand('kubectl exec pod-a -- ps aux')).toBe(true);
+    expect(isAgentReadSafeCommand('kubectl exec -n default pod-a -c istio-proxy -- curl http://localhost:15000/config_dump')).toBe(true);
+  });
+
+  it('flags non-kubectl reads (curl / jq / grep chains) as read-safe', () => {
+    expect(isAgentReadSafeCommand('curl http://prometheus:9090/api/v1/query?query=up')).toBe(true);
+    expect(isAgentReadSafeCommand('kubectl get pods -o json | jq ".items[].metadata.name"')).toBe(true);
+  });
+
+  it('flags `kubectl get/describe/logs/top` as read-safe (already low-risk)', () => {
+    expect(isAgentReadSafeCommand('kubectl get pods')).toBe(true);
+    expect(isAgentReadSafeCommand('kubectl describe pod foo')).toBe(true);
+    expect(isAgentReadSafeCommand('kubectl logs foo --tail=200')).toBe(true);
+    expect(isAgentReadSafeCommand('kubectl top pods')).toBe(true);
+  });
+
+  it('refuses `kubectl delete/drain` — critical risk, always confirms', () => {
+    expect(isAgentReadSafeCommand('kubectl delete pod foo')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl drain node-1')).toBe(false);
+  });
+
+  it('refuses destructive shell verbs (rm / mkfs / redirect to /)', () => {
+    expect(isAgentReadSafeCommand('rm -rf /tmp/data')).toBe(false);
+    expect(isAgentReadSafeCommand('mkfs.ext4 /dev/sdb1')).toBe(false);
+    expect(isAgentReadSafeCommand('echo bad > /etc/hosts')).toBe(false);
+  });
+
+  it('refuses explicit kubectl write verbs (apply / create / patch / scale / rollout / …)', () => {
+    // These are the writes the agent should propose via remediation_plan_create
+    // rather than execute directly. Even with bypass on, the runner forces
+    // the operator to approve them.
+    expect(isAgentReadSafeCommand('kubectl apply -f manifest.yaml')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl create deployment foo --image=nginx')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl patch deployment foo -p \'{"spec":{"replicas":3}}\'')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl scale deployment foo --replicas=5')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl rollout restart deployment foo')).toBe(false);
+    expect(isAgentReadSafeCommand('kubectl label pod foo team=infra')).toBe(false);
+  });
+
+  it('catches writes hidden in command chains', () => {
+    // The agent could try to sneak a write past the surface check by
+    // bundling it with a read. The regex matches on substring, so `apply`
+    // anywhere in the chain still flags.
+    expect(
+      isAgentReadSafeCommand('kubectl get pods && kubectl apply -f bad.yaml'),
+    ).toBe(false);
+    expect(
+      isAgentReadSafeCommand('kubectl get cm | xargs -I{} kubectl delete cm {}'),
+    ).toBe(false);
+  });
+});
+
+describe('resolveOpsCommandConfirmation — approver attribution', () => {
+  // Pairs with the /execute and /reject HTTP endpoints. The approver field is
+  // the audit trail's "who actually executed this" — "who approved = who
+  // executed" per the audit contract. Tests below pin the data shape so a
+  // refactor can't silently drop attribution.
+
+  // Imported lazily so the helper module remains under test isolation.
+  const id = 'test-confirmation';
+  function seedConfirmation(): void {
+    // Reach into the module via createConfirmation? Not exported. Use the
+    // runner end-to-end pattern: spawn a confirmation through the runner,
+    // capture its id, then resolve via the exported helper.
+  }
+  void seedConfirmation;
+
+  it('stamps approvedByUserId and approvedAt when an approver is supplied', async () => {
+    // Drive a real confirmation through the runner so we exercise the same
+    // code path as production (avoids reaching into private maps).
+    const runner = new KubectlOpsCommandRunner({
+      connectors: fakeConnectorRepo({
+        connectors: [
+          mkConnector({
+            id: 'kube-prod',
+            config: { kubeconfig: 'apiVersion: v1\nkind: Config' },
+          }),
+        ],
+        secrets: new Map(),
+      }),
+      orgId: 'org_a',
+    });
+    let captured: OpsCommandConfirmation | undefined;
+    const pending = runner.runCommand({
+      connectorId: 'kube-prod',
+      command: 'kubectl exec foo -- ps aux', // forces confirmation
+      intent: 'read',
+      identity: {
+        userId: 'agent-sa',
+        orgId: 'org_a',
+        orgRole: 'Editor' as const,
+        isServerAdmin: false,
+        authenticatedBy: 'api_key' as const,
+      },
+      sessionId: 's1',
+      onConfirmationRequired: (c) => {
+        captured = c;
+        // Simulate the /execute endpoint: approver = human "operator-bob".
+        resolveOpsCommandConfirmation(c.id, 'rejected', { userId: 'operator-bob' });
+      },
+    });
+    const r = await pending;
+    expect(r.observation).toContain('rejected');
+    expect(captured).toBeDefined();
+    if (!captured) return;
+    // Confirmation row preserves the approver + timestamp.
+    expect(captured.approvedByUserId).toBe('operator-bob');
+    expect(captured.approvedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(captured.userId).toBe('agent-sa'); // proposer untouched
+  });
+  void id;
 });

--- a/packages/api-gateway/src/services/ops-command-runner.ts
+++ b/packages/api-gateway/src/services/ops-command-runner.ts
@@ -43,6 +43,7 @@ import {
   resolveConnectorPolicy,
   templateDefaultPolicy,
 } from './ops-policy.js';
+import type { AuditWriter } from '../auth/audit-writer.js';
 
 const log = createLogger('ops-command-runner');
 
@@ -59,12 +60,44 @@ export interface KubectlOpsCommandRunnerDeps {
    * Optional — when omitted, only wildcard policies match.
    */
   resolveUserTeams?: (identity: Identity) => Promise<readonly string[]>;
+  /**
+   * Background investigation agents have no human at the keyboard to click a
+   * confirmation card. When true, this runner bypasses the confirmation gate
+   * for read-shaped commands (per `isAgentReadSafeCommand`) — covering
+   * non-kubectl probes (`curl`, `jq`) and `kubectl exec ... -- <read-cmd>`
+   * which the policy classifier flags as `runtime.exec`/'ask' by default.
+   *
+   * The bypass NEVER applies to (a) commands classified as `critical` risk
+   * (`kubectl delete/drain`, `rm`, `mkfs`, …), (b) explicit kubectl write
+   * verbs (`apply`/`create`/`patch`/…), or (c) commands where an operator
+   * has set an EXPLICIT (team/org) policy row — operator config always wins.
+   *
+   * Agent honesty about the command being read-only is enforced by the
+   * orchestrator prompt; the runner only checks the surface shape.
+   */
+  readOnlyAgentBypass?: boolean;
+  /**
+   * Optional audit sink. When provided, every executed command (success or
+   * failure) emits one `ops.command.run` row. Attribution rules:
+   *   - confirmed by a human → actor = the approver (the human "owns" the
+   *     execution per the "who approved = who executed" principle); the
+   *     proposing agent's id lives in metadata.agentUserId.
+   *   - bypassed (`readOnlyAgentBypass` opened the gate) → actor = the
+   *     agent SA; metadata.bypassed = true so SIEM can filter.
+   *   - no policy/risk gate hit at all (e.g. `kubectl get` from interactive
+   *     chat) → actor = the calling identity directly.
+   *
+   * Omit in tests that don't care about audit.
+   */
+  audit?: AuditWriter;
 }
 
 export interface OpsCommandConfirmation {
   id: string;
   kind: 'kubectl' | 'cluster_shell';
   orgId: string;
+  /** The agent identity that proposed the command. Audit attribution falls
+   *  back to this when no human approver is recorded (e.g. read-only bypass). */
   userId: string;
   sessionId: string;
   connectorId: string;
@@ -77,6 +110,12 @@ export interface OpsCommandConfirmation {
   summary: string;
   expiresAt: string;
   status: 'pending' | 'executed' | 'rejected' | 'expired' | 'failed';
+  /** The human who clicked approve/reject. Set by `/execute` and `/reject`.
+   *  Absent when status flips to `expired` or when bypassed. The audit row
+   *  attributes execution to this user — "who approved = who executed". */
+  approvedByUserId?: string;
+  /** ISO timestamp of the approve/reject click. Paired with approvedByUserId. */
+  approvedAt?: string;
 }
 
 export interface OpsRunResult {
@@ -131,6 +170,41 @@ export function classifyShellCommandRisk(command: string): OpsCommandConfirmatio
  */
 export function shellCommandNeedsConfirmation(command: string): boolean {
   return classifyShellCommandRisk(command) !== 'low';
+}
+
+/**
+ * Kubectl write verbs that are unambiguous mutations and must always
+ * confirm even when the caller is a background investigation agent.
+ *
+ * `exec` is intentionally excluded: agents legitimately use
+ * `kubectl exec ... -- ps/cat/netstat/curl localhost:15000/...` to probe
+ * sidecar internals. The inner command's read-only-ness is the prompt's
+ * contract, not the runner's regex job. `cp` is also excluded for the
+ * same reason (file extraction from a pod is read-shaped); a `cp` that
+ * pushes a file in is still detectable through the destination form
+ * only with deeper parsing — that's a follow-up.
+ */
+const KUBECTL_UNAMBIGUOUS_WRITE_RE =
+  /\bkubectl\s+(?:[^\n|;&]*\s)?(apply|create|patch|edit|replace|scale|cordon|uncordon|rollout|annotate|label|taint|set)\b/;
+
+/**
+ * Surface-level safety classifier for the background-investigation bypass.
+ *
+ * Returns true when the command shape is plausibly read-only: no critical
+ * verbs (`delete`/`drain`/`rm`/`mkfs`/…), no unambiguous kubectl writes
+ * (`apply`/`create`/`patch`/…). `kubectl exec` and pure non-kubectl shell
+ * commands (curl/jq/grep) pass — the agent is contractually limited to
+ * read-only inner commands by the orchestrator prompt.
+ *
+ * This is a SURFACE check only. A `kubectl exec -- sh -c 'rm -rf /'`
+ * passes because the inner script isn't parsed. The trust model:
+ * background agent prompt forbids writes; runner enforces the obvious
+ * cases; audit log captures everything for post-hoc review.
+ */
+export function isAgentReadSafeCommand(command: string): boolean {
+  if (classifyShellCommandRisk(command) === 'critical') return false;
+  if (KUBECTL_UNAMBIGUOUS_WRITE_RE.test(command)) return false;
+  return true;
 }
 
 function createConfirmation(params: {
@@ -201,10 +275,15 @@ export function getOpsCommandConfirmation(id: string): OpsCommandConfirmation | 
 export function resolveOpsCommandConfirmation(
   id: string,
   status: Extract<OpsCommandConfirmation['status'], 'executed' | 'rejected' | 'failed'>,
+  approver?: { userId: string },
 ): OpsCommandConfirmation | undefined {
   const confirmation = getOpsCommandConfirmation(id);
   if (!confirmation || confirmation.status !== 'pending') return confirmation;
   confirmation.status = status;
+  if (approver) {
+    confirmation.approvedByUserId = approver.userId;
+    confirmation.approvedAt = new Date().toISOString();
+  }
   const waiter = CONFIRMATION_WAITERS.get(id);
   if (waiter) {
     CONFIRMATION_WAITERS.delete(id);
@@ -327,8 +406,34 @@ export class KubectlOpsCommandRunner implements OpsCommandRunner {
 
     const policyWantsConfirm = policy === 'ask';
     const riskWantsConfirm = shellCommandNeedsConfirmation(command);
-    const needsConfirmation =
+    let needsConfirmation =
       !params.confirmed && (policyWantsConfirm || riskWantsConfirm);
+
+    // Background investigation bypass: no human at the keyboard, so a
+    // confirmation card would block the run indefinitely. Only applies when
+    // (a) caller opted in, (b) command shape is read-safe, (c) operator has
+    // not set an explicit policy (explicit ask/block always wins).
+    if (
+      needsConfirmation &&
+      this.deps.readOnlyAgentBypass &&
+      explicit === 'no-policy' &&
+      isAgentReadSafeCommand(command)
+    ) {
+      needsConfirmation = false;
+      log.info(
+        {
+          userId: params.identity.userId,
+          capability,
+          commandHead: command.slice(0, 120),
+        },
+        'background investigation bypass: read-shaped command auto-approved',
+      );
+    }
+
+    // Track who approved (if anyone) — feeds the audit attribution below.
+    let approvedByUserId: string | undefined;
+    const bypassed = !needsConfirmation && (policyWantsConfirm || riskWantsConfirm);
+
     if (needsConfirmation) {
       const confirmation = createConfirmation({
         orgId: this.deps.orgId,
@@ -342,6 +447,10 @@ export class KubectlOpsCommandRunner implements OpsCommandRunner {
       if (decision !== 'executed') {
         return { observation: `User did not approve "${command}" (${decision}).`, success: false };
       }
+      // Re-read so we see fields the `/execute` endpoint stamped onto the
+      // confirmation (approvedByUserId, approvedAt).
+      const settled = getOpsCommandConfirmation(confirmation.id);
+      approvedByUserId = settled?.approvedByUserId;
     }
 
     // Real shell semantics. The command runs as `sh -c <command>` with the
@@ -366,6 +475,34 @@ export class KubectlOpsCommandRunner implements OpsCommandRunner {
     // observation and decides for itself; the runner is a passthrough.
     const result = await adapter.execute(action);
     const observation = typeof result.output === 'string' ? result.output : JSON.stringify(result.output);
+
+    // Audit emission. "Who approved = who executed" — when a human approved,
+    // they own the action; otherwise the agent SA does (with bypassed=true
+    // for SIEM filtering when the gate was opened by the read-only bypass).
+    if (this.deps.audit) {
+      const actorId = approvedByUserId ?? params.identity.userId;
+      const actorType: 'user' | 'service_account' =
+        approvedByUserId ? 'user' : 'service_account';
+      void this.deps.audit.log({
+        action: 'ops.command.run',
+        actorType,
+        actorId,
+        orgId: this.deps.orgId,
+        targetType: 'connector',
+        targetId: connector.id,
+        targetName: connector.name,
+        outcome: 'success',
+        metadata: {
+          command: command.slice(0, 2000),
+          capability,
+          agentUserId: params.identity.userId,
+          ...(approvedByUserId ? { approvedByUserId } : {}),
+          bypassed,
+          sessionId: params.sessionId,
+        },
+      });
+    }
+
     return { observation, success: true };
   }
 

--- a/packages/common/src/kb/__tests__/bundled-seeds.test.ts
+++ b/packages/common/src/kb/__tests__/bundled-seeds.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { BUNDLED_SEEDS } from '../bundled-seeds.js';
 
 describe('BUNDLED_SEEDS shape invariants', () => {
-  it('has exactly 18 entries', () => {
-    expect(BUNDLED_SEEDS.length).toBe(18);
+  it('has broad built-in coverage', () => {
+    expect(BUNDLED_SEEDS.length).toBeGreaterThanOrEqual(40);
   });
 
   it('every seed has a unique id', () => {
@@ -44,6 +44,35 @@ describe('BUNDLED_SEEDS shape invariants', () => {
     for (const s of BUNDLED_SEEDS) {
       expect(Array.isArray(s.intentTags)).toBe(true);
       expect(s.intentTags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ships compact Istio and Kubernetes alert guidance', () => {
+    const ids = new Set(BUNDLED_SEEDS.map((s) => s.id));
+    const istio = BUNDLED_SEEDS.find((s) => s.id === 'bundled-istio');
+    expect(istio?.title).toBe('Istio');
+    expect(istio?.body).toContain('## Data plane dashboard');
+    expect(istio?.body).toContain('## Control plane dashboard');
+    expect(istio?.body).toContain('## Alerts');
+    expect(ids.has('bundled-k8s-workload-alerts')).toBe(true);
+  });
+
+  it('covers common infra, cloud, and managed-service families', () => {
+    const ids = new Set(BUNDLED_SEEDS.map((s) => s.id));
+    for (const id of [
+      'bundled-prometheus',
+      'bundled-loki',
+      'bundled-opentelemetry-collector',
+      'bundled-elasticsearch',
+      'bundled-clickhouse',
+      'bundled-aws-eks',
+      'bundled-aws-rds',
+      'bundled-gcp-gke',
+      'bundled-gcp-pubsub',
+      'bundled-azure-aks',
+      'bundled-azure-cosmosdb',
+    ]) {
+      expect(ids.has(id)).toBe(true);
     }
   });
 });

--- a/packages/common/src/kb/bundled-seeds.ts
+++ b/packages/common/src/kb/bundled-seeds.ts
@@ -13,6 +13,47 @@ import type { KnowledgeInsertInput } from './types.js';
 
 type Seed = Omit<KnowledgeInsertInput, 'orgId'>;
 
+function compactSeed(input: {
+  id: string;
+  title: string;
+  description: string;
+  intentTags: string[];
+  dashboard: string[];
+  alerts: string[];
+  troubleshooting: string[];
+  notes?: string[];
+}): Seed {
+  return {
+    id: input.id,
+    source: 'bundled',
+    sourceRef: null,
+    title: input.title,
+    description: input.description,
+    intentTags: input.intentTags,
+    createdBy: null,
+    body: `## When to use
+
+${input.description}
+
+## Dashboard
+
+${input.dashboard.map((line) => `- ${line}`).join('\n')}
+
+## Alerts
+
+${input.alerts.map((line) => `- ${line}`).join('\n')}
+
+## Troubleshooting
+
+${input.troubleshooting.map((line) => `- ${line}`).join('\n')}${input.notes && input.notes.length > 0 ? `
+
+## Notes
+
+${input.notes.map((line) => `- ${line}`).join('\n')}` : ''}
+`,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Patterns
 // ---------------------------------------------------------------------------
@@ -203,112 +244,174 @@ const istio: Seed = {
   id: 'bundled-istio',
   source: 'bundled',
   sourceRef: null,
-  title: 'Istio data plane dashboard',
+  title: 'Istio',
   description:
-    'When the user runs Istio service mesh and wants a data-plane dashboard covering envoy sidecar resources, per-pod inbound/outbound request flow, TCP layer, and ingress gateway traffic.',
-  intentTags: ['istio', 'service-mesh', 'envoy', 'ingress', 'gateway', 'k8s', 'kubernetes'],
+    'When working with Istio service mesh dashboards or alerts across data plane, control plane, gateways, xDS, mTLS certificates, and Envoy sidecars.',
+  intentTags: ['istio', 'service-mesh', 'envoy', 'ingress', 'gateway', 'xds', 'mtls', 'alert', 'dashboard', 'kubernetes'],
   createdBy: null,
   body: `## When to use
 
-The cluster runs Istio and you want an operational data-plane view scoped to a namespace. Mirrors a real production layout: sidecar resources, per-pod request status code split (inbound and outbound), TCP layer, and the ingress gateway viewed separately. Requires cAdvisor + kube-state-metrics + Istio metrics scraping.
+Use this for Istio dashboards, alert rules, and investigations. Keep dashboards split by data plane vs control plane. Before creating alerts, check that the metric exists and preview the query.
 
-Variables to expose: \`NAMESPACE\` (k8s namespace), \`WORKLOAD\` (workload regex, default \`.*\`), \`TIME_RANGE\` (rate window, default \`5m\`).
+Variables: \`NAMESPACE\`, \`WORKLOAD\` (regex, default \`.*\`), \`TIME_RANGE\` (default \`5m\`).
 
-## Recommended dashboard
+## Data plane dashboard
 
-### Row 1 — Proxy resource usage (4 panels, w=3 each)
+Use these for sidecars and gateways.
 
-CPU utilization (percent):
+Proxy CPU per pod:
 
 \`\`\`promql
 sum by (pod) (rate(container_cpu_usage_seconds_total{container="istio-proxy", namespace="$NAMESPACE"}[$TIME_RANGE])) * 100
 \`\`\`
 
-CPU vs quota (percent):
-
-\`\`\`promql
-sum by (pod) (rate(container_cpu_usage_seconds_total{container="istio-proxy", namespace="$NAMESPACE"}[$TIME_RANGE]))
-  / on(pod) group_left() (container_spec_cpu_quota{container="istio-proxy", namespace="$NAMESPACE"} / 100000) * 100
-\`\`\`
-
-Memory utilization (percent):
-
-\`\`\`promql
-container_memory_working_set_bytes{container="istio-proxy", namespace="$NAMESPACE"}
-  / container_spec_memory_limit_bytes{container="istio-proxy", namespace="$NAMESPACE"} * 100
-\`\`\`
-
-Memory bytes:
+Proxy memory per pod:
 
 \`\`\`promql
 container_memory_working_set_bytes{container="istio-proxy", namespace="$NAMESPACE"}
 \`\`\`
 
-**Without cAdvisor (no \`container_*\` metrics scraped).** When the cluster scrapes only the Istio sidecars themselves (no kubelet/cAdvisor), use the metrics the pilot-agent + envoy expose directly. They share \`kubernetes_pod_name\` / \`app\` labels so per-pod grouping still works:
+Inbound request rate:
 
 \`\`\`promql
-# CPU per pod (percent) — pilot-agent process is a stand-in for the proxy:
+sum by (destination_workload) (
+  rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE])
+)
+\`\`\`
+
+Inbound 5xx rate:
+
+\`\`\`promql
+sum by (destination_workload) (
+  rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE", response_code=~"5.."}[$TIME_RANGE])
+)
+\`\`\`
+
+P99 latency:
+
+\`\`\`promql
+histogram_quantile(0.99,
+  sum by (le, destination_workload) (
+    rate(istio_request_duration_milliseconds_bucket{reporter="destination", destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE])
+  )
+)
+\`\`\`
+
+If cAdvisor is missing, use Istio-native sidecar metrics:
+
+\`\`\`promql
 sum by (kubernetes_pod_name) (rate(istio_agent_process_cpu_seconds_total{kubernetes_namespace="$NAMESPACE"}[$TIME_RANGE])) * 100
-
-# Memory per pod (bytes) — envoy's own allocator:
 sum by (kubernetes_pod_name) (envoy_server_memory_allocated{kubernetes_namespace="$NAMESPACE"})
-
-# Memory ratio per pod (allocated / heap_size):
-sum by (kubernetes_pod_name) (envoy_server_memory_allocated{kubernetes_namespace="$NAMESPACE"})
-  / sum by (kubernetes_pod_name) (envoy_server_memory_heap_size{kubernetes_namespace="$NAMESPACE"}) * 100
 \`\`\`
 
-Prefer the cAdvisor path when both are available — it's the true container view. The Istio-native path is the fallback so the dashboard still has a CPU/memory row in clusters that didn't deploy cAdvisor.
+## Control plane dashboard
 
-### Row 2 — Ingress requests (reporter="destination")
+Use these for \`istiod\`.
 
-Four panels: total / 2xx / 4xx / 5xx, plus a fifth for non-OK envoy response_flags.
+Istiod CPU per pod:
 
 \`\`\`promql
-# Total
-sum by (pod) (rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE]))
-
-# Per status class — vary response_code=~"2..|4..|5.."
-sum by (pod) (rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE", response_code=~"5.."}[$TIME_RANGE]))
-
-# Non-OK flag
-sum by (pod) (rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE", response_flags!="-"}[$TIME_RANGE]))
+sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="istio-system", pod=~"istiod-.*"}[$TIME_RANGE])) * 100
 \`\`\`
 
-### Row 3 — Egress requests (reporter="source")
-
-Mirror Row 2 but with \`reporter="source"\` and \`source_workload_namespace\`.
-
-### Row 4 — TCP layer
-
-Four panels: connections opened/closed (count), bytes sent/received (Bps).
+Istiod memory per pod:
 
 \`\`\`promql
-sum by (pod) (rate(istio_tcp_connections_opened_total{destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE]))
-sum by (pod) (rate(istio_tcp_connections_closed_total{destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE]))
-sum by (pod) (rate(istio_tcp_sent_bytes_total{destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE]))
-sum by (pod) (rate(istio_tcp_received_bytes_total{destination_workload_namespace="$NAMESPACE"}[$TIME_RANGE]))
+container_memory_working_set_bytes{namespace="istio-system", pod=~"istiod-.*"}
 \`\`\`
 
-### Row 5 — Ingress gateway resources
-
-Three panels (w=4): gateway CPU vs quota, memory utilization, memory bytes — same shape as Row 1 but filtered by \`pod=~"istio-ingressgateway-.*"\`.
-
-### Row 6 — Gateway-originated requests
-
-Five panels: total + 2xx/4xx/5xx + non-OK flag, with \`source_workload="istio-ingressgateway"\`.
+Istiod target up:
 
 \`\`\`promql
-sum by (pod) (rate(istio_requests_total{source_workload="istio-ingressgateway"}[$TIME_RANGE]))
-sum by (pod) (rate(istio_requests_total{source_workload="istio-ingressgateway", response_code=~"5.."}[$TIME_RANGE]))
+up{job="istiod"}
+\`\`\`
+
+XDS proxy requests / responses:
+
+\`\`\`promql
+sum(rate(istio_agent_xds_proxy_requests[$TIME_RANGE]))
+sum(rate(istio_agent_xds_proxy_responses[$TIME_RANGE]))
+\`\`\`
+
+XDS connection failures:
+
+\`\`\`promql
+sum(rate(envoy_cluster_upstream_cx_connect_fail{cluster_name="xds-grpc"}[$TIME_RANGE]))
+\`\`\`
+
+## Gateway dashboard
+
+Gateway CPU, memory, request rate, and 5xx:
+
+\`\`\`promql
+sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="istio-system", pod=~"istio-ingressgateway-.*"}[$TIME_RANGE])) * 100
+container_memory_working_set_bytes{namespace="istio-system", pod=~"istio-ingressgateway-.*"}
+sum(rate(istio_requests_total{source_workload="istio-ingressgateway"}[$TIME_RANGE]))
+sum(rate(istio_requests_total{source_workload="istio-ingressgateway", response_code=~"5.."}[$TIME_RANGE]))
+\`\`\`
+
+## Alerts
+
+Istiod down. Prefer kube-state-metrics when available:
+
+\`\`\`promql
+kube_deployment_status_replicas_available{namespace="istio-system", deployment="istiod"} < 1
+\`\`\`
+
+If kube-state-metrics is not available, use target absence:
+
+\`\`\`promql
+absent(up{job="istiod"})
+\`\`\`
+
+xDS connection failures:
+
+\`\`\`promql
+sum(rate(envoy_cluster_upstream_cx_connect_fail{cluster_name="xds-grpc"}[5m])) > 0.05
+\`\`\`
+
+xDS remote drops:
+
+\`\`\`promql
+sum(rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{cluster_name="xds-grpc"}[5m])) > 0.05
+\`\`\`
+
+mTLS cert expiring within 24h:
+
+\`\`\`promql
+count(istio_agent_cert_expiry_seconds < 86400) > 0
+\`\`\`
+
+Proxy CPU utilization over 50% by pod. Prefer cAdvisor when available:
+
+\`\`\`promql
+sum by (pod) (
+  rate(container_cpu_usage_seconds_total{container="istio-proxy", namespace="$NAMESPACE"}[5m])
+) * 100 > 50
+\`\`\`
+
+If cAdvisor is not available, use the Istio agent process metric:
+
+\`\`\`promql
+sum by (kubernetes_pod_name) (
+  rate(istio_agent_process_cpu_seconds_total{kubernetes_namespace="$NAMESPACE"}[5m])
+) * 100 > 50
+\`\`\`
+
+High 5xx ratio:
+
+\`\`\`promql
+sum(rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE", response_code=~"5.."}[5m]))
+/
+sum(rate(istio_requests_total{reporter="destination", destination_workload_namespace="$NAMESPACE"}[5m])) > 0.05
 \`\`\`
 
 ## Troubleshooting
 
-- 5xx-class rising inbound but not outbound — the workload itself is failing, not its dependencies.
-- 5xx outbound on a service whose dependencies are healthy — check Envoy response_flags for circuit breaking (\`UO\`) or no healthy upstream (\`UH\`).
-- Sidecar CPU near limit — bump \`sidecar.istio.io/proxyCPULimit\`; tail Envoy logs for stat overflow.
-- Gateway saturated — scale ingress gateway replicas; check upstream cluster connection pool settings.
+- Data-plane 5xx rising: check workload logs, Envoy response flags, and upstream health.
+- Control-plane target absent: check \`kubectl get deploy,pods -n istio-system\` and \`kubectl logs -n istio-system deploy/istiod\`.
+- Cert expiry: check affected pods with \`min by (kubernetes_namespace,kubernetes_pod_name) (istio_agent_cert_expiry_seconds)\`.
+- For local demos, use short for-duration values; in production, use 2-5m for xDS alerts and 7d/24h thresholds for certs.
 `,
 };
 
@@ -393,6 +496,120 @@ sum by (pod) (rate(container_network_receive_bytes_total{namespace="$NAMESPACE",
 - Ready count drops below replicas — readiness probe failing; check probe config and pod logs.
 - 5xx ratio spike with stable latency — upstream dependency failure.
 - p99 spike with stable rate — GC pause, lock contention, or downstream slowness.
+`,
+};
+
+const kubernetesWorkloadAlerts: Seed = {
+  id: 'bundled-k8s-workload-alerts',
+  source: 'bundled',
+  sourceRef: null,
+  title: 'Kubernetes workload alert runbooks',
+  description:
+    'When creating or investigating Kubernetes workload alerts: unavailable deployments, pod restarts, CrashLoopBackOff, OOMKilled, CPU/memory saturation, and safe kubectl repairs.',
+  intentTags: ['k8s', 'kubernetes', 'alert', 'runbook', 'deployment', 'pod', 'crashloop', 'oom', 'restart'],
+  createdBy: null,
+  body: `## When to use
+
+Use this when the user asks for practical Kubernetes workload alerts or wants a demo that can be triggered and repaired with simple \`kubectl\` commands. Prefer kube-state-metrics for lifecycle alerts and cAdvisor for resource saturation.
+
+## Alert templates
+
+Deployment has unavailable replicas:
+
+\`\`\`promql
+kube_deployment_status_replicas_unavailable{namespace="$NAMESPACE", deployment="$DEPLOYMENT"} > 0
+\`\`\`
+
+Recommended severity: high for user-facing services. Recommended for-duration: 2m.
+
+Pod restart spike:
+
+\`\`\`promql
+sum by (namespace, pod) (increase(kube_pod_container_status_restarts_total{namespace="$NAMESPACE"}[10m])) > 2
+\`\`\`
+
+Recommended severity: medium. Recommended for-duration: 0-2m.
+
+CrashLoopBackOff:
+
+\`\`\`promql
+max by (namespace, pod, container) (
+  kube_pod_container_status_waiting_reason{namespace="$NAMESPACE", reason="CrashLoopBackOff"}
+) > 0
+\`\`\`
+
+Recommended severity: high. Recommended for-duration: 2m.
+
+OOMKilled:
+
+\`\`\`promql
+sum by (namespace, pod, container) (
+  increase(kube_pod_container_status_restarts_total{namespace="$NAMESPACE"}[10m])
+)
+and on (namespace, pod, container)
+kube_pod_container_status_last_terminated_reason{namespace="$NAMESPACE", reason="OOMKilled"} == 1
+\`\`\`
+
+Recommended severity: high. Recommended for-duration: 0-2m.
+
+Container memory near limit:
+
+\`\`\`promql
+container_memory_working_set_bytes{namespace="$NAMESPACE", container!="", container!="POD"}
+  / container_spec_memory_limit_bytes{namespace="$NAMESPACE", container!="", container!="POD"} > 0.9
+\`\`\`
+
+Recommended severity: medium. Recommended for-duration: 10m.
+
+## Local simulation
+
+Unavailable deployment demo:
+
+\`\`\`bash
+kubectl scale deploy/productpage-v1 -n default --replicas=0
+\`\`\`
+
+Repair:
+
+\`\`\`bash
+kubectl scale deploy/productpage-v1 -n default --replicas=1
+kubectl rollout status deploy/productpage-v1 -n default
+\`\`\`
+
+Bad image / CrashLoop-style demo:
+
+\`\`\`bash
+kubectl set image deploy/productpage-v1 -n default productpage=does-not-exist:demo
+\`\`\`
+
+Repair by undoing the rollout:
+
+\`\`\`bash
+kubectl rollout undo deploy/productpage-v1 -n default
+kubectl rollout status deploy/productpage-v1 -n default
+\`\`\`
+
+Restart spike demo:
+
+\`\`\`bash
+kubectl rollout restart deploy/productpage-v1 -n default
+kubectl rollout status deploy/productpage-v1 -n default
+\`\`\`
+
+## Investigation checklist
+
+- Check rollout: \`kubectl rollout status deploy/$DEPLOYMENT -n $NAMESPACE\`.
+- Inspect pods: \`kubectl get pods -n $NAMESPACE -l app=$APP -o wide\`.
+- Describe failing pod: \`kubectl describe pod -n $NAMESPACE $POD\`.
+- Read logs: \`kubectl logs -n $NAMESPACE $POD --all-containers --tail=200\`.
+- For restarts, check previous logs: \`kubectl logs -n $NAMESPACE $POD --previous --all-containers --tail=200\`.
+- Correlate with recent changes: image updates, config maps, secrets, env vars, probes, resource limits.
+
+## Notes
+
+- Avoid alerting directly on pod count without deployment context; rolling updates naturally create short pod churn.
+- Prefer \`kube_deployment_status_replicas_unavailable\` for service impact and restart/OOM alerts for root-cause hints.
+- In local kind demos, use short for-duration values. In production, increase for-duration to avoid noise during expected rollouts.
 `,
 };
 
@@ -1162,6 +1379,628 @@ Reference: https://github.com/prometheus/client_golang
 };
 
 // ---------------------------------------------------------------------------
+// Compact product cards
+// ---------------------------------------------------------------------------
+
+const prometheus: Seed = compactSeed({
+  id: 'bundled-prometheus',
+  title: 'Prometheus',
+  description:
+    'Use for Prometheus server health, scrape reliability, TSDB pressure, rule evaluation, and alerting pipeline checks.',
+  intentTags: ['prometheus', 'metrics', 'tsdb', 'alertmanager', 'scrape', 'dashboard', 'alert'],
+  dashboard: [
+    '`up` by job and target',
+    '`scrape_duration_seconds`, `scrape_samples_scraped`, `scrape_series_added`',
+    '`prometheus_tsdb_head_series`, `prometheus_tsdb_head_chunks`, WAL/compaction metrics',
+    '`prometheus_rule_evaluation_duration_seconds` and failed rule evaluations',
+    'Alertmanager notification success/failure if Alertmanager is scraped',
+  ],
+  alerts: [
+    'Target down: `up == 0` with job scoping and a short for-duration',
+    'Scrape slow: high `scrape_duration_seconds / scrape_timeout_seconds`',
+    'TSDB cardinality growth: `increase(prometheus_tsdb_head_series[1h])` above expected baseline',
+    'Rule evaluation failures: `increase(prometheus_rule_evaluation_failures_total[5m]) > 0`',
+  ],
+  troubleshooting: [
+    'Check `/targets` for scrape errors and relabel output',
+    'Inspect high-cardinality labels before raising retention or resources',
+    'For slow rules, run the PromQL manually and reduce label fanout',
+  ],
+});
+
+const loki: Seed = compactSeed({
+  id: 'bundled-loki',
+  title: 'Loki',
+  description:
+    'Use for Loki ingestion, query latency, distributor/ingester health, rejected log lines, and tenant volume dashboards or alerts.',
+  intentTags: ['loki', 'logs', 'logql', 'grafana', 'observability', 'dashboard', 'alert'],
+  dashboard: [
+    'Ingestion rate by tenant, namespace, and stream',
+    'Rejected lines by reason and tenant',
+    'Query latency and query rate by frontend/querier',
+    'Ingester memory, chunks, flush failures, and WAL replay state',
+    'Object-store request errors and latency if available',
+  ],
+  alerts: [
+    'Rejected log lines: sustained `rate(loki_discarded_samples_total[5m]) > 0`',
+    'Ingestion down: distributor received bytes/log lines drop to zero for an active tenant',
+    'Query failures: sustained non-zero failed request rate',
+    'Ingester flush failures or WAL replay stuck',
+  ],
+  troubleshooting: [
+    'Start with rejected-line reasons and tenant limits',
+    'Check label cardinality; Loki incidents often come from unbounded labels',
+    'For missing logs, trace path: collector -> distributor -> ingester -> object store',
+  ],
+});
+
+const otelCollector: Seed = compactSeed({
+  id: 'bundled-opentelemetry-collector',
+  title: 'OpenTelemetry Collector',
+  description:
+    'Use for OpenTelemetry Collector pipelines: receiver load, processor drops, exporter failures, queue pressure, and telemetry routing.',
+  intentTags: ['otel', 'opentelemetry', 'collector', 'traces', 'metrics', 'logs', 'dashboard', 'alert'],
+  dashboard: [
+    'Receiver accepted/refused spans, metrics, and log records',
+    'Processor dropped items and batch processor queue behavior',
+    'Exporter sent/failed items by exporter',
+    'Exporter queue size/capacity and retry counts',
+    'Collector CPU, memory, and restarts',
+  ],
+  alerts: [
+    'Exporter failures: sustained `rate(otelcol_exporter_send_failed_spans[5m]) > 0` or equivalent signal type',
+    'Queue near full: exporter queue size / capacity > 0.8',
+    'Receiver refused items > 0',
+    'Collector restart spike or memory near limit',
+  ],
+  troubleshooting: [
+    'Find the first pipeline stage where accepted becomes refused/dropped',
+    'If exporter queue is full, check downstream backend latency and retry settings',
+    'Validate config after edits; many collector outages are config shape errors',
+  ],
+});
+
+const elasticsearch: Seed = compactSeed({
+  id: 'bundled-elasticsearch',
+  title: 'Elasticsearch / OpenSearch',
+  description:
+    'Use for Elasticsearch or OpenSearch clusters: shard health, indexing/search latency, JVM pressure, disk watermarks, and rejected thread pools.',
+  intentTags: ['elasticsearch', 'opensearch', 'search', 'lucene', 'jvm', 'dashboard', 'alert'],
+  dashboard: [
+    'Cluster health and unassigned/relocating shards',
+    'Indexing rate, search rate, indexing/search latency',
+    'JVM heap used percent, GC time, and old-gen pressure',
+    'Disk used percent per node and watermark proximity',
+    'Thread pool rejected tasks by pool',
+  ],
+  alerts: [
+    'Cluster red/yellow sustained',
+    'Unassigned shards > 0',
+    'JVM heap > 85% for 10m or GC overhead high',
+    'Disk watermark near high/flood-stage',
+    'Thread pool rejections > 0 for search/write',
+  ],
+  troubleshooting: [
+    'Check shard allocation explain before moving data manually',
+    'Correlate heap pressure with query/indexing changes',
+    'For disk pressure, delete/roll over indices before flood-stage blocks writes',
+  ],
+});
+
+const clickhouse: Seed = compactSeed({
+  id: 'bundled-clickhouse',
+  title: 'ClickHouse',
+  description:
+    'Use for ClickHouse health: query latency, merges, mutations, replication lag, parts count, disk pressure, and error rates.',
+  intentTags: ['clickhouse', 'olap', 'database', 'analytics', 'dashboard', 'alert'],
+  dashboard: [
+    'Query rate and p95/p99 query duration',
+    'Insert rate and failed query/insert rate',
+    'Merge backlog, active merges, and mutation backlog',
+    'Parts count per table and detached parts',
+    'Replication lag, readonly replicas, and disk usage',
+  ],
+  alerts: [
+    'Too many parts for hot tables',
+    'Replication lag growing or replica readonly',
+    'Disk free below threshold',
+    'Mutation backlog sustained',
+    'Query exception rate above baseline',
+  ],
+  troubleshooting: [
+    'Check `system.parts`, `system.merges`, `system.mutations`, and `system.replication_queue`',
+    'High parts usually means insert batching is too small',
+    'Disk pressure can block merges and make query latency worse',
+  ],
+});
+
+const cassandra: Seed = compactSeed({
+  id: 'bundled-cassandra',
+  title: 'Cassandra',
+  description:
+    'Use for Cassandra clusters: read/write latency, pending compactions, tombstones, dropped messages, repair, and disk pressure.',
+  intentTags: ['cassandra', 'database', 'nosql', 'jmx', 'dashboard', 'alert'],
+  dashboard: [
+    'Read/write request rate and p95/p99 latency',
+    'Pending compactions and compaction throughput',
+    'Tombstone scanned histogram and coordinator timeouts',
+    'Dropped messages by verb',
+    'Disk used, SSTable count, and node up/down',
+  ],
+  alerts: [
+    'Node down or unreachable',
+    'Read/write p99 latency above SLO',
+    'Pending compactions growing',
+    'Dropped messages > 0 sustained',
+    'Disk usage > 80-85%',
+  ],
+  troubleshooting: [
+    'Check `nodetool status`, `tpstats`, `compactionstats`, and table histograms',
+    'High tombstones usually need data-model or TTL review',
+    'Avoid restarting multiple nodes in the same replica set at once',
+  ],
+});
+
+const zookeeper: Seed = compactSeed({
+  id: 'bundled-zookeeper',
+  title: 'ZooKeeper',
+  description:
+    'Use for ZooKeeper quorum health: leader election, outstanding requests, latency, watches, connections, and znodes.',
+  intentTags: ['zookeeper', 'coordination', 'kafka', 'quorum', 'dashboard', 'alert'],
+  dashboard: [
+    'Server state by node: leader/follower/observer',
+    'Outstanding requests and request latency',
+    'Active connections and watches',
+    'Znode count, ephemeral nodes, and approximate data size',
+    'Disk fsync latency and snapshot/log size if available',
+  ],
+  alerts: [
+    'No leader or more than one leader',
+    'Quorum unavailable or node down',
+    'Outstanding requests sustained high',
+    'Request latency above baseline',
+    'Disk space low on data/log volume',
+  ],
+  troubleshooting: [
+    'Check four-letter commands or admin server output before restarting',
+    'Validate quorum config and network between peers',
+    'For Kafka-backed clusters, check broker impact before touching ZooKeeper',
+  ],
+});
+
+const awsEks: Seed = compactSeed({
+  id: 'bundled-aws-eks',
+  title: 'AWS EKS',
+  description:
+    'Use for EKS clusters: Kubernetes workload health plus AWS node group, API server, load balancer, and cluster add-on signals.',
+  intentTags: ['aws', 'eks', 'kubernetes', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'Kubernetes node/pod health and workload availability',
+    'Managed node group desired/ready capacity',
+    'API server request rate, latency, and errors if control-plane metrics are enabled',
+    'AWS Load Balancer Controller errors and ALB/NLB target health',
+    'CoreDNS, CNI/IP exhaustion, and cluster add-on health',
+  ],
+  alerts: [
+    'Node not ready or node group below desired capacity',
+    'Pod pending due to IP exhaustion, quota, or insufficient resources',
+    'ALB/NLB unhealthy targets > 0',
+    'CoreDNS unavailable or DNS latency high',
+    'API server 5xx or latency above baseline',
+  ],
+  troubleshooting: [
+    'Check node group events, ASG activity, and EC2 capacity errors',
+    'For pod networking, inspect VPC CNI logs and ENI/IP usage',
+    'For ingress failures, inspect ALB target groups and controller logs',
+  ],
+});
+
+const awsEcs: Seed = compactSeed({
+  id: 'bundled-aws-ecs',
+  title: 'AWS ECS / Fargate',
+  description:
+    'Use for ECS services and Fargate tasks: desired vs running tasks, CPU/memory, deployment rollout, task exits, and load balancer target health.',
+  intentTags: ['aws', 'ecs', 'fargate', 'cloudwatch', 'container', 'dashboard', 'alert'],
+  dashboard: [
+    'Desired, running, pending, and stopped task counts per service',
+    'CPU and memory utilization per service/task',
+    'Deployment rollout state and task start/stop reasons',
+    'ALB target response time, 5xx, and unhealthy targets',
+    'Container logs error rate if logs are metricized',
+  ],
+  alerts: [
+    'Running tasks < desired tasks',
+    'Task restart/stop spike',
+    'CPU or memory > 85% sustained',
+    'Unhealthy ALB targets > 0',
+    'Deployment stuck or rollback detected',
+  ],
+  troubleshooting: [
+    'Start with ECS service events and stopped task reason',
+    'Check image pull, IAM task role, secrets, and health check config',
+    'If ALB targets are unhealthy, compare container port, security groups, and health path',
+  ],
+});
+
+const awsLambda: Seed = compactSeed({
+  id: 'bundled-aws-lambda',
+  title: 'AWS Lambda',
+  description:
+    'Use for Lambda functions: invocations, errors, duration, throttles, concurrency, cold starts, async failures, and DLQ/backlog.',
+  intentTags: ['aws', 'lambda', 'serverless', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'Invocations, errors, and error rate by function/alias',
+    'Duration p95/p99 and timeout proximity',
+    'Throttles, concurrent executions, and provisioned concurrency utilization',
+    'Iterator age for stream/event-source mappings',
+    'DLQ/SQS destination failures and async event age',
+  ],
+  alerts: [
+    'Error rate above baseline',
+    'Throttles > 0 sustained',
+    'Duration p99 near timeout',
+    'Iterator age growing',
+    'DLQ messages or async failures > 0',
+  ],
+  troubleshooting: [
+    'Check recent deploy/alias shift and function logs first',
+    'Throttles can be account concurrency, reserved concurrency, or downstream backpressure',
+    'For stream sources, fix consumer errors before increasing parallelization',
+  ],
+});
+
+const awsRds: Seed = compactSeed({
+  id: 'bundled-aws-rds',
+  title: 'AWS RDS / Aurora',
+  description:
+    'Use for RDS or Aurora: CPU, connections, free storage, replica lag, deadlocks, read/write latency, and engine-specific database metrics.',
+  intentTags: ['aws', 'rds', 'aurora', 'postgres', 'mysql', 'database', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'CPUUtilization, DatabaseConnections, FreeStorageSpace',
+    'Read/WriteIOPS and read/write latency',
+    'ReplicaLag or Aurora replica lag',
+    'Deadlocks, lock waits, rollbacks, and slow query indicators when exporter metrics exist',
+    'Burst balance / ACU / serverless capacity where relevant',
+  ],
+  alerts: [
+    'CPU > 85% sustained',
+    'Free storage low or storage autoscaling near limit',
+    'Connections > 80% of max connections',
+    'Replica lag above SLO',
+    'Deadlock or rollback rate spike',
+  ],
+  troubleshooting: [
+    'Check Performance Insights / slow query data for top SQL',
+    'Connection pressure usually needs pool tuning before instance scaling',
+    'Replica lag can be write volume, long transaction, storage I/O, or replica class too small',
+  ],
+});
+
+const awsElastiCache: Seed = compactSeed({
+  id: 'bundled-aws-elasticache',
+  title: 'AWS ElastiCache',
+  description:
+    'Use for ElastiCache Redis or Memcached: CPU, memory, evictions, connections, cache hit ratio, replication lag, and failover events.',
+  intentTags: ['aws', 'elasticache', 'redis', 'memcached', 'cache', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'CPUUtilization / EngineCPUUtilization',
+    'DatabaseMemoryUsagePercentage or bytes used',
+    'Cache hit ratio, gets/sets, evictions, expired keys',
+    'CurrConnections and new connections',
+    'ReplicationLag and failover events for Redis clusters',
+  ],
+  alerts: [
+    'Memory usage > 85-90%',
+    'Evictions > 0 when not expected',
+    'Hit ratio below target',
+    'Replication lag above SLO',
+    'CPU sustained high or connection spike',
+  ],
+  troubleshooting: [
+    'Check hot keys and big keys before scaling',
+    'Evictions mean maxmemory policy and dataset size need review',
+    'Replication lag often follows write spikes or slow replica class',
+  ],
+});
+
+const awsAlbNlb: Seed = compactSeed({
+  id: 'bundled-aws-load-balancers',
+  title: 'AWS ALB / NLB',
+  description:
+    'Use for AWS load balancers: request rate, 4xx/5xx, target health, latency, connection errors, and capacity anomalies.',
+  intentTags: ['aws', 'alb', 'nlb', 'load-balancer', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'RequestCount / ActiveFlowCount / NewFlowCount',
+    'TargetResponseTime p95/p99 for ALB',
+    'HTTPCode_ELB_5XX and HTTPCode_Target_5XX',
+    'HealthyHostCount and UnHealthyHostCount per target group',
+    'TargetConnectionErrorCount and rejected connections',
+  ],
+  alerts: [
+    'Unhealthy targets > 0',
+    'ELB 5xx > 0 sustained',
+    'Target 5xx ratio above SLO',
+    'Target response time above SLO',
+    'NLB TCP reset / rejected flow spike',
+  ],
+  troubleshooting: [
+    'Separate load balancer 5xx from target 5xx',
+    'For unhealthy targets, inspect health path, security groups, and app readiness',
+    'For latency, compare ALB target time with app RED metrics',
+  ],
+});
+
+const awsMessaging: Seed = compactSeed({
+  id: 'bundled-aws-messaging',
+  title: 'AWS SQS / SNS / EventBridge',
+  description:
+    'Use for AWS managed messaging: SQS backlog and age, DLQ growth, SNS delivery failures, and EventBridge failed invocations.',
+  intentTags: ['aws', 'sqs', 'sns', 'eventbridge', 'queue', 'messaging', 'cloudwatch', 'dashboard', 'alert'],
+  dashboard: [
+    'SQS visible messages, in-flight messages, and oldest message age',
+    'SQS sent/received/deleted message rates',
+    'DLQ visible messages',
+    'SNS published messages and delivery failures',
+    'EventBridge matched events, failed invocations, and throttles',
+  ],
+  alerts: [
+    'SQS oldest message age above SLO',
+    'SQS visible messages growing while consumers are healthy',
+    'DLQ messages > 0',
+    'SNS delivery failures > 0',
+    'EventBridge failed invocations or throttles > 0',
+  ],
+  troubleshooting: [
+    'Backlog can be producer spike, consumer errors, or downstream throttling',
+    'Inspect DLQ sample payloads before redrive',
+    'For EventBridge, check target permissions and target service limits',
+  ],
+});
+
+const gcpGke: Seed = compactSeed({
+  id: 'bundled-gcp-gke',
+  title: 'Google Kubernetes Engine',
+  description:
+    'Use for GKE clusters: Kubernetes workload health, node pools, control-plane/API health, load balancing, DNS, and autoscaler behavior.',
+  intentTags: ['gcp', 'gke', 'kubernetes', 'cloud-monitoring', 'dashboard', 'alert'],
+  dashboard: [
+    'Kubernetes node, pod, and workload availability',
+    'Node pool desired/ready node count and autoscaler events',
+    'API server request latency/errors if exposed',
+    'GCLB backend health, latency, 4xx/5xx',
+    'CoreDNS/kube-dns health and DNS latency',
+  ],
+  alerts: [
+    'Node not ready or node pool under target size',
+    'Pods pending due to resources, quota, or image pull',
+    'Backend unhealthy in load balancer',
+    'DNS unavailable or high error rate',
+    'Cluster autoscaler unable to scale',
+  ],
+  troubleshooting: [
+    'Check GKE events, node pool operations, and quota first',
+    'For networking, inspect NEG/backend service health',
+    'For pod scheduling, compare requests, quotas, and node taints',
+  ],
+});
+
+const gcpCloudRun: Seed = compactSeed({
+  id: 'bundled-gcp-cloud-run',
+  title: 'Google Cloud Run',
+  description:
+    'Use for Cloud Run services: request count, latency, 4xx/5xx, container instance count, cold starts, concurrency, and revisions.',
+  intentTags: ['gcp', 'cloud-run', 'serverless', 'cloud-monitoring', 'dashboard', 'alert'],
+  dashboard: [
+    'Request count and request latency by service/revision',
+    '4xx/5xx response count and error ratio',
+    'Container instance count and concurrency',
+    'CPU/memory utilization if available',
+    'Revision rollout and traffic split',
+  ],
+  alerts: [
+    '5xx ratio above SLO',
+    'Latency p95/p99 above SLO',
+    'Instance count at max with latency rising',
+    'Cold-start sensitive service has high startup latency',
+    'Revision error rate worse than previous revision',
+  ],
+  troubleshooting: [
+    'Compare failing revision with previous revision',
+    'Check container startup logs and health/startup probes',
+    'Tune min instances/concurrency before scaling blindly',
+  ],
+});
+
+const gcpCloudSql: Seed = compactSeed({
+  id: 'bundled-gcp-cloud-sql',
+  title: 'Google Cloud SQL',
+  description:
+    'Use for Cloud SQL MySQL/PostgreSQL/SQL Server: CPU, connections, storage, disk I/O, replication lag, locks, and slow queries.',
+  intentTags: ['gcp', 'cloud-sql', 'postgres', 'mysql', 'database', 'cloud-monitoring', 'dashboard', 'alert'],
+  dashboard: [
+    'CPU utilization, memory utilization, and disk utilization',
+    'Connections vs max connections',
+    'Read/write IOPS and disk latency',
+    'Replication lag for replicas',
+    'Engine-specific slow queries, deadlocks, locks, and cache hit ratio if exporter exists',
+  ],
+  alerts: [
+    'CPU > 85% sustained',
+    'Disk utilization or free bytes near limit',
+    'Connections > 80% of max',
+    'Replica lag above SLO',
+    'Deadlock/lock wait spike',
+  ],
+  troubleshooting: [
+    'Use Query Insights or engine logs for top SQL',
+    'Connection pressure usually needs pooling changes',
+    'Disk latency can come from storage limits, not only query volume',
+  ],
+});
+
+const gcpPubSub: Seed = compactSeed({
+  id: 'bundled-gcp-pubsub',
+  title: 'Google Pub/Sub',
+  description:
+    'Use for Pub/Sub topics and subscriptions: backlog, oldest unacked message age, ack latency, delivery failures, and dead-letter topics.',
+  intentTags: ['gcp', 'pubsub', 'messaging', 'queue', 'cloud-monitoring', 'dashboard', 'alert'],
+  dashboard: [
+    'Subscription backlog message count and bytes',
+    'Oldest unacked message age',
+    'Ack message count/rate and ack latency',
+    'Push subscription error response classes',
+    'Dead-letter topic publish count',
+  ],
+  alerts: [
+    'Oldest unacked message age above SLO',
+    'Backlog growing while consumers are healthy',
+    'Push endpoint 5xx/4xx sustained',
+    'Dead-letter messages > 0',
+    'Ack latency above baseline',
+  ],
+  troubleshooting: [
+    'Check subscriber error logs and downstream dependency health',
+    'For push, inspect endpoint status codes and auth',
+    'Backlog often needs consumer fixes before scaling subscriber count',
+  ],
+});
+
+const azureAks: Seed = compactSeed({
+  id: 'bundled-azure-aks',
+  title: 'Azure Kubernetes Service',
+  description:
+    'Use for AKS clusters: workload health, node pools, Azure load balancer/application gateway, DNS, CNI/IP pressure, and autoscaler state.',
+  intentTags: ['azure', 'aks', 'kubernetes', 'azure-monitor', 'dashboard', 'alert'],
+  dashboard: [
+    'Kubernetes node, pod, and deployment availability',
+    'Node pool ready count vs desired count',
+    'CPU/memory pressure by node and namespace',
+    'Application Gateway / Load Balancer backend health',
+    'CoreDNS health and Azure CNI IP usage if available',
+  ],
+  alerts: [
+    'Node not ready or node pool below desired',
+    'Deployment unavailable replicas > 0',
+    'Pod pending due to IP/resource pressure',
+    'Backend health probe failures',
+    'DNS unavailable or high error rate',
+  ],
+  troubleshooting: [
+    'Check AKS node pool events and VMSS health',
+    'For ingress, inspect Application Gateway backend health and AGIC logs',
+    'For pod scheduling, check quotas, taints, and Azure CNI IP exhaustion',
+  ],
+});
+
+const azureAppService: Seed = compactSeed({
+  id: 'bundled-azure-app-service',
+  title: 'Azure App Service / Functions',
+  description:
+    'Use for Azure App Service and Functions: request rate, response status, latency, instance count, CPU/memory, restarts, and dependency errors.',
+  intentTags: ['azure', 'app-service', 'functions', 'serverless', 'azure-monitor', 'dashboard', 'alert'],
+  dashboard: [
+    'Requests, response time, HTTP 4xx/5xx',
+    'CPU percentage and memory working set',
+    'Instance count and restarts',
+    'Function execution count, failures, and duration',
+    'Dependency failures from Application Insights if connected',
+  ],
+  alerts: [
+    'HTTP 5xx ratio above SLO',
+    'Response time p95/p99 above SLO',
+    'Function failures or timeout spike',
+    'CPU/memory high sustained',
+    'Restart count spike',
+  ],
+  troubleshooting: [
+    'Check deployment slot/recent release first',
+    'Use Application Insights traces and dependency failures',
+    'Scale out only after checking thread pool, connection pool, and downstream errors',
+  ],
+});
+
+const azureSql: Seed = compactSeed({
+  id: 'bundled-azure-sql',
+  title: 'Azure SQL Database',
+  description:
+    'Use for Azure SQL: DTU/vCore pressure, sessions, deadlocks, blocking, storage, log IO, query duration, and replication/failover health.',
+  intentTags: ['azure', 'sql', 'database', 'azure-monitor', 'dashboard', 'alert'],
+  dashboard: [
+    'CPU/DTU percentage, data IO percentage, log IO percentage',
+    'Sessions and workers percentage',
+    'Storage used and allocated data storage',
+    'Deadlocks, blocked processes, and query duration if query store is exposed',
+    'Replication lag/failover group health where applicable',
+  ],
+  alerts: [
+    'CPU/DTU > 85% sustained',
+    'Data or log IO > 85% sustained',
+    'Storage near max',
+    'Deadlocks > 0 sustained',
+    'Blocked sessions above baseline',
+  ],
+  troubleshooting: [
+    'Start with Query Store top resource-consuming queries',
+    'Check missing indexes and plan regressions before scaling tier',
+    'For log IO pressure, inspect transaction size and batching',
+  ],
+});
+
+const azureCosmosDb: Seed = compactSeed({
+  id: 'bundled-azure-cosmosdb',
+  title: 'Azure Cosmos DB',
+  description:
+    'Use for Cosmos DB: request units, throttles, latency, availability, partition skew, consistency, and storage pressure.',
+  intentTags: ['azure', 'cosmosdb', 'nosql', 'database', 'ru', 'azure-monitor', 'dashboard', 'alert'],
+  dashboard: [
+    'Total requests and normalized RU consumption',
+    '429 throttled requests by container/partition key range',
+    'Server-side latency p95/p99',
+    'Availability and failed requests by status code',
+    'Storage used by database/container',
+  ],
+  alerts: [
+    '429 rate above acceptable baseline',
+    'Normalized RU consumption > 80-90%',
+    'Latency p95/p99 above SLO',
+    'Availability below SLO',
+    'Storage near quota',
+  ],
+  troubleshooting: [
+    'Check partition key skew before increasing RU',
+    'Inspect top queries and indexing policy',
+    '429 can be normal if SDK retry hides it; alert on user-visible impact too',
+  ],
+});
+
+const azureServiceBus: Seed = compactSeed({
+  id: 'bundled-azure-service-bus',
+  title: 'Azure Service Bus',
+  description:
+    'Use for Service Bus queues and topics: active/dead-letter messages, age/backlog, incoming/outgoing rate, throttles, and consumer failures.',
+  intentTags: ['azure', 'service-bus', 'queue', 'messaging', 'azure-monitor', 'dashboard', 'alert'],
+  dashboard: [
+    'Active messages, scheduled messages, dead-letter messages',
+    'Incoming/outgoing messages and requests',
+    'Server errors, user errors, and throttled requests',
+    'Queue/topic size and oldest message age if available',
+    'Consumer processing latency from app metrics',
+  ],
+  alerts: [
+    'Dead-letter messages > 0',
+    'Active messages or oldest age growing',
+    'Throttled requests > 0 sustained',
+    'Server errors > 0 sustained',
+    'Consumer lag above SLO',
+  ],
+  troubleshooting: [
+    'Inspect DLQ sample messages before redrive',
+    'Backlog usually points to consumer errors or downstream slowness',
+    'Throttling may require SKU/namespace capacity changes or sender rate limits',
+  ],
+});
+
+// ---------------------------------------------------------------------------
 // Export
 // ---------------------------------------------------------------------------
 
@@ -1171,6 +2010,7 @@ export const BUNDLED_SEEDS: ReadonlyArray<Omit<KnowledgeInsertInput, 'orgId'>> =
   perPodOps,
   istio,
   k8sWorkload,
+  kubernetesWorkloadAlerts,
   postgres,
   mysql,
   mongodb,
@@ -1184,4 +2024,27 @@ export const BUNDLED_SEEDS: ReadonlyArray<Omit<KnowledgeInsertInput, 'orgId'>> =
   jvm,
   nodejs,
   go,
+  prometheus,
+  loki,
+  otelCollector,
+  elasticsearch,
+  clickhouse,
+  cassandra,
+  zookeeper,
+  awsEks,
+  awsEcs,
+  awsLambda,
+  awsRds,
+  awsElastiCache,
+  awsAlbNlb,
+  awsMessaging,
+  gcpGke,
+  gcpCloudRun,
+  gcpCloudSql,
+  gcpPubSub,
+  azureAks,
+  azureAppService,
+  azureSql,
+  azureCosmosDb,
+  azureServiceBus,
 ];

--- a/packages/web/src/components/chat/ChatTranscript.tsx
+++ b/packages/web/src/components/chat/ChatTranscript.tsx
@@ -3,7 +3,7 @@ import type { ChatEvent } from '../../hooks/useDashboardChat.js';
 import type { PendingChangeKind, PendingChangeStatus } from '../../types/pending-changes.js';
 import AgentActivityBlock from './AgentActivityBlock.js';
 import AskUserPrompt from './AskUserPrompt.js';
-import ChangeProposalCard from './ChangeProposalCard.js';
+import DashboardChangeConfirmCard from './DashboardChangeConfirmCard.js';
 import { DatasourceChoiceChip } from './DatasourceChoiceChip.js';
 import { ErrorMessage, UserMessage, AssistantMessage } from './MessageComponents.js';
 import OpsCommandConfirmCard from './OpsCommandConfirmCard.js';
@@ -110,31 +110,29 @@ function renderMessageBlock(
     );
   }
 
-  if (evt.kind === 'pending_change_created' && evt.pendingChange) {
-    const p = evt.pendingChange;
-    const overlay = proposalStatusOverlay?.get(p.id);
-    return (
-      <ChangeProposalCard
-        key={evt.id}
-        proposalId={p.id}
-        dashboardId={p.dashboardId}
-        panelId={p.panelId ?? null}
-        changeKind={(p.changeKind as PendingChangeKind) ?? 'modify_panel'}
-        summary={p.summary ?? 'Proposed change'}
-        beforeJson={p.beforeJson}
-        afterJson={p.afterJson}
-        initialStatus={(p.status as PendingChangeStatus) ?? 'pending'}
-        {...(overlay ? { controlledStatus: overlay } : {})}
-      />
-    );
-  }
-
   if (evt.kind === 'ops_command_confirmation_required' && evt.opsConfirmation) {
     return (
       <OpsCommandConfirmCard
         key={evt.id}
         confirmation={evt.opsConfirmation}
         onResolved={onOpsConfirmationResolved}
+      />
+    );
+  }
+
+  if (evt.kind === 'pending_change_created' && evt.pendingChange) {
+    const p = evt.pendingChange;
+    const overlay = proposalStatusOverlay?.get(p.id);
+    return (
+      <DashboardChangeConfirmCard
+        key={evt.id}
+        proposalId={p.id}
+        dashboardId={p.dashboardId}
+        panelId={p.panelId ?? null}
+        changeKind={(p.changeKind as PendingChangeKind) ?? 'modify_panel'}
+        summary={p.summary ?? 'Apply proposed dashboard update'}
+        initialStatus={(p.status as PendingChangeStatus) ?? 'pending'}
+        {...(overlay ? { controlledStatus: overlay } : {})}
       />
     );
   }

--- a/packages/web/src/components/chat/DashboardChangeConfirmCard.tsx
+++ b/packages/web/src/components/chat/DashboardChangeConfirmCard.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { pendingChangesApi } from '../../api/client.js';
+import type { PendingChangeKind, PendingChangeStatus } from '../../types/pending-changes.js';
+
+interface DashboardChangeConfirmCardProps {
+  proposalId: string;
+  dashboardId: string;
+  panelId: string | null;
+  changeKind: PendingChangeKind;
+  summary: string;
+  initialStatus?: PendingChangeStatus;
+  controlledStatus?: PendingChangeStatus;
+  onResolved?: (status: PendingChangeStatus) => void;
+}
+
+export default function DashboardChangeConfirmCard({
+  proposalId,
+  dashboardId,
+  panelId,
+  changeKind,
+  summary,
+  initialStatus = 'pending',
+  controlledStatus,
+  onResolved,
+}: DashboardChangeConfirmCardProps) {
+  const [status, setStatus] = useState<PendingChangeStatus>(controlledStatus ?? initialStatus);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (controlledStatus && controlledStatus !== status) {
+      setStatus(controlledStatus);
+    }
+  }, [controlledStatus, status]);
+
+  const resolve = async (next: 'accepted' | 'rejected') => {
+    setBusy(true);
+    setError('');
+    try {
+      if (next === 'accepted') {
+        await pendingChangesApi.accept(dashboardId, proposalId);
+        window.dispatchEvent(new CustomEvent('dashboard:refresh-panels', {
+          detail: { dashboardId },
+        }));
+      } else {
+        await pendingChangesApi.reject(dashboardId, proposalId);
+      }
+      setStatus(next);
+      onResolved?.(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Confirmation failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (status !== 'pending') {
+    const glyph = status === 'accepted' ? '✓' : status === 'rejected' ? '✕' : '·';
+    const label = status === 'accepted' ? 'Applied dashboard change' :
+      status === 'rejected' ? 'Cancelled dashboard change' :
+        'Dashboard change expired';
+    return (
+      <div className="text-xs text-on-surface-variant">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="inline-flex items-center gap-2 hover:text-on-surface"
+        >
+          <span>{glyph}</span>
+          <span>{label}</span>
+          <span className="opacity-60">{expanded ? '▾' : '▸'}</span>
+        </button>
+        {expanded && (
+          <pre className="mt-2 font-mono whitespace-pre-wrap break-all bg-[var(--color-surface)] border border-[var(--color-outline-variant)] rounded p-2">
+            {summary}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-[var(--color-outline-variant)] rounded-lg p-4 bg-[var(--color-surface-highest)] space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold text-on-surface">Confirm dashboard change</div>
+          <div className="text-xs text-on-surface-variant">
+            {changeKind}{panelId ? ` · ${panelId}` : ''}
+          </div>
+        </div>
+        <span className="text-xs uppercase tracking-wide text-on-surface-variant">pending</span>
+      </div>
+      <p className="text-sm text-on-surface">{summary}</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void resolve('accepted')}
+          className="px-3 py-2 rounded-md bg-primary text-on-primary-fixed font-semibold disabled:opacity-50"
+        >
+          {busy ? 'Working...' : 'Yes, apply'}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void resolve('rejected')}
+          className="px-3 py-2 rounded-md border border-[var(--color-outline-variant)] disabled:opacity-50"
+        >
+          No, cancel
+        </button>
+      </div>
+      {error && (
+        <pre className="font-mono text-xs whitespace-pre-wrap break-all bg-[var(--color-surface)] border border-[var(--color-outline-variant)] rounded p-2 text-error">
+          {error}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/event-processing.ts
+++ b/packages/web/src/components/chat/event-processing.ts
@@ -54,18 +54,9 @@ export function groupEvents(
       evt.kind === 'pending_change_created' ||
       evt.kind === 'ops_command_confirmation_required'
     ) {
-      // pending_change_created renders as an inline change-proposal card. We
-      // intentionally flush the agent activity block first so the card sits
-      // right after the tool_call that produced it — matches the
-      // "AI says X, here's a card to apply or cancel" Claude-Code pattern.
       flushAgent();
       blocks.push({ type: 'message', event: evt });
 
-      // Claude-Code-style "blocking" behavior: when a change_proposal is
-      // unresolved, the conversation pauses below it — hide every event
-      // that came after this proposal. Once the user clicks Apply / Cancel
-      // (or the overlay map flips status to non-pending) the remainder of
-      // the conversation reappears.
       if (evt.kind === 'pending_change_created') {
         const proposalId =
           (evt as { pendingChange?: { id?: string } }).pendingChange?.id;
@@ -96,8 +87,7 @@ export function groupEvents(
       }
     } else if (evt.kind === 'pending_change_resolved' || evt.kind === 'ops_command_confirmation_resolved') {
       // Resolution events don't render their own block; the corresponding
-      // change_proposal card overlays its status via the page-level overlay
-      // map. Drop them from the block stream.
+      // confirmation card overlays its status via the page-level overlay map.
       continue;
     } else if (evt.kind === 'done') {
       flushAgent();

--- a/packages/web/src/pages/DashboardWorkspace.tsx
+++ b/packages/web/src/pages/DashboardWorkspace.tsx
@@ -338,7 +338,7 @@ export default function DashboardWorkspace() {
     const newPanels = panels.map((p) => (p.id === updated.id ? updated : p));
     const res = await apiClient.putValidated<Dashboard>(
       `/dashboards/${id}/panels`,
-      newPanels,
+      { panels: newPanels },
       DashboardSchema,
       'Dashboard',
     );


### PR DESCRIPTION
## Summary

Two coupled changes so background investigations can actually run, and every executed command has a traceable owner.

### 1. Read-only-shape bypass for `background_orchestrator` runs

The \`ops_run_command\` confirmation gate blocks forever on read-shaped commands the surface classifier maps to \`runtime.exec\` (\`curl\`, \`jq\`, \`kubectl exec -- ps\`) because no human is at the keyboard for an auto-investigation. The runner now takes \`readOnlyAgentBypass\` and, when set, skips the gate for commands that pass \`isAgentReadSafeCommand\`.

Bypass NEVER applies to:
- critical risk (\`delete\`/\`drain\`/\`rm\`/\`mkfs\`/…)
- explicit kubectl writes (\`apply\`/\`create\`/\`patch\`/\`scale\`/\`rollout\`/…)
- commands where an operator set an explicit team/org policy row (operator config always wins)

The matching contract lives in the orchestrator system prompt (\`getBackgroundShellContractSection\`) so the agent self-restricts inner exec commands to reads.

### 2. Approver-attributed audit

\`OpsCommandConfirmation\` now records \`approvedByUserId\` + \`approvedAt\`. The \`/execute\` and \`/reject\` handlers drop the legacy \`confirmation.userId === auth.userId\` check (background SAs created confirmations no human could ever match); RBAC \`OpsCommandsRun\` on the connector OR \`InstanceConfigWrite\` is the real gate.

Every executed command emits an \`ops.command.run\` audit row:
- \`actorId\` = the approver when one exists ("who approved = who executed")
- else the agent SA, with \`metadata.bypassed=true\` so SIEM can filter
- \`metadata.agentUserId\` always preserves the proposer for chain-of-custody

| Scenario | actor | metadata |
|---|---|---|
| Foreground chat, user runs \`kubectl get\` | user | \`agentUserId=user, bypassed=false\` |
| Foreground chat, agent runs \`kubectl exec\`, Alice approves | Alice | \`agentUserId=user, approvedByUserId=alice\` |
| Background investigation \`curl localhost:15000/…\` (bypass) | agent SA | \`agentUserId=SA, bypassed=true\` |
| Background investigation \`kubectl delete\` (critical, Alice approves) | Alice | \`agentUserId=SA, approvedByUserId=alice\` |

### Why now

Caught during a manual end-to-end test where an alert-triggered investigation got stuck at step 5 for 6+ minutes — the agent had emitted a \`kubectl exec\` to inspect the istio-proxy sidecar and there was no UI surface that could approve it (the same-userId check rejected the human's click). The bypass unblocks the read-shaped path; the audit changes make sure we don't lose accountability in exchange.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`ops-command-runner.test.ts\` — 21/21 pass (8 new: \`isAgentReadSafeCommand\` matrix + approver-stamping)
- [x] \`packages/api-gateway\` full suite — 978/978 pass
- [ ] Manual: trigger an istio-proxy CPU alert, watch background investigation run \`kubectl exec\` / \`curl\` without stalling, verify \`audit_log\` rows have correct actor attribution
- [ ] Manual: trigger a write that needs approval (e.g. \`kubectl scale\`), have a non-SA user approve, verify the \`/execute\` call succeeds and the audit row attributes the action to that user (not the SA)

## Note on second commit

\`9ccafc6\` carries over unrelated WIP edits that were already in the working tree before this session (KB bundled seeds, dashboard handler, pending-changes route, chat transcript, a new \`DashboardChangeConfirmCard\` component). Substantive review of those belongs in a separate PR — they're bundled here only because the user asked to include everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard panel changes now validate required fields (title, visualization) to prevent invalid states
  * Alert history displays only rules that currently exist in the system
  * Fixed dashboard panel save request format

* **New Features**
  * Background agent operations for read-only commands now skip manual confirmation
  * Command approvals now capture approver identity and timestamp for attribution
  * Expanded knowledge base with guidance for infrastructure platforms (Prometheus, Loki, Elasticsearch, AWS/GCP/Azure services)

* **Tests**
  * Added validation tests for dashboard panel modifications and pending changes
  * Enhanced test coverage for alert history filtering and command read-safety classification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->