### PR TITLE
Connector + chat + agent patch set (7 fixes)

### DIFF
--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -545,10 +545,17 @@ export async function handleDashboardAddPanels(
   ctx: ActionContext,
   args: Record<string, unknown>,
 ): Promise<string> {
-  const dashboardId = ctx.activeDashboardId;
+  const explicitId =
+    typeof args.dashboardId === 'string' && args.dashboardId.trim()
+      ? args.dashboardId.trim()
+      : null;
+
+  const dashboardId = explicitId ?? ctx.activeDashboardId;
   if (!dashboardId) {
-    return 'Error: no active dashboard. Call dashboard_create first.';
+    return 'Error: no active dashboard. Pass dashboardId, or call dashboard_create first.';
   }
+
+  if (explicitId) ctx.activeDashboardId = explicitId;
   const panels = args.panels as Array<Record<string, unknown>> | undefined;
   if (!panels || !Array.isArray(panels) || panels.length === 0) {
     return 'Error: "panels" array is required with at least one panel config.';

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -463,7 +463,7 @@ function getDashboardContextSection(dashboard: Dashboard, timeRange?: { start: s
 
   return `# Current Dashboard Context
 Title: ${dashboard.title}${timeRangeText}
-This dashboard is the active target for dashboard.* tool calls — do not pass a dashboardId parameter.
+This dashboard is the active target for dashboard.* tool calls. Other dashboard.* tools always act on the active dashboard. Only dashboard_add_panels accepts an explicit dashboardId parameter — pass it when the user names a different existing dashboard you resolved via dashboard_list; that call also switches the active target so subsequent dashboard.* calls follow.
 
 ## Panels (${dashboard.panels.length} total)
 ${panelsSummary}

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -47,15 +47,24 @@ function resolveConnectorScope(args: Record<string, unknown>): string {
 }
 
 /**
- * Dashboard mutation tools no longer take `dashboardId` as a parameter — the
- * id lives on `ctx.activeDashboardId`, set by `dashboard_create` /
- * `dashboard_clone`. When the active id is missing the handler returns a
- * clear "call dashboard_create first" error and never reaches a side effect,
- * so the gate falls back to wildcard rather than minting a deny sentinel —
- * an unusable id wouldn't tighten the gate, only confuse the failure mode.
+ * Dashboard mutation tools target either the active dashboard (id lives on
+ * `ctx.activeDashboardId`, set by `dashboard_create` / `dashboard_clone` /
+ * page context) or an explicit `args.dashboardId` when the caller passes one
+ * (currently only `dashboard_add_panels` accepts it). Explicit wins over
+ * active. When neither is available the handler returns a clear error and
+ * never reaches a side effect, so the gate falls back to wildcard rather
+ * than minting a deny sentinel — an unusable id wouldn't tighten the gate,
+ * only confuse the failure mode.
  */
-function resolveDashboardScope(ctx: ActionContext): string {
-  const id = ctx.activeDashboardId;
+function resolveDashboardScope(
+  ctx: ActionContext,
+  args?: Record<string, unknown>,
+): string {
+  const explicit =
+    args && typeof args.dashboardId === 'string' && args.dashboardId.trim()
+      ? args.dashboardId.trim()
+      : null;
+  const id = explicit ?? ctx.activeDashboardId;
   return id ? `dashboards:uid:${id}` : 'dashboards:uid:*';
 }
 
@@ -83,7 +92,7 @@ export const TOOL_PERMS: Record<string, ToolPermissionBuilder> = {
       'dashboards:create',
       `folders:uid:${String(args.folderUid ?? '*')}`,
     ),
-  'dashboard_add_panels': (_args, ctx) => ac.eval('dashboards:write', resolveDashboardScope(ctx)),
+  'dashboard_add_panels': (args, ctx) => ac.eval('dashboards:write', resolveDashboardScope(ctx, args)),
   'dashboard_remove_panels': (_args, ctx) => ac.eval('dashboards:write', resolveDashboardScope(ctx)),
   'dashboard_modify_panel': (_args, ctx) => ac.eval('dashboards:write', resolveDashboardScope(ctx)),
   'dashboard_set_title': (_args, ctx) => ac.eval('dashboards:write', resolveDashboardScope(ctx)),

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -688,7 +688,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: {
       name: 'dashboard_add_panels',
       description:
-        'Add one or more panels to the active dashboard. Call dashboard_create or dashboard_open first; this tool implicitly targets that dashboard. The model constructs panel configs directly (title, visualization, queries, unit, ...). Panel sizing and layout are auto-applied. Every query must carry an explicit datasourceId — there is NO inheritance from the dashboard primary. For a single-source dashboard, set every query to the dashboard primary id. For cross-source compare panels, set per query (one source per query). The handler rejects panels with any missing datasourceId.\n\n' +
+        'Add one or more panels to a dashboard. By default targets the active dashboard (set by dashboard_create / dashboard_clone / current page context). To target a different existing dashboard, pass `dashboardId` — call `dashboard_list` first to resolve the id by name before doing so. The model constructs panel configs directly (title, visualization, queries, unit, ...). Panel sizing and layout are auto-applied. Every query must carry an explicit datasourceId — there is NO inheritance from the dashboard primary. For a single-source dashboard, set every query to the dashboard primary id. For cross-source compare panels, set per query (one source per query). The handler rejects panels with any missing datasourceId.\n\n' +
         'PRE-FLIGHT: if the dashboard targets a NAMED system (Redis, Kafka, Postgres, nginx, Istio, ...) call kb_recommend FIRST, then kb_get any relevant result and use that body as the canonical metric/layout source. Call web_search only after KB returns no relevant entry. Carve-out: skip KB only when the exact metric names and layout you are about to use are already quoted in the current conversation.\n\n' +
         'Skipping the pre-flight is the dominant failure mode: training-data priors invent plausible-looking names → metrics_validate rejects → re-plan → wasted turns. KB lookups are cheap and bundled entries are the source of truth for common stacks.\n\n' +
         'Validate every non-trivial query through metrics_validate before this call. The handler rejects unvalidated queries. If the user asks for several distinct dashboard areas, create and populate one focused dashboard at a time instead of combining them into one oversized dashboard.\n\n' +
@@ -696,6 +696,11 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
       input_schema: {
         type: 'object',
         properties: {
+          dashboardId: {
+            type: 'string',
+            description:
+              'Optional target dashboard id. Use this when the user names an existing dashboard found via dashboard_list and the current page context is not that dashboard. Passing this also makes the named dashboard the active target for subsequent dashboard.* tool calls in this turn.',
+          },
           panels: {
             type: 'array',
             description: 'Panel configs. datasourceId is REQUIRED per query. unit is optional; use only known metric unit metadata or omit it.',

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -38,7 +38,8 @@
     "ldapjs": "^3.0.7",
     "prom-client": "^15.1.3",
     "socket.io": "^4.8.2",
-    "supertest": "^7.1.2"
+    "supertest": "^7.1.2",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/packages/api-gateway/src/app/agent-factory.ts
+++ b/packages/api-gateway/src/app/agent-factory.ts
@@ -31,6 +31,7 @@ import {
   buildAdapterRegistry,
   toAgentConnectors,
 } from '../services/dashboard-service.js';
+import { hydrateConnectorSecrets } from '../utils/connector-secrets.js';
 import { toAlertRuleStore } from '../services/chat-service.js';
 import { KubectlOpsCommandRunner, connectorToOpsConfig } from '../services/ops-command-runner.js';
 import type { Persistence } from './persistence.js';
@@ -92,8 +93,15 @@ export function buildBackgroundOrchestratorFactory(
     const llmAuditRepo = deps.persistence.repos.llmAudit;
     const auditSink = llmAuditRepo ? createDbAuditSink(llmAuditRepo) : undefined;
     const gateway = createLlmGateway(llm, undefined, auditSink);
-    const adapters = buildAdapterRegistry(
+    // Hydrate token-auth ciphertext into `config.apiKey` for adapter
+    // construction. Original `connectors` (used for `toAgentConnectors`
+    // prompt feed below) stays credential-free.
+    const hydratedConnectors = await hydrateConnectorSecrets(
       connectors,
+      deps.persistence.repos.connectors,
+    );
+    const adapters = buildAdapterRegistry(
+      hydratedConnectors,
       [],
     );
     const opsConnectors = connectors

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -260,7 +260,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     authMiddleware,
     userRateLimiter,
     createOrgContextMiddleware({ orgUsers: authRepos.orgUsers }),
-    createQueryRouter({ setupConfig, ac: accessControl }),
+    createQueryRouter({ setupConfig, ac: accessControl, connectorRepo: repos.connectors }),
   );
 
   // -- W6 business routes ----------------------------------------------
@@ -454,6 +454,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     setupConfig,
     ac: accessControl,
     audit: authSub.audit,
+    connectorRepo: repos.connectors,
   }));
   // PR-C — save inline chart as a dashboard panel (new or append).
   app.use('/api/metrics', userRateLimiter, createMetricsSaveAsDashboardRouter({
@@ -470,6 +471,7 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     setupConfig,
     ac: accessControl,
     audit: authSub.audit,
+    connectorRepo: repos.connectors,
     ...(deps.runner ? { runner: deps.runner } : {}),
   }));
   // /api/folders is mounted in rbac-routes.ts (T7.1).

--- a/packages/api-gateway/src/routes/alert-rules.ts
+++ b/packages/api-gateway/src/routes/alert-rules.ts
@@ -17,6 +17,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import { AlertRuleService } from '../services/alert-rule-service.js';
+import type { ConnectorSecretReader } from '../utils/connector-secrets.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
 import { getOrgId } from '../middleware/workspace-context.js';
 
@@ -42,6 +43,9 @@ export interface AlertRulesRouterDeps {
   reportStore?: IInvestigationReportRepository;
   /** Required for preview/backtest to resolve configured metrics datasources. */
   setupConfig: SetupConfigService;
+  /** Optional secret reader — hydrates token-auth credentials before the
+   * preview adapter call so backtest queries authenticate. */
+  connectorRepo?: ConnectorSecretReader;
   /**
    * RBAC surface. `AccessControlSurface` is used (not the concrete service)
    * because this router is mounted outside the async auth IIFE in server.ts
@@ -66,7 +70,7 @@ export interface AlertRulesRouterDeps {
 export function createAlertRulesRouter(deps: AlertRulesRouterDeps): Router {
   const store = deps.alertRuleStore;
   const router = Router();
-  const alertRuleService = new AlertRuleService(store, deps.setupConfig);
+  const alertRuleService = new AlertRuleService(store, deps.setupConfig, deps.connectorRepo);
   const audit = deps.audit;
   const requirePermission = createRequirePermission(deps.ac);
 

--- a/packages/api-gateway/src/routes/chat.ts
+++ b/packages/api-gateway/src/routes/chat.ts
@@ -209,7 +209,6 @@ async function handleChatStream(
   }, 30_000);
 
   let agentError: Error | null = null;
-  let result: Awaited<ReturnType<ChatService['handleMessage']>> | undefined;
   try {
     const service = new ChatService(deps);
     // Race the agent's awaited handleMessage against the abort signal so
@@ -269,7 +268,7 @@ async function handleChatStream(
         { once: true },
       );
     });
-    result = await Promise.race([agentPromise, abortPromise]);
+    await Promise.race([agentPromise, abortPromise]);
   } catch (err) {
     agentError = err instanceof Error ? err : new Error(String(err));
   }
@@ -312,14 +311,12 @@ async function handleChatStream(
           );
         }
       }
-    } else if (result && !closed) {
-      sendSseEvent(res, {
-        type: 'done',
-        messageId: result.assistantMessageId,
-        sessionId: result.sessionId,
-        ...(result.navigate ? { navigate: result.navigate } : {}),
-      } as DashboardSseEvent & { sessionId: string });
     }
+    // No route-level `done` emission — chat-service.handleMessage emits
+    // the terminal `done` exactly once via wrappedSendEvent before
+    // returning, so it lands on both the in-request stream AND the
+    // persisted event trace / live bus. Duplicating it here would write
+    // a second `done` to the HTTP response.
   } finally {
     clearInterval(heartbeat);
     // CRITICAL: set closed BEFORE res.end() so any sendEvent callback

--- a/packages/api-gateway/src/routes/connectors.test.ts
+++ b/packages/api-gateway/src/routes/connectors.test.ts
@@ -346,6 +346,52 @@ describe('DELETE /api/connectors/:id/policies/:subjectType/:subjectId/:capabilit
   });
 });
 
+describe('maskForWire — credential redaction', () => {
+  it('strips credential-shaped keys from config in GET /:id', async () => {
+    const repo = new MemoryConnectorRepo();
+    await repo.create({
+      id: 'leaky',
+      orgId: 'org_a',
+      type: 'prometheus' as ConnectorType,
+      name: 'p',
+      config: {
+        url: 'http://prom:9090',
+        apiKey: 'sk-leak-me',
+        password: 'hunter2',
+        bearerToken: 'eyJ-leak',
+        client_secret: 'shhh',
+        privateKey: '-----BEGIN-----',
+        tlsVerify: true,
+      },
+      createdBy: 'u1',
+    });
+    const app = mountRouter(repo);
+    const res = await request(app).get('/api/connectors/leaky');
+    expect(res.status).toBe(200);
+    const cfg = res.body.connector.config as Record<string, unknown>;
+    expect(cfg).toEqual({ url: 'http://prom:9090', tlsVerify: true });
+    expect(JSON.stringify(res.body)).not.toContain('sk-leak-me');
+    expect(JSON.stringify(res.body)).not.toContain('hunter2');
+    expect(JSON.stringify(res.body)).not.toContain('eyJ-leak');
+  });
+
+  it('strips credential-shaped keys from config in GET / list', async () => {
+    const repo = new MemoryConnectorRepo();
+    await repo.create({
+      id: 'leaky2',
+      orgId: 'org_a',
+      type: 'prometheus' as ConnectorType,
+      name: 'p',
+      config: { url: 'http://prom:9090', apiKey: 'sk-leak-me' },
+      createdBy: 'u1',
+    });
+    const app = mountRouter(repo);
+    const res = await request(app).get('/api/connectors');
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain('sk-leak-me');
+  });
+});
+
 describe('GET /api/connectors/:id/policies — query filter', () => {
   async function setupWithMixedPolicies(): Promise<MemoryConnectorRepo> {
     const repo = new MemoryConnectorRepo();

--- a/packages/api-gateway/src/routes/connectors.ts
+++ b/packages/api-gateway/src/routes/connectors.ts
@@ -93,11 +93,25 @@ function connectorScope(id = '*'): string {
   return id === '*' ? 'connectors:*' : `connectors:uid:${id}`;
 }
 
+// Credential-shaped keys that must never appear in wire responses. The
+// `connector_secrets` table is the only legitimate home for these; inline
+// values in `config` are a legacy/misuse pattern and would leak via
+// GET /connectors otherwise. Match case-insensitively against the full key
+// name and any segment of a camelCase / snake_case identifier.
+const REDACT_KEY_TOKENS = ['apikey', 'password', 'token', 'secret', 'credential', 'privatekey'];
+
+function isCredentialKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[_-]/g, '');
+  return REDACT_KEY_TOKENS.some((tok) => normalized.includes(tok));
+}
+
 function maskForWire(connector: Connector): Connector {
-  return {
-    ...connector,
-    config: { ...connector.config },
-  };
+  const config: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(connector.config)) {
+    if (isCredentialKey(key)) continue;
+    config[key] = value;
+  }
+  return { ...connector, config };
 }
 
 function readStatus(value: unknown): ConnectorStatus | undefined {

--- a/packages/api-gateway/src/routes/dashboard/query.ts
+++ b/packages/api-gateway/src/routes/dashboard/query.ts
@@ -9,12 +9,18 @@ import type { Connector } from '@agentic-obs/common'
 import type { AuthenticatedRequest } from '../../middleware/auth.js'
 import { authMiddleware } from '../../middleware/auth.js'
 import { PrometheusHttpClient } from '@agentic-obs/adapters'
+import { normalizePrometheusBaseUrl } from '../../utils/prometheus-url.js'
+import { hydrateConnectorSecrets, type ConnectorSecretReader } from '../../utils/connector-secrets.js'
 import type { SetupConfigService } from '../../services/setup-config-service.js'
 import type { AccessControlSurface } from '../../services/accesscontrol-holder.js'
 
 export interface QueryRouterDeps {
   setupConfig: SetupConfigService
   ac: AccessControlSurface
+  /** Optional secret reader. When supplied, token-auth connectors with no inline
+   * `config.apiKey` are hydrated from `connector_secrets` before adapter
+   * construction. Omit in tests that don't exercise auth headers. */
+  connectorRepo?: ConnectorSecretReader
 }
 
 // -- Helpers
@@ -47,7 +53,7 @@ function configString(connector: Connector, key: string): string | undefined {
 }
 
 function buildClientConfig(connector: Connector): ConstructorParameters<typeof PrometheusHttpClient>[0] {
-  const cfg: ConstructorParameters<typeof PrometheusHttpClient>[0] = { baseUrl: configString(connector, 'url') ?? '' }
+  const cfg: ConstructorParameters<typeof PrometheusHttpClient>[0] = { baseUrl: normalizePrometheusBaseUrl(configString(connector, 'url') ?? '') }
   const username = configString(connector, 'username')
   const password = configString(connector, 'password')
   const apiKey = configString(connector, 'apiKey')
@@ -133,6 +139,12 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
   const router = Router()
   const { setupConfig } = deps
 
+  async function hydrateOne(connector: Connector): Promise<Connector> {
+    if (!deps.connectorRepo) return connector
+    const [hydrated] = await hydrateConnectorSecrets([connector], deps.connectorRepo)
+    return hydrated ?? connector
+  }
+
   // POST /api/query/range
   router.post('/range', authMiddleware, async (req: Request, res: Response) => {
     const { query, start, end, step = '30s', datasourceId, environment, cluster, variableValues } = req.body as {
@@ -167,7 +179,8 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
     const startDate = start ? new Date(start) : new Date(endDate.getTime() - 30 * 60 * 1000)
 
     try {
-      const client = new PrometheusHttpClient(buildClientConfig(ds))
+      const dsHydrated = await hydrateOne(ds)
+      const client = new PrometheusHttpClient(buildClientConfig(dsHydrated))
       const result = await client.rangeQuery(query, startDate, endDate, step)
       res.json(result)
     } catch (err) {
@@ -204,7 +217,8 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
     if (!(await requireDatasourcePermission(deps, req, res, ACTIONS.ConnectorsQuery, ds.id))) return
 
     try {
-      const client = new PrometheusHttpClient(buildClientConfig(ds))
+      const dsHydrated = await hydrateOne(ds)
+      const client = new PrometheusHttpClient(buildClientConfig(dsHydrated))
       const result = await client.instantQuery(query, time ? new Date(time) : undefined)
       res.json(result)
     } catch (err) {
@@ -231,8 +245,9 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
     if (!(await requireDatasourcePermission(deps, req, res, ACTIONS.ConnectorsRead, ds.id))) return
 
     try {
-      const baseUrl = (configString(ds, 'url') ?? '').replace(/\/$/, '')
-      const headers = buildFetchHeaders(ds)
+      const dsHydrated = await hydrateOne(ds)
+      const baseUrl = normalizePrometheusBaseUrl(configString(dsHydrated, 'url') ?? '')
+      const headers = buildFetchHeaders(dsHydrated)
 
       let url: string
       if (match) {
@@ -285,8 +300,9 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
     if (!(await requireDatasourcePermission(deps, req, res, ACTIONS.ConnectorsRead, ds.id))) return
 
     try {
-      const baseUrl = (configString(ds, 'url') ?? '').replace(/\/$/, '')
-      const headers = buildFetchHeaders(ds)
+      const dsHydrated = await hydrateOne(ds)
+      const baseUrl = normalizePrometheusBaseUrl(configString(dsHydrated, 'url') ?? '')
+      const headers = buildFetchHeaders(dsHydrated)
       const params = new URLSearchParams()
       if (metric) params.set('match[]', metric)
       const url = `${baseUrl}/api/v1/labels?${params}`
@@ -361,9 +377,12 @@ export function createQueryRouter(deps: QueryRouterDeps): Router {
       resolved.push(ds)
     }
 
+    const resolvedHydrated = deps.connectorRepo
+      ? await hydrateConnectorSecrets(resolved, deps.connectorRepo)
+      : resolved
     const settled = await Promise.allSettled(
       queries.map(async (q, i) => {
-        const ds = resolved[i]!
+        const ds = resolvedHydrated[i]!
         const client = new PrometheusHttpClient(buildClientConfig(ds))
         return q.instant
           ? client.instantQuery(q.expr)

--- a/packages/api-gateway/src/routes/dashboard/router.ts
+++ b/packages/api-gateway/src/routes/dashboard/router.ts
@@ -17,6 +17,7 @@ import { VariableResolver } from './variable-resolver.js'
 import { ac, ACTIONS, AuditAction, assertWritable, ProvisionedResourceError } from '@agentic-obs/common'
 import type { Dashboard, PanelConfig } from '@agentic-obs/common'
 import type { SetupConfigService } from '../../services/setup-config-service.js'
+import { normalizePrometheusBaseUrl } from '../../utils/prometheus-url.js'
 import type { AuditWriter } from '../../auth/audit-writer.js'
 import { getOrgId } from '../../middleware/workspace-context.js'
 
@@ -491,7 +492,7 @@ export function createDashboardRouter(deps: DashboardRouterDeps): ExpressRouter 
       let prometheusUrl = ''
       const headers: Record<string, string> = {}
       if (promConnector) {
-        prometheusUrl = typeof promConnector.config.url === 'string' ? promConnector.config.url : ''
+        prometheusUrl = normalizePrometheusBaseUrl(typeof promConnector.config.url === 'string' ? promConnector.config.url : '')
         const username = typeof promConnector.config.username === 'string' ? promConnector.config.username : ''
         const password = typeof promConnector.config.password === 'string' ? promConnector.config.password : ''
         const apiKey = typeof promConnector.config.apiKey === 'string' ? promConnector.config.apiKey : ''

--- a/packages/api-gateway/src/routes/llm-factory.ts
+++ b/packages/api-gateway/src/routes/llm-factory.ts
@@ -80,7 +80,13 @@ export function createLlmProvider(cfg: LlmFactoryConfig): LLMProvider {
   const apiKeyHelper = cfg.apiKeyHelper ?? undefined;
 
   if (cfg.provider === 'corporate-gateway') {
-    return createForCorpGateway(cfg.apiFormat ?? 'anthropic', cfg.baseUrl, apiKey, apiKeyHelper);
+    return createForCorpGateway(
+      cfg.apiFormat ?? 'anthropic',
+      cfg.baseUrl,
+      apiKey,
+      apiKeyHelper,
+      cfg.authType ?? 'bearer',
+    );
   }
 
   switch (cfg.provider) {
@@ -179,6 +185,7 @@ function createForCorpGateway(
   baseUrl: string | null | undefined,
   apiKey: string,
   apiKeyHelper: string | undefined,
+  authType: 'api-key' | 'bearer',
 ): LLMProvider {
   const base = baseUrl || undefined;
   const helperOpt = apiKeyHelper ? { apiKeyHelper } : {};
@@ -199,6 +206,7 @@ function createForCorpGateway(
         ...helperOpt,
         baseUrl: base,
         endpointFlavor: 'bedrock',
+        apiType: authType,
       });
     case 'anthropic':
     default:
@@ -206,6 +214,7 @@ function createForCorpGateway(
         apiKey,
         ...helperOpt,
         baseUrl: base,
+        apiType: authType,
       });
   }
 }

--- a/packages/api-gateway/src/routes/metrics-query.ts
+++ b/packages/api-gateway/src/routes/metrics-query.ts
@@ -28,12 +28,18 @@ import { authMiddleware } from '../middleware/auth.js';
 import { createRequirePermission } from '../middleware/require-permission.js';
 import type { AccessControlSurface } from '../services/accesscontrol-holder.js';
 import type { SetupConfigService } from '../services/setup-config-service.js';
+import { normalizePrometheusBaseUrl } from '../utils/prometheus-url.js';
+import { hydrateConnectorSecrets, type ConnectorSecretReader } from '../utils/connector-secrets.js';
 import type { AuditWriter } from '../auth/audit-writer.js';
 
 export interface MetricsQueryRouterDeps {
   setupConfig: SetupConfigService;
   ac: AccessControlSurface;
   audit: AuditWriter;
+  /** Optional secret reader. Hydrates `config.apiKey` from `connector_secrets`
+   * before constructing the Prometheus adapter so token-auth datasources
+   * actually authenticate. */
+  connectorRepo?: ConnectorSecretReader;
   /**
    * Test seam — defaults to constructing a real `PrometheusMetricsAdapter`
    * from the connector's config. Tests pass a stub so they don't need a live
@@ -149,7 +155,7 @@ function configString(connector: Connector, key: string): string | undefined {
 }
 
 function defaultBuildAdapter(connector: Connector) {
-  const baseUrl = configString(connector, 'url') ?? '';
+  const baseUrl = normalizePrometheusBaseUrl(configString(connector, 'url') ?? '');
   const headers: Record<string, string> = {};
   const username = configString(connector, 'username');
   const password = configString(connector, 'password');
@@ -326,7 +332,10 @@ export function createMetricsQueryRouter(deps: MetricsQueryRouterDeps): Router {
 
       const startedAt = Date.now();
       try {
-        const adapter = buildAdapter(ds);
+        const dsForAdapter = deps.connectorRepo
+          ? (await hydrateConnectorSecrets([ds], deps.connectorRepo))[0] ?? ds
+          : ds;
+        const adapter = buildAdapter(dsForAdapter);
         const series = await adapter.rangeQuery(query, rangeOrErr.start, rangeOrErr.end, step);
         const summary = summarizeChart(series, kind);
 

--- a/packages/api-gateway/src/services/alert-rule-service.ts
+++ b/packages/api-gateway/src/services/alert-rule-service.ts
@@ -2,6 +2,7 @@ import { type AlertOperator } from '@agentic-obs/common';
 import type { IAlertRuleRepository } from '@agentic-obs/data-layer';
 import { PrometheusMetricsAdapter } from '@agentic-obs/adapters';
 import { resolvePrometheusConnector } from './dashboard-service.js';
+import { hydrateConnectorSecrets, type ConnectorSecretReader } from '../utils/connector-secrets.js';
 import type { SetupConfigService } from './setup-config-service.js';
 import {
   previewAlertCondition,
@@ -21,6 +22,7 @@ export class AlertRuleService {
   constructor(
     _store: IAlertRuleRepository,
     private readonly setupConfig: SetupConfigService,
+    private readonly connectorRepo?: ConnectorSecretReader,
   ) {}
 
   /**
@@ -33,7 +35,10 @@ export class AlertRuleService {
     input: PreviewAlertRuleInput,
     orgId: string,
   ): Promise<PreviewAlertResult> {
-    const connectors = await this.setupConfig.listConnectors({ orgId });
+    const rawConnectors = await this.setupConfig.listConnectors({ orgId });
+    const connectors = this.connectorRepo
+      ? await hydrateConnectorSecrets(rawConnectors, this.connectorRepo)
+      : rawConnectors;
     const prom = resolvePrometheusConnector(connectors);
     if (!prom) {
       return { kind: 'missing_capability', reason: 'no_metrics_datasource' };

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -23,6 +23,7 @@ import {
   buildAdapterRegistry,
   toAgentConnectors,
 } from './dashboard-service.js';
+import { hydrateConnectorSecrets } from '../utils/connector-secrets.js';
 import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
 
 // Web-search adapter is configuration-free for the default DuckDuckGo
@@ -288,7 +289,7 @@ function pickAgentTypeFromContext(
 // Event kinds that represent transient signalling (terminator / navigation
 // side-effect) and should NOT be persisted to the event trace. `reply` events
 // are persisted so history replay keeps the same interleaving users saw live.
-const SKIP_PERSIST_KINDS = new Set(['done', 'navigate']);
+const SKIP_PERSIST_KINDS = new Set(['navigate']);
 
 export interface ChatSessionResult {
   sessionId: string;
@@ -444,7 +445,10 @@ export class ChatService {
         if (bus) bus.publish(resolvedSessionId, seq++, event);
         return;
       }
-      if (SKIP_PERSIST_KINDS.has(event.type)) return;
+      if (SKIP_PERSIST_KINDS.has(event.type)) {
+        if (bus) bus.publish(resolvedSessionId, seq++, event);
+        return;
+      }
       const eventSeq = seq++;
       const record = {
         id: randomUUID(),
@@ -496,8 +500,15 @@ export class ChatService {
       : undefined;
     const gateway = createLlmGateway(llm, undefined, auditSink);
     const model = llm.model;
+    // Resolve token-auth ciphertext into `config.apiKey` for adapter
+     // construction. The hydrated copy is local to the adapter registry; the
+     // original `connectors` (used below for `toAgentConnectors` → prompt and
+     // for `connectorToOpsConfig`) stays credential-free.
+    const hydratedConnectors = this.deps.connectorRepo
+      ? await hydrateConnectorSecrets(connectors, this.deps.connectorRepo)
+      : connectors;
     const adapters = buildAdapterRegistry(
-      connectors,
+      hydratedConnectors,
       [],
     );
 
@@ -767,12 +778,57 @@ export class ChatService {
       }
     }
 
+    // Emit terminal `done` here so it lands in the persisted event trace
+    // AND on the live bus exactly once per turn. The route no longer fires
+    // a fallback `done` after handleMessage — this is the single source.
+    wrappedSendEvent({
+      type: 'done',
+      messageId: assistantMessageId,
+      sessionId: resolvedSessionId,
+      ...(navigate ? { navigate } : {}),
+    } as DashboardSseEvent);
+
     return {
       sessionId: resolvedSessionId,
       replyContent,
       assistantMessageId,
       navigate,
     };
+    } catch (err) {
+      // Publish a terminal `error` to the persisted event trace + live bus so
+      // tabs tailing via /events/stream don't get stuck on the spinner. The
+      // POST-stream tab receives its own `event: error` from the route's
+      // catch, so we deliberately skip the in-request sendEvent here.
+      const errorEvent = {
+        type: 'error',
+        sessionId: resolvedSessionId,
+        message: err instanceof Error ? err.message : String(err),
+      } as DashboardSseEvent;
+      const eventSeq = seq++;
+      if (eventStore) {
+        const record = {
+          id: randomUUID(),
+          sessionId: resolvedSessionId,
+          seq: eventSeq,
+          kind: errorEvent.type,
+          payload: errorEvent as unknown as Record<string, unknown>,
+          timestamp: new Date().toISOString(),
+        };
+        persistChain = persistChain.then(async () => {
+          try {
+            await eventStore.append(record);
+            if (bus) bus.publish(resolvedSessionId, eventSeq, errorEvent);
+          } catch (persistErr) {
+            log.warn(
+              { err: persistErr, sessionId: resolvedSessionId, seq: eventSeq },
+              'failed to persist terminal error event',
+            );
+          }
+        });
+      } else if (bus) {
+        bus.publish(resolvedSessionId, eventSeq, errorEvent);
+      }
+      throw err;
     } finally {
       // Drain in-flight persist+publish on BOTH success and error paths.
       // Bounded by the serialization invariant above — this awaits all

--- a/packages/api-gateway/src/services/connector-test.test.ts
+++ b/packages/api-gateway/src/services/connector-test.test.ts
@@ -48,7 +48,7 @@ describe('testConnectorAgainstBackend — http-get', () => {
     const out = await testConnectorAgainstBackend(makeConnector(), null);
     expect(out.ok).toBe(true);
     const call = fetchMock.mock.calls[0]!;
-    expect(call[0]).toBe('https://prom.example/api/v1/status/buildinfo');
+    expect(call[0]).toBe('https://prom.example/api/v1/query?query=vector(1)');
     expect((call[1] as RequestInit).headers).toEqual({});
   });
 
@@ -56,7 +56,7 @@ describe('testConnectorAgainstBackend — http-get', () => {
     vi.stubGlobal('fetch', mockFetch(async () => jsonResponse(500, 'boom')));
     const out = await testConnectorAgainstBackend(makeConnector(), null);
     expect(out.ok).toBe(false);
-    expect(out.message).toBe('HTTP 500');
+    expect(out.message).toMatch(/HTTP 500/);
     expect(out.detail).toBe('boom');
   });
 
@@ -108,7 +108,7 @@ describe('testConnectorAgainstBackend — http-get', () => {
       makeConnector({ config: { url: 'https://prom.example/' } }),
       null,
     );
-    expect(fetchMock.mock.calls[0]![0]).toBe('https://prom.example/api/v1/status/buildinfo');
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://prom.example/api/v1/query?query=vector(1)');
   });
 });
 

--- a/packages/api-gateway/src/services/connector-test.ts
+++ b/packages/api-gateway/src/services/connector-test.ts
@@ -10,9 +10,15 @@
 
 import { request as httpsRequest } from 'node:https';
 import { readFile } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
 import type { Connector } from '@agentic-obs/common';
 import { getConnectorTemplate, type ConnectorType } from '@agentic-obs/common';
 import { createLogger } from '@agentic-obs/server-utils/logging';
+import { normalizePrometheusBaseUrl } from '../utils/prometheus-url.js';
+import {
+  resolveExecCredential,
+  type KubeconfigExecSpec,
+} from './kubeconfig-exec.js';
 
 const log = createLogger('connector-test');
 
@@ -130,7 +136,8 @@ async function testHttpGet(
 ): Promise<ConnectorTestOutcome> {
   const rawUrl = typeof connector.config['url'] === 'string' ? (connector.config['url'] as string) : '';
   if (!rawUrl) return { ok: false, message: 'connector has no url configured' };
-  const base = rawUrl.replace(/\/+$/, '');
+  const isPromCompat = connector.type === 'prometheus' || connector.type === 'victoria-metrics';
+  const base = isPromCompat ? normalizePrometheusBaseUrl(rawUrl) : rawUrl.replace(/\/+$/, '');
   const target = `${base}${path}`;
 
   const template = getConnectorTemplate(connector.type as ConnectorType);
@@ -145,9 +152,12 @@ async function testHttpGet(
     const res = await fetch(target, { method: 'GET', headers, signal: controller.signal });
     if (res.ok) return { ok: true };
     const body = await safeReadBody(res);
+    const message = isPromCompat
+      ? `Could not run a Prometheus query against this URL (HTTP ${res.status} from ${target}). Check that the URL is the Prometheus API root or proxy root, not a full query path, and that any token has query permission.`
+      : `HTTP ${res.status}`;
     return {
       ok: false,
-      message: `HTTP ${res.status}`,
+      message,
       ...(body ? { detail: body } : {}),
     };
   } catch (err) {
@@ -173,17 +183,41 @@ async function testKubernetesVersion(
   const targetApiServer = apiServer || kubeconfig?.server?.replace(/\/+$/, '') || '';
 
   if (targetApiServer) {
-    const token = kubeconfig?.token ?? (secret ? extractKubeconfigToken(secret) : null);
     const headers: Record<string, string> = { Accept: 'application/json' };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-    if (kubeconfig?.clientCertificate && kubeconfig.clientKey) {
+
+    // Resolve auth in priority order: static token → exec plugin → cert/key.
+    let bearer: string | null = kubeconfig?.token
+      ?? (secret ? extractKubeconfigToken(secret) : null);
+    if (!bearer && kubeconfig?.exec) {
+      try {
+        const { token } = await resolveExecCredential(kubeconfig.exec, {
+          connectorId: connector.id,
+        });
+        bearer = token;
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : String(err) };
+      }
+    }
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+
+    // Route to the HTTPS path whenever the kubeconfig demands TLS knobs that
+    // node fetch can't express: insecure-skip-tls-verify, a custom CA, or a
+    // mTLS cert/key pair. Fetch only suffices when none of these are set.
+    const hasClientCertPair = !!(kubeconfig?.clientCertificate && kubeconfig.clientKey);
+    const needsHttpsPath =
+      kubeconfig?.insecureSkipTlsVerify === true ||
+      !!kubeconfig?.certificateAuthority ||
+      hasClientCertPair;
+    if (needsHttpsPath) {
       return runK8sVersionHttpsRequest(
         `${targetApiServer}/version`,
         {
           headers,
-          cert: kubeconfig.clientCertificate,
-          key: kubeconfig.clientKey,
-          ca: kubeconfig.certificateAuthority,
+          ...(hasClientCertPair
+            ? { cert: kubeconfig!.clientCertificate, key: kubeconfig!.clientKey }
+            : {}),
+          ...(kubeconfig?.certificateAuthority ? { ca: kubeconfig.certificateAuthority } : {}),
+          ...(kubeconfig?.insecureSkipTlsVerify === true ? { insecureSkipTlsVerify: true } : {}),
         },
         connector.id,
       );
@@ -207,49 +241,124 @@ async function testKubernetesVersion(
 
 interface ParsedKubeconfig {
   server?: string;
+  insecureSkipTlsVerify?: boolean;
   certificateAuthority?: string;
   clientCertificate?: string;
   clientKey?: string;
   token?: string;
+  exec?: KubeconfigExecSpec;
 }
 
+/**
+ * Parse a kubeconfig YAML (or JSON) string. Honors `current-context` and
+ * resolves the matching `clusters[*].name` and `users[*].name` entries.
+ * Returns null if the input cannot be parsed or contains no recognizable
+ * fields.
+ */
 function parseKubeconfig(input: string): ParsedKubeconfig | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
-  try {
-    const cfg = JSON.parse(trimmed) as {
-      clusters?: Array<{ cluster?: Record<string, unknown> }>;
-      users?: Array<{ user?: Record<string, unknown> }>;
-    };
-    const cluster = cfg.clusters?.[0]?.cluster;
-    const user = cfg.users?.[0]?.user;
-    const out: ParsedKubeconfig = {};
-    if (typeof cluster?.['server'] === 'string') out.server = cluster['server'];
-    if (typeof cluster?.['certificate-authority-data'] === 'string') {
-      out.certificateAuthority = decodeBase64Pem(cluster['certificate-authority-data']);
-    }
-    if (typeof user?.['client-certificate-data'] === 'string') {
-      out.clientCertificate = decodeBase64Pem(user['client-certificate-data']);
-    }
-    if (typeof user?.['client-key-data'] === 'string') {
-      out.clientKey = decodeBase64Pem(user['client-key-data']);
-    }
-    if (typeof user?.['token'] === 'string') out.token = user['token'];
-    return Object.keys(out).length > 0 ? out : null;
-  } catch {
-    const out: ParsedKubeconfig = {};
-    const server = trimmed.match(/^\s*server:\s*([^\s#]+)/m)?.[1];
-    if (server) out.server = server.replace(/^["']|["']$/g, '');
-    const ca = trimmed.match(/^\s*certificate-authority-data:\s*([^\s#]+)/m)?.[1];
-    if (ca) out.certificateAuthority = decodeBase64Pem(ca.replace(/^["']|["']$/g, ''));
-    const cert = trimmed.match(/^\s*client-certificate-data:\s*([^\s#]+)/m)?.[1];
-    if (cert) out.clientCertificate = decodeBase64Pem(cert.replace(/^["']|["']$/g, ''));
-    const key = trimmed.match(/^\s*client-key-data:\s*([^\s#]+)/m)?.[1];
-    if (key) out.clientKey = decodeBase64Pem(key.replace(/^["']|["']$/g, ''));
-    const token = extractKubeconfigToken(trimmed);
-    if (token) out.token = token;
-    return Object.keys(out).length > 0 ? out : null;
+
+  // Raw token (single line, no kubeconfig markers) is a legacy convenience;
+  // upstream callers can pass it as the secret directly. We don't treat it
+  // as a kubeconfig — return null and let the caller fall back to
+  // extractKubeconfigToken.
+  if (!trimmed.includes('\n') && !trimmed.includes('apiVersion') && !trimmed.includes('clusters')) {
+    return null;
   }
+
+  type RawCluster = {
+    server?: unknown;
+    'certificate-authority-data'?: unknown;
+    'insecure-skip-tls-verify'?: unknown;
+  };
+  type RawExec = {
+    command?: unknown;
+    args?: unknown;
+    env?: unknown;
+    apiVersion?: unknown;
+  };
+  type RawUser = {
+    token?: unknown;
+    'client-certificate-data'?: unknown;
+    'client-key-data'?: unknown;
+    exec?: unknown;
+  };
+  type RawConfig = {
+    'current-context'?: unknown;
+    contexts?: Array<{ name?: unknown; context?: { cluster?: unknown; user?: unknown } }>;
+    clusters?: Array<{ name?: unknown; cluster?: RawCluster }>;
+    users?: Array<{ name?: unknown; user?: RawUser }>;
+  };
+
+  let cfg: RawConfig;
+  try {
+    cfg = parseYaml(trimmed) as RawConfig;
+  } catch {
+    return null;
+  }
+  if (!cfg || typeof cfg !== 'object') return null;
+
+  const currentContext = typeof cfg['current-context'] === 'string' ? cfg['current-context'] : null;
+  const contexts = Array.isArray(cfg.contexts) ? cfg.contexts : [];
+  const chosenContext = currentContext
+    ? contexts.find((c) => c?.name === currentContext)
+    : contexts[0];
+  const clusterName = typeof chosenContext?.context?.cluster === 'string'
+    ? chosenContext.context.cluster
+    : null;
+  const userName = typeof chosenContext?.context?.user === 'string'
+    ? chosenContext.context.user
+    : null;
+
+  const clusters = Array.isArray(cfg.clusters) ? cfg.clusters : [];
+  const users = Array.isArray(cfg.users) ? cfg.users : [];
+  const cluster = (clusterName ? clusters.find((c) => c?.name === clusterName) : clusters[0])?.cluster;
+  const user = (userName ? users.find((u) => u?.name === userName) : users[0])?.user;
+
+  const out: ParsedKubeconfig = {};
+  if (typeof cluster?.server === 'string') out.server = cluster.server;
+  if (typeof cluster?.['insecure-skip-tls-verify'] === 'boolean') {
+    out.insecureSkipTlsVerify = cluster['insecure-skip-tls-verify'];
+  }
+  if (typeof cluster?.['certificate-authority-data'] === 'string') {
+    out.certificateAuthority = decodeBase64Pem(cluster['certificate-authority-data']);
+  }
+  if (typeof user?.token === 'string') out.token = user.token;
+  if (typeof user?.['client-certificate-data'] === 'string') {
+    out.clientCertificate = decodeBase64Pem(user['client-certificate-data']);
+  }
+  if (typeof user?.['client-key-data'] === 'string') {
+    out.clientKey = decodeBase64Pem(user['client-key-data']);
+  }
+  const execSpec = parseExecSpec(user?.exec);
+  if (execSpec) out.exec = execSpec;
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function parseExecSpec(raw: unknown): KubeconfigExecSpec | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as { command?: unknown; args?: unknown; env?: unknown; apiVersion?: unknown };
+  if (typeof r.command !== 'string' || r.command.length === 0) return null;
+  const out: KubeconfigExecSpec = { command: r.command };
+  if (Array.isArray(r.args)) {
+    out.args = r.args.filter((v): v is string => typeof v === 'string');
+  }
+  if (Array.isArray(r.env)) {
+    const env: Array<{ name: string; value: string }> = [];
+    for (const e of r.env) {
+      if (e && typeof e === 'object') {
+        const obj = e as { name?: unknown; value?: unknown };
+        if (typeof obj.name === 'string' && typeof obj.value === 'string') {
+          env.push({ name: obj.name, value: obj.value });
+        }
+      }
+    }
+    if (env.length > 0) out.env = env;
+  }
+  if (typeof r.apiVersion === 'string') out.apiVersion = r.apiVersion;
+  return out;
 }
 
 function decodeBase64Pem(value: string): string {
@@ -258,7 +367,13 @@ function decodeBase64Pem(value: string): string {
 
 async function runK8sVersionHttpsRequest(
   url: string,
-  opts: { headers: Record<string, string>; ca?: string; cert: string; key: string },
+  opts: {
+    headers: Record<string, string>;
+    ca?: string;
+    cert?: string;
+    key?: string;
+    insecureSkipTlsVerify?: boolean;
+  },
   connectorId: string,
 ): Promise<ConnectorTestOutcome> {
   return new Promise((resolve) => {
@@ -267,9 +382,10 @@ async function runK8sVersionHttpsRequest(
       {
         method: 'GET',
         headers: opts.headers,
-        ca: opts.ca,
-        cert: opts.cert,
-        key: opts.key,
+        ...(opts.ca ? { ca: opts.ca } : {}),
+        ...(opts.cert ? { cert: opts.cert } : {}),
+        ...(opts.key ? { key: opts.key } : {}),
+        ...(opts.insecureSkipTlsVerify ? { rejectUnauthorized: false } : {}),
         timeout: DEFAULT_TIMEOUT_MS,
       },
       (res) => {

--- a/packages/api-gateway/src/services/dashboard-service.ts
+++ b/packages/api-gateway/src/services/dashboard-service.ts
@@ -2,6 +2,7 @@ import type { Connector } from '@agentic-obs/common';
 import { AdapterRegistry } from '@agentic-obs/agent-core';
 import { PrometheusMetricsAdapter, LokiLogsAdapter } from '@agentic-obs/adapters';
 import type { IChangesAdapter } from '@agentic-obs/adapters';
+import { normalizePrometheusBaseUrl } from '../utils/prometheus-url.js';
 
 /**
  * Convert Connector[] to the narrower prompt config shape
@@ -42,7 +43,7 @@ export function resolvePrometheusConnector(connectors: Connector[]): PrometheusC
   const prom = promConnectors.find((c) => c.isDefault) ?? promConnectors[0];
   if (!prom) return undefined;
 
-  return { url: configString(prom, 'url') ?? '', headers: connectorHeaders(prom) };
+  return { url: normalizePrometheusBaseUrl(configString(prom, 'url') ?? ''), headers: connectorHeaders(prom) };
 }
 
 function configString(connector: Connector, key: string): string | undefined {
@@ -88,9 +89,10 @@ export function buildAdapterRegistry(
     const url = configString(connector, 'url') ?? '';
     const headers = connectorHeaders(connector);
     if (connector.type === 'prometheus' || connector.type === 'victoria-metrics') {
+      const base = normalizePrometheusBaseUrl(url);
       registry.register({
-        info: { id: connector.id, name: connector.name, type: connector.type, url, signalType: 'metrics', isDefault: connector.isDefault },
-        metrics: new PrometheusMetricsAdapter(url, headers),
+        info: { id: connector.id, name: connector.name, type: connector.type, url: base, signalType: 'metrics', isDefault: connector.isDefault },
+        metrics: new PrometheusMetricsAdapter(base, headers),
       });
     } else if (connector.type === 'loki') {
       registry.register({

--- a/packages/api-gateway/src/services/kubeconfig-exec.ts
+++ b/packages/api-gateway/src/services/kubeconfig-exec.ts
@@ -1,0 +1,345 @@
+/**
+ * Kubeconfig `user.exec` credential plugin runner.
+ *
+ * SECURITY: connector configs (including kubeconfigs) can be user-provided,
+ * and this code runs on the api-gateway host. A naive `exec` of whatever the
+ * kubeconfig says is a remote code execution vulnerability.
+ *
+ * Defense in depth applied here:
+ *   1. Feature-gated: disabled unless `KUBECONFIG_EXEC_PLUGIN=1` is set on
+ *      the api-gateway process environment.
+ *   2. Strict allowlist: only `kubectl oidc-login get-token ...` is permitted.
+ *      No other binary, no other subcommand.
+ *   3. `execFile` (no shell): the command and args are passed as an argv array
+ *      to the OS, so shell metacharacters in args cannot trigger interpretation.
+ *   4. Env scrubbing: the child process gets PATH + HOME from the parent ONLY,
+ *      plus whatever the kubeconfig `user.exec.env` block declares (which is
+ *      itself part of the connector secret — same trust boundary as the rest
+ *      of the kubeconfig).
+ *   5. Timeout + maxBuffer: kills runaways and prevents stdout-bomb DoS.
+ *   6. In-process token cache: tokens are cached until 30s before their
+ *      `status.expirationTimestamp`, then refreshed. Bounds the exec rate.
+ *   7. Audit log: connector id, command, duration, ok — NEVER the token,
+ *      NEVER full stderr (which oidc-login may print user identifiers into).
+ */
+
+import { execFile } from 'node:child_process';
+import { createLogger } from '@agentic-obs/server-utils/logging';
+
+const log = createLogger('kubeconfig-exec');
+
+// --- Tunable safety defaults (top of file for easy review) -----------------
+
+/** Env var that must be set to '1' on the api-gateway to enable exec at all. */
+const EXEC_ENABLED_ENV = 'KUBECONFIG_EXEC_PLUGIN';
+
+/** Only this command is allowed. No path, must be a bare name resolved via PATH. */
+const ALLOWED_COMMAND = 'kubectl';
+
+/** The first two args must match exactly. Further args (issuer URL, client-id) pass through. */
+const REQUIRED_LEADING_ARGS: ReadonlyArray<string> = ['oidc-login', 'get-token'];
+
+/** Hard ceiling on exec duration. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Hard ceiling on combined stdout+stderr bytes. */
+const DEFAULT_MAX_BUFFER = 1 * 1024 * 1024;
+
+/** Refresh the cached token this many ms before its declared expiry. */
+const EXPIRY_SAFETY_MARGIN_MS = 30_000;
+
+/** Parent-process env vars passed through to the child. */
+const PARENT_ENV_ALLOWLIST: ReadonlyArray<string> = ['PATH', 'HOME'];
+
+/**
+ * Env names that are NEVER set on the child, regardless of source. Loader
+ * hijack vectors (LD_ and DYLD_ prefixes) and Node's NODE_OPTIONS (arbitrary --require).
+ * Case-sensitive on POSIX, which is what we target.
+ */
+const ENV_DENYLIST: ReadonlySet<string> = new Set([
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'LD_AUDIT',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'DYLD_FRAMEWORK_PATH',
+  'NODE_OPTIONS',
+]);
+
+/** Hard cap on total argv length (command + args). */
+const MAX_ARGS = 20;
+
+/** Hard cap on per-arg byte length. */
+const MAX_ARG_BYTES = 1024;
+
+/**
+ * Allowlist of arg shapes accepted beyond the two mandatory leading args.
+ *
+ * `prefix` entries match `arg.startsWith(prefix)` (value not validated).
+ * `exact` entries require an exact bare match (for boolean flags).
+ */
+const EXTRA_ARG_PREFIXES: ReadonlyArray<string> = [
+  '--issuer-url=',
+  '--client-id=',
+  '--client-secret=',
+  '--extra-scope=',
+  '--listen-address=',
+  '--username=',
+  '--password=',
+  '--token-cache-dir=',
+  '--certificate-authority=',
+  '--certificate-authority-data=',
+  '--v=',
+];
+
+const EXTRA_ARG_EXACT: ReadonlySet<string> = new Set([
+  '--skip-open-browser',
+  '--insecure-skip-tls-verify',
+  '-v',
+]);
+
+/** User-facing error when exec is gated off. */
+export const EXEC_DISABLED_MESSAGE =
+  'Kubeconfig exec auth requires KUBECONFIG_EXEC_PLUGIN=1 on the api-gateway.';
+
+// --- Types ----------------------------------------------------------------
+
+export interface KubeconfigExecSpec {
+  command: string;
+  args?: string[];
+  env?: Array<{ name: string; value: string }>;
+  apiVersion?: string;
+}
+
+export interface ResolveExecCredentialOpts {
+  connectorId: string;
+  timeoutMs?: number;
+  maxBuffer?: number;
+}
+
+export interface ResolvedExecCredential {
+  token: string;
+  expiresAt: Date | null;
+}
+
+interface ExecCredentialResponse {
+  apiVersion?: string;
+  kind?: string;
+  status?: {
+    token?: string;
+    expirationTimestamp?: string;
+  };
+}
+
+// --- Cache ----------------------------------------------------------------
+
+interface CacheEntry {
+  token: string;
+  expiresAt: Date | null;
+}
+
+const tokenCache = new Map<string, CacheEntry>();
+
+function cacheKey(spec: KubeconfigExecSpec, connectorId: string): string {
+  // Include only fields that affect the child invocation. Env order matters
+  // semantically (last write wins) so preserve declared order. connectorId
+  // is included so two connectors with identical exec specs get isolated
+  // cache entries (and audit logs can distinguish refreshes per connector).
+  return JSON.stringify({
+    connectorId,
+    command: spec.command,
+    args: spec.args ?? [],
+    env: (spec.env ?? []).map((e) => [e.name, e.value]),
+  });
+}
+
+/** Soft cap on cache size; evict insertion-oldest when exceeded. */
+const TOKEN_CACHE_MAX = 128;
+
+function isFresh(entry: CacheEntry, now: number): boolean {
+  if (!entry.expiresAt) return false; // No expiry declared → don't trust cache
+  return entry.expiresAt.getTime() - now > EXPIRY_SAFETY_MARGIN_MS;
+}
+
+// --- Public API -----------------------------------------------------------
+
+export function isExecPluginEnabled(): boolean {
+  return process.env[EXEC_ENABLED_ENV] === '1';
+}
+
+export async function resolveExecCredential(
+  spec: KubeconfigExecSpec,
+  opts: ResolveExecCredentialOpts,
+): Promise<ResolvedExecCredential> {
+  if (!isExecPluginEnabled()) {
+    throw new Error(EXEC_DISABLED_MESSAGE);
+  }
+
+  // Allowlist gate. Command must be the bare allowed name; args[0..1] must
+  // match required leading args exactly.
+  if (spec.command !== ALLOWED_COMMAND) {
+    throw new Error(
+      `Kubeconfig exec command "${spec.command}" is not allowed. Only "${ALLOWED_COMMAND}" is permitted.`,
+    );
+  }
+  const args = spec.args ?? [];
+  for (let i = 0; i < REQUIRED_LEADING_ARGS.length; i++) {
+    if (args[i] !== REQUIRED_LEADING_ARGS[i]) {
+      throw new Error(
+        `Kubeconfig exec args must begin with "${REQUIRED_LEADING_ARGS.join(' ')}". Got: "${args.slice(0, REQUIRED_LEADING_ARGS.length).join(' ')}".`,
+      );
+    }
+  }
+  if (args.length > MAX_ARGS) {
+    throw new Error(`Kubeconfig exec args exceed maximum count of ${MAX_ARGS}.`);
+  }
+  for (let i = REQUIRED_LEADING_ARGS.length; i < args.length; i++) {
+    const a = args[i]!;
+    if (Buffer.byteLength(a, 'utf8') > MAX_ARG_BYTES) {
+      throw new Error(`Kubeconfig exec arg #${i} exceeds ${MAX_ARG_BYTES} bytes.`);
+    }
+    if (EXTRA_ARG_EXACT.has(a)) continue;
+    if (EXTRA_ARG_PREFIXES.some((p) => a.startsWith(p))) continue;
+    throw new Error(`Kubeconfig exec arg "${a}" is not in the allowlist.`);
+  }
+
+  const key = cacheKey(spec, opts.connectorId);
+  const cached = tokenCache.get(key);
+  const now = Date.now();
+  if (cached && isFresh(cached, now)) {
+    return { token: cached.token, expiresAt: cached.expiresAt };
+  }
+
+  // Env composition order (host always wins for PATH/HOME):
+  //   1. Start empty — never inherit parent env wholesale.
+  //   2. Layer kubeconfig user.exec.env entries FIRST.
+  //   3. Layer parent allowlist LAST so the host's PATH/HOME override any
+  //      attempt to redirect the loader/PATH via the kubeconfig.
+  // Denylist (loader hijack, NODE_OPTIONS) is enforced regardless of source.
+  const filteredEnv: Record<string, string> = {};
+  for (const e of spec.env ?? []) {
+    if (typeof e?.name === 'string' && typeof e?.value === 'string') {
+      if (ENV_DENYLIST.has(e.name)) continue;
+      filteredEnv[e.name] = e.value;
+    }
+  }
+  for (const name of PARENT_ENV_ALLOWLIST) {
+    if (ENV_DENYLIST.has(name)) continue;
+    const v = process.env[name];
+    if (typeof v === 'string') filteredEnv[name] = v;
+  }
+
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const started = Date.now();
+
+  const stdout = await new Promise<string>((resolve, reject) => {
+    execFile(
+      spec.command,
+      args,
+      {
+        timeout,
+        maxBuffer,
+        env: filteredEnv,
+        // Explicit: no shell. (execFile defaults to no shell, but the
+        // intent matters for review.)
+        shell: false,
+        windowsHide: true,
+      },
+      (err, sout) => {
+        if (err) {
+          // Surface a generic class of failure to the caller without leaking
+          // stderr (oidc-login can print user emails / claims into it).
+          const code = (err as NodeJS.ErrnoException).code;
+          // Node signals an execFile timeout by SIGTERM-killing the child;
+          // ETIMEDOUT here would be a network/IO code (which execFile doesn't
+          // actually emit for the timeout path). Use the killed/signal pair.
+          const e = err as Error & { killed?: boolean; signal?: NodeJS.Signals };
+          if (e.killed === true || e.signal === 'SIGTERM') {
+            reject(new Error(`kubeconfig exec timed out after ${timeout}ms`));
+          } else if (code === 'ENOENT') {
+            reject(new Error(`exec credential plugin "${spec.command}" not found on PATH`));
+          } else {
+            reject(new Error(`exec credential plugin failed (${code ?? 'error'})`));
+          }
+          return;
+        }
+        resolve(sout);
+      },
+    );
+  }).catch((err) => {
+    log.warn(
+      {
+        connectorId: opts.connectorId,
+        command: spec.command,
+        durationMs: Date.now() - started,
+        ok: false,
+      },
+      'kubeconfig exec credential failed',
+    );
+    throw err;
+  });
+
+  let parsed: ExecCredentialResponse;
+  try {
+    parsed = JSON.parse(stdout) as ExecCredentialResponse;
+  } catch {
+    log.warn(
+      { connectorId: opts.connectorId, command: spec.command, durationMs: Date.now() - started, ok: false },
+      'kubeconfig exec credential returned non-JSON',
+    );
+    throw new Error('exec credential plugin did not return valid JSON');
+  }
+
+  if (
+    parsed.kind !== 'ExecCredential' ||
+    typeof parsed.apiVersion !== 'string' ||
+    !parsed.apiVersion.startsWith('client.authentication.k8s.io/')
+  ) {
+    log.warn(
+      { connectorId: opts.connectorId, command: spec.command, durationMs: Date.now() - started, ok: false },
+      'kubeconfig exec credential returned wrong shape',
+    );
+    throw new Error('exec credential plugin returned an unexpected response shape');
+  }
+
+  const token = parsed.status?.token;
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error('exec credential plugin returned no token');
+  }
+
+  let expiresAt: Date | null = null;
+  const expStr = parsed.status?.expirationTimestamp;
+  if (typeof expStr === 'string') {
+    const t = Date.parse(expStr);
+    if (Number.isFinite(t)) expiresAt = new Date(t);
+  }
+
+  // Never cache without a declared expiry — an unbounded entry would never
+  // refresh and the token would silently outlive its real validity.
+  if (expiresAt) {
+    if (tokenCache.size >= TOKEN_CACHE_MAX) {
+      // Map preserves insertion order — drop the oldest entry.
+      const oldest = tokenCache.keys().next().value;
+      if (oldest !== undefined) tokenCache.delete(oldest);
+    }
+    tokenCache.set(key, { token, expiresAt });
+  }
+
+  log.info(
+    {
+      connectorId: opts.connectorId,
+      command: spec.command,
+      durationMs: Date.now() - started,
+      ok: true,
+    },
+    'kubeconfig exec credential refreshed',
+  );
+
+  return { token, expiresAt };
+}
+
+/** Test-only: clear the in-process cache. */
+export function __clearExecCredentialCache(): void {
+  tokenCache.clear();
+}

--- a/packages/api-gateway/src/services/ops-command-runner.ts
+++ b/packages/api-gateway/src/services/ops-command-runner.ts
@@ -21,6 +21,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { parse as parseYaml } from 'yaml';
 import { createLogger } from '@agentic-obs/server-utils/logging';
 import { ClusterShellExecutionAdapter, ShellExecutionAdapter } from '@agentic-obs/adapters';
 import type {
@@ -123,6 +124,42 @@ export interface OpsRunResult {
   success?: boolean;
   confirmationRequired?: boolean;
   confirmation?: OpsCommandConfirmation;
+}
+
+/**
+ * Env var name that gates the kubeconfig `user.exec` credential plugin path.
+ * Mirrors `EXEC_ENABLED_ENV` in kubeconfig-exec.ts — duplicated here to keep
+ * this gate-check independent of that module's import surface.
+ */
+const KUBECONFIG_EXEC_ENV = 'KUBECONFIG_EXEC_PLUGIN';
+
+/**
+ * Refuse to hand a kubeconfig with `user.exec` to kubectl unless the api-gateway
+ * operator has explicitly opted into the exec plugin. We don't strip the field —
+ * mutating user credentials silently could break their intent and would hide
+ * the misconfiguration. Reject loudly so the operator sees it.
+ */
+function assertNoUnauthorizedExec(kubeconfigYaml: string): void {
+  if (process.env[KUBECONFIG_EXEC_ENV] === '1') return;
+  let cfg: unknown;
+  try {
+    cfg = parseYaml(kubeconfigYaml);
+  } catch {
+    return; // Malformed YAML — let kubectl produce the user-facing error.
+  }
+  if (!cfg || typeof cfg !== 'object') return;
+  const users = (cfg as { users?: unknown }).users;
+  if (!Array.isArray(users)) return;
+  for (const entry of users) {
+    if (entry && typeof entry === 'object') {
+      const user = (entry as { user?: unknown }).user;
+      if (user && typeof user === 'object' && 'exec' in user && (user as { exec?: unknown }).exec) {
+        throw new Error(
+          'Kubeconfig with user.exec auth requires KUBECONFIG_EXEC_PLUGIN=1 on the api-gateway.',
+        );
+      }
+    }
+  }
 }
 
 const PENDING_CONFIRMATIONS = new Map<string, OpsCommandConfirmation>();
@@ -608,6 +645,15 @@ export class KubectlOpsCommandRunner implements OpsCommandRunner {
   }
 
   private async resolveKubeconfig(connector: Connector): Promise<string> {
+    const yaml = await this.loadKubeconfigYaml(connector);
+    // Gate-bypass defense: if the kubeconfig contains user.exec, the
+    // operator must have explicitly enabled the plugin. We never run kubectl
+    // with an exec-bearing kubeconfig unless the host env opts in.
+    assertNoUnauthorizedExec(yaml);
+    return yaml;
+  }
+
+  private async loadKubeconfigYaml(connector: Connector): Promise<string> {
     const inline = connector.config['kubeconfig'];
     if (typeof inline === 'string' && inline) return inline;
     const secretRef = connector.config['secretRef'];

--- a/packages/api-gateway/src/utils/connector-secrets.ts
+++ b/packages/api-gateway/src/utils/connector-secrets.ts
@@ -1,0 +1,58 @@
+import type { Connector } from '@agentic-obs/common';
+
+/**
+ * Subset of `IConnectorRepository` used for secret resolution. Kept narrow so
+ * callers can pass a full repo or any object that exposes `getSecret`.
+ */
+export interface ConnectorSecretReader {
+  getSecret(connectorId: string): Promise<{ ciphertext: Uint8Array } | null>;
+}
+
+function inlineApiKey(connector: Connector): string | undefined {
+  const value = connector.config['apiKey'];
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Connector types whose stored ciphertext is a bearer-style API token that
+ * belongs in `config.apiKey`. Other types (e.g. `kubernetes`, where the
+ * ciphertext is a kubeconfig YAML) resolve their secret through their own
+ * runner and must NOT be hydrated here.
+ */
+const TOKEN_AUTH_TYPES = new Set(['prometheus', 'victoria-metrics', 'loki']);
+
+/**
+ * Resolve `connector_secrets` ciphertext into `config.apiKey` for connectors
+ * that don't already carry an inline credential. Returns new Connector objects
+ * (original `connector.config` is not mutated). Connectors with no stored
+ * secret pass through unchanged.
+ *
+ * Decrypted tokens MUST NOT be forwarded into LLM prompts or audit payloads.
+ * The orchestrator's `toAgentConnectors` strips credential fields — keep that
+ * boundary intact when adding new call sites.
+ */
+export async function hydrateConnectorSecrets(
+  connectors: Connector[],
+  secretReader: ConnectorSecretReader,
+): Promise<Connector[]> {
+  return Promise.all(
+    connectors.map(async (connector) => {
+      if (!TOKEN_AUTH_TYPES.has(connector.type)) return connector;
+      if (inlineApiKey(connector)) return connector;
+
+      const row = await secretReader.getSecret(connector.id);
+      if (!row?.ciphertext || row.ciphertext.length === 0) return connector;
+
+      const token = Buffer.from(row.ciphertext).toString('utf8').trim();
+      if (!token) return connector;
+
+      return {
+        ...connector,
+        config: {
+          ...connector.config,
+          apiKey: token,
+        },
+      };
+    }),
+  );
+}

--- a/packages/api-gateway/src/utils/datasource.ts
+++ b/packages/api-gateway/src/utils/datasource.ts
@@ -1,4 +1,5 @@
 import { ensureSafeUrl } from './url-validator.js';
+import { normalizePrometheusBaseUrl } from './prometheus-url.js';
 
 /**
  * Shape required for a connectivity probe. Intentionally narrower than
@@ -31,9 +32,11 @@ export async function testDatasourceConnection(
     let testUrl: string;
     switch (ds.type) {
       case 'prometheus':
-      case 'victoria-metrics':
-        testUrl = `${ds.url.replace(/\/$/, '')}/api/v1/status/buildinfo`;
+      case 'victoria-metrics': {
+        const base = normalizePrometheusBaseUrl(ds.url);
+        testUrl = `${base}/api/v1/query?query=${encodeURIComponent('vector(1)')}`;
         break;
+      }
       case 'loki':
         testUrl = `${ds.url.replace(/\/$/, '')}/ready`;
         break;

--- a/packages/api-gateway/src/utils/prometheus-url.ts
+++ b/packages/api-gateway/src/utils/prometheus-url.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalize a Prometheus-compatible base URL.
+ *
+ * Trims whitespace, strips trailing slashes, and removes a trailing `/api/v1`
+ * so users pasting either the API root, an AMP workspace URL, or a Grafana
+ * datasource proxy URL all converge on the same base. Idempotent under
+ * repeated `/api/v1` suffixes.
+ */
+export function normalizePrometheusBaseUrl(url: string): string {
+  let out = url.trim().replace(/\/+$/, '');
+  while (out.endsWith('/api/v1')) out = out.slice(0, -'/api/v1'.length);
+  return out;
+}

--- a/packages/common/src/models/connector-template.ts
+++ b/packages/common/src/models/connector-template.ts
@@ -171,7 +171,7 @@ export const PROMETHEUS_TEMPLATE: ConnectorTemplate = {
       'http://kube-prometheus-stack-prometheus.monitoring.svc:9090',
     ],
   },
-  verify: { kind: 'http-get', path: '/api/v1/status/buildinfo' },
+  verify: { kind: 'http-get', path: '/api/v1/query?query=vector(1)' },
 };
 
 export const VICTORIA_METRICS_TEMPLATE: ConnectorTemplate = {
@@ -180,7 +180,7 @@ export const VICTORIA_METRICS_TEMPLATE: ConnectorTemplate = {
   capabilities: ['metrics.discover', 'metrics.query', 'metrics.validate'],
   configSchema: httpUrlSchema,
   credential: 'token',
-  verify: { kind: 'http-get', path: '/api/v1/status/buildinfo' },
+  verify: { kind: 'http-get', path: '/api/v1/query?query=vector(1)' },
 };
 
 export const LOKI_TEMPLATE: ConnectorTemplate = {

--- a/packages/llm-gateway/src/providers/anthropic.ts
+++ b/packages/llm-gateway/src/providers/anthropic.ts
@@ -216,6 +216,7 @@ export class AnthropicProvider implements LLMProvider {
   private readonly cacheControl: boolean;
   private readonly apiVersion: string;
   private readonly endpointFlavor: AnthropicEndpointFlavor;
+  private readonly apiType: 'api-key' | 'bearer';
 
   constructor(private readonly config: AnthropicConfig) {
     this.resolveKey = buildApiKeyResolver({
@@ -226,6 +227,16 @@ export class AnthropicProvider implements LLMProvider {
     this.cacheControl = config.cacheControl ?? false;
     this.apiVersion = config.apiVersion ?? DEFAULT_API_VERSION;
     this.endpointFlavor = config.endpointFlavor ?? 'native';
+    this.apiType = config.apiType ?? 'api-key';
+  }
+
+  private applyAuthHeader(headers: Record<string, string>, apiKey: string): void {
+    if (!apiKey) return;
+    if (this.apiType === 'bearer') {
+      headers.Authorization = `Bearer ${apiKey}`;
+      return;
+    }
+    headers['x-api-key'] = apiKey;
   }
 
   async complete(messages: CompletionMessage[], options: LLMOptions): Promise<LLMResponse> {
@@ -329,9 +340,7 @@ export class AnthropicProvider implements LLMProvider {
       'Content-Type': 'application/json',
       'anthropic-version': this.apiVersion,
     };
-    if (apiKey) {
-      headers['x-api-key'] = apiKey;
-    }
+    this.applyAuthHeader(headers, apiKey);
 
     const fetchInit = {
       method: 'POST',
@@ -413,7 +422,7 @@ export class AnthropicProvider implements LLMProvider {
     try {
       const apiKey = await this.resolveKey();
       const headers: Record<string, string> = { 'anthropic-version': this.apiVersion };
-      if (apiKey) headers['x-api-key'] = apiKey;
+      this.applyAuthHeader(headers, apiKey);
       response = await fetch(`${this.baseUrl}/v1/models`, { headers });
     } catch (err) {
       const kind = classifyProviderHttpError({ cause: err });

--- a/packages/web/src/components/chat/AgentActivityBlock.tsx
+++ b/packages/web/src/components/chat/AgentActivityBlock.tsx
@@ -218,7 +218,10 @@ export default function AgentActivityBlock({
 
   // Summary for collapsed state — phase-grouped (steps), so 5 metrics_query
   // events still summarize as one "Querying metrics" phase rather than 5.
-  const doneCount = steps.filter((s) => s.done).length;
+  // Count by steps.length rather than done-only: some activity (e.g. an
+  // ops command confirmation block) shows up as a step without a paired
+  // tool_call/tool_result, so done-only undercounts to "0 steps" despite
+  // visible activity.
   const failCount = steps.filter((s) => s.result && !s.result.success).length;
   const lastActive = [...steps].reverse().find((s) => !s.done);
 
@@ -234,7 +237,7 @@ export default function AgentActivityBlock({
         : 'Working'
     : onlyThinking
       ? 'Thinking'
-      : `${doneCount} step${doneCount === 1 ? '' : 's'}${failCount > 0 ? ` (${failCount} failed)` : ''}`;
+      : `${steps.length} step${steps.length === 1 ? '' : 's'}${failCount > 0 ? ` (${failCount} failed)` : ''}`;
 
   return (
     <div className="my-2">

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -353,6 +353,12 @@ export function useChat(): UseChatResult {
   // no longer cancels on client-disconnect, the local abort alone wouldn't
   // actually stop the agent.
   const runIdRef = useRef<string | null>(null);
+  // True while the POST /chat stream is active. The chat-service emits the
+  // same events on both the in-request stream AND the live bus, so if a
+  // bus subscription is also open during the POST we'd double-render every
+  // event. While this flag is set, the subscription path drops everything
+  // except `idle` (which is harmless control signalling).
+  const postStreamActiveRef = useRef(false);
   // Session id source of truth: the URL (`?chat=<id>`) for deeplinks plus the
   // Recents list on Home for picking a prior conversation. There used to be a
   // `localStorage.chat_session_id` mirror here so a new tab would auto-resume
@@ -414,6 +420,16 @@ export function useChat(): UseChatResult {
           : eventType;
 
       const id = crypto.randomUUID();
+
+      // Terminal `idle` from the live-tail bus — the orchestrator finished
+      // and the session is no longer generating. Always clear the spinner,
+      // even if this is the only terminator we see (e.g. a session reopened
+      // after `done` was already persisted, then the subscription replays
+      // tail events and the next bus signal is `idle`).
+      if (resolvedType === 'idle') {
+        setIsGenerating(false);
+        return;
+      }
 
       switch (resolvedType) {
         // Backend-emitted at the start of every detached agent run (Phase 1).
@@ -683,8 +699,12 @@ export function useChat(): UseChatResult {
               maxSeqRef.current = seq;
             }
           }
-          // Skip control events that aren't real chat events.
-          if (eventType === 'idle') return;
+          // While the POST /chat stream is active, the in-request callback
+          // already delivers every event we care about — the bus mirror
+          // would double-render. Drop everything except `idle`, which is a
+          // useful safety terminator (clears the spinner if `done` is
+          // somehow missed).
+          if (postStreamActiveRef.current && eventType !== 'idle') return;
           handleSSEEvent(eventType, rawData);
         },
         controller.signal,
@@ -727,6 +747,7 @@ export function useChat(): UseChatResult {
       appendEvent({ id: userMsg.id, kind: 'message', message: userMsg });
       setIsGenerating(true);
 
+      postStreamActiveRef.current = true;
       try {
         // Always inject the browser's local timezone so the agent can map
         // any clock time the user mentions ("9:59" off the panel's x-axis)
@@ -764,6 +785,7 @@ export function useChat(): UseChatResult {
           });
         }
       } finally {
+        postStreamActiveRef.current = false;
         setIsGenerating(false);
       }
     },

--- a/packages/web/src/pages/connector-config-form.tsx
+++ b/packages/web/src/pages/connector-config-form.tsx
@@ -40,7 +40,7 @@ const URI_PLACEHOLDERS: Partial<Record<ConnectorType, Partial<Record<string, str
   kubernetes: {
     apiServer: 'https://kubernetes.default.svc — leave blank to use in-cluster',
   },
-  prometheus: { url: 'http://prometheus.monitoring.svc:9090' },
+  prometheus: { url: 'http://prometheus.monitoring.svc:9090 or Grafana/AMP proxy URL' },
   loki: { url: 'http://loki.monitoring.svc:3100' },
   'victoria-metrics': { url: 'http://victoria-metrics.monitoring.svc:8428' },
   elasticsearch: { url: 'http://elasticsearch.monitoring.svc:9200' },
@@ -58,6 +58,17 @@ function placeholderFor(
   if (prop.description) return prop.description;
   if (prop.format === 'uri') return URI_PLACEHOLDERS[type]?.[key] ?? '';
   return '';
+}
+
+// Persistent helper text shown under a field (placeholders disappear on focus).
+const FIELD_HELP: Partial<Record<ConnectorType, Partial<Record<string, string>>>> = {
+  prometheus: {
+    url: 'API root or proxy URL that forwards /api/v1/query. Works with self-hosted Prometheus, AMP, and Grafana datasource proxies.',
+  },
+};
+
+function helpFor(type: ConnectorType, key: string): string | null {
+  return FIELD_HELP[type]?.[key] ?? null;
 }
 
 // Schema-driven default values. Used on type switch — keys that have a
@@ -175,6 +186,7 @@ export function ConnectorConfigFields({
         const inputType = prop.format === 'uri' ? 'url' : 'text';
         const v = config[key];
         const value = typeof v === 'string' ? v : '';
+        const help = helpFor(type, key);
         return (
           <div key={key}>
             <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">
@@ -190,6 +202,9 @@ export function ConnectorConfigFields({
               required={required}
               aria-label={label}
             />
+            {help && (
+              <p className="text-xs text-[var(--color-on-surface-variant)] mt-1">{help}</p>
+            )}
           </div>
         );
       })}

--- a/packages/web/src/pages/setup/StepLlm.tsx
+++ b/packages/web/src/pages/setup/StepLlm.tsx
@@ -195,6 +195,26 @@ export function StepLlm({
           </div>
         )}
 
+        {config.provider === 'corporate-gateway' && (
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">Auth Type</label>
+            <select
+              value={config.authType ?? 'bearer'}
+              onChange={(e) => {
+                onChange({ authType: e.target.value as LlmConfig['authType'] });
+                setTestResult(null);
+              }}
+              className="w-full px-3 py-2 rounded-lg border border-[var(--color-outline-variant)] bg-[var(--color-surface-high)] text-[var(--color-on-surface)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 focus:border-[var(--color-primary)]"
+            >
+              <option value="bearer">Bearer Token (Authorization header)</option>
+              <option value="api-key">API Key (x-api-key header)</option>
+            </select>
+            <p className="text-xs text-[var(--color-on-surface-variant)] mt-1">
+              How the gateway expects the credential. Most enterprise gateways (LiteLLM, Kong, Apigee, Okta-fronted) use Bearer.
+            </p>
+          </div>
+        )}
+
         {provider.needsKey && (
           <div>
             <label className="block text-sm font-medium text-[var(--color-on-surface)] mb-1.5">API Key (optional if upstream auth is used)</label>


### PR DESCRIPTION
## Summary

A patch set covering seven independent fixes across the LLM gateway, connector secret/URL handling, chat reliability, agent tooling, and Kubernetes auth. Each item went through an architect + PM review pass; details and known follow-ups are in the commit message.

## Changes

1. **Corporate Gateway Bearer Auth** — `AnthropicProvider` gains `apiType: 'api-key' | 'bearer'`; setup wizard adds an Auth Type select for the `corporate-gateway` provider. Legacy rows without `authType` default to Bearer so existing installs auto-fix on restart.
2. **Prometheus / AMP probe + URL normalization** — new `utils/prometheus-url.ts` (`normalizePrometheusBaseUrl`, idempotent). Probe path moved from `/api/v1/status/buildinfo` to `/api/v1/query?query=vector(1)` so AMP / Grafana proxy URLs validate. Probe failures return a Prometheus-specific message; form shows persistent URL help.
3. **Connector secret hydration** — new `utils/connector-secrets.ts` hydrates token-auth connectors (`prometheus`, `victoria-metrics`, `loki`) from `connector_secrets` into `config.apiKey` at adapter-construction time. Wired into chat, agent-factory, dashboard query, metrics query, alert rule service. `toAgentConnectors` still feeds prompts with the credential-free original array. Includes a `maskForWire` fix so `GET /connectors` no longer echoes inline `apiKey`.
4. **Chat `done` event / stuck spinner** — `done` events now persist; `handleMessage` emits a single `done` via `wrappedSendEvent` before returning; the route-level fallback is removed. Frontend handles `idle`, uses `postStreamActiveRef` to drop mirrored bus events during the POST stream. Catch block in `handleMessage` publishes a terminal `error` to the bus so live-tail subscribers in other tabs don't sit on a stuck spinner.
5. **`dashboard_add_panels` explicit `dashboardId`** — handler accepts optional `args.dashboardId` (precedence over `ctx.activeDashboardId`; explicit calls sticky-update ctx). Schema, permissions, and orchestrator prompt updated together. Prompt narrowed so the model only attempts `dashboardId` on `dashboard_add_panels`.
6. **Kubernetes kubeconfig OIDC exec plugin (gated)** — new `services/kubeconfig-exec.ts` runs `kubectl oidc-login get-token` behind `KUBECONFIG_EXEC_PLUGIN=1`. Allowlisted command + arg prefixes, arg count + per-arg byte caps, `execFile` (no shell), 10s timeout, 1 MiB stdout cap. Child env starts empty, layers kubeconfig `exec.env` first then `PARENT_ENV_ALLOWLIST` (PATH, HOME); denylist for `LD_PRELOAD`/`LD_LIBRARY_PATH`/`DYLD_*`/`NODE_OPTIONS` regardless of source. Token cache keyed by `connectorId`, capped at 128, evicts oldest, never caches without `expirationTimestamp`. YAML parsing replaced with the `yaml` package and now honors `current-context`, `certificate-authority-data`, `client-cert/key-data`, and `insecure-skip-tls-verify`. HTTPS path used when CA OR cert+key OR insecure-skip-tls-verify is set. `ops-command-runner` asserts no unauthorized `user.exec` before handing the kubeconfig to `kubectl`, closing the bypass.
7. **`AgentActivityBlock` 0 steps** — collapsed summary uses `steps.length`, not `doneCount`, so ops confirmation flows that haven't completed yet no longer summarize as "0 steps".

## Test plan

- [x] `npm run typecheck` (tsc --build) — clean across common, adapters, agent-core, llm-gateway, api-gateway, web
- [x] `npm test` — connector-test (11/11), dashboard/query (5/5), metrics-query (5/5), chat-service (4/4), agent-core handlers (197/197) — all passing
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Manual smoke test — recommended scenarios:
  - Corporate Gateway → Anthropic format → Bearer; verify `/setup-llm` test succeeds
  - Prometheus connector with `/api/v1` suffix pasted by user; verify no `/api/v1/api/v1`
  - Token-auth Prometheus stored only in `connector_secrets`; verify dashboard panels load with Bearer
  - Reopen a completed chat session; spinner should NOT show
  - Chat error mid-turn in tab A while tab B is subscribed; verify tab B's spinner clears via the bus `error` event
  - `dashboard_add_panels` with explicit `dashboardId` resolved via `dashboard_list` while on a different dashboard page
  - K8s kubeconfig with `user.exec` and `KUBECONFIG_EXEC_PLUGIN` unset → clear disabled-gate error; with the env var set → token resolves and probe succeeds
- [ ] Added/updated tests for the new behavior — limited; existing tests cover most surfaces (Prometheus probe URL assertion updated; connector redaction tests added). Spec-listed new tests for `normalizePrometheusBaseUrl`, hydration, k8s exec, chat `done` persistence are deferred to follow-up.

## Known follow-ups (out of scope)

- `connector_secrets.ciphertext` is currently utf8-encoded plaintext; needs envelope encryption.
- Five sibling `dashboard.*` tools (`remove_panels`, `modify_panel`, `set_title`, `add_variable`, `rearrange`) still target only the active dashboard. Prompt now guards against the model passing `dashboardId` there, but symmetry is a future change.
- Pin `kubectl` to an absolute path instead of relying on `PARENT_ENV_ALLOWLIST`'d PATH.
- Add the spec-listed unit tests for hydration, URL normalize, k8s exec gating, and chat `done` persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add panels to specific dashboards by name, rather than only the active dashboard.
  * New auth type selector (Bearer vs API Key) for corporate LLM gateway configuration.
  * Kubernetes connectors now support TLS certificates and authentication plugins.

* **Bug Fixes**
  * Chat messages no longer duplicate in certain scenarios.
  * Credentials are now redacted from connector API responses.
  * Activity summaries now accurately count all visible steps.

* **Improvements**
  * Prometheus/Victoria Metrics URL normalization improves configuration reliability.
  * Connector configuration form now displays field-specific help text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->