### PR TITLE
Dashboard viz + agent self-correction fixes (6 themes)

### DIFF
--- a/packages/agent-core/src/agent/agent-registry.ts
+++ b/packages/agent-core/src/agent/agent-registry.ts
@@ -80,6 +80,8 @@ agentRegistry.register({
     'setting_get', 'setting_set',
     // Lazy tool loading — fetches deferred schemas on demand
     'tool_search',
+    // On-demand task-context module loading — splits the system prompt
+    'load_task_context',
     // Clarifying question — terminal tool handled inside ReActLoop
     'ask_user',
   ],

--- a/packages/agent-core/src/agent/agent-types.ts
+++ b/packages/agent-core/src/agent/agent-types.ts
@@ -55,6 +55,8 @@ export type AgentToolName =
   | 'verifier.run'
   // Lazy tool loading (fetches deferred-tool schemas on demand)
   | 'tool_search'
+  // On-demand task-context module loading (splits the system prompt)
+  | 'load_task_context'
   // Clarifying question — terminal tool handled inside ReActLoop
   | 'ask_user';
 

--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard-build-flow.regression.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard-build-flow.regression.test.ts
@@ -119,7 +119,7 @@ describe('regression: dashboard build flow (connectors -> discover -> validate -
       sourceId: 'prom',
       query: expr,
     });
-    expect(validate).toMatch(/Valid query/);
+    expect(validate).toMatch(/\d+ series/);
     expect(ctx.dashboardBuildEvidence.validatedQueries.has(expr)).toBe(true);
 
     // 4) Create dashboard — sets activeDashboardId and marks it freshly created.

--- a/packages/agent-core/src/agent/handlers/__tests__/metrics.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/metrics.test.ts
@@ -210,30 +210,68 @@ describe('metrics handlers', () => {
   });
 
   describe('handleMetricsValidate', () => {
-    it('marks the tool_result as success: false when the query is invalid', async () => {
+    it('reports a run failure when the query does not parse/execute', async () => {
       const adapter = makeAdapter({
         testQuery: vi.fn().mockResolvedValue({ ok: false, error: 'parse error' }),
       });
       const ctx = makeFakeActionContext({ adapters: makeAdaptersWithMetrics(adapter) });
       const observation = await handleMetricsValidate(ctx, { sourceId: 'prom', query: 'bogus(' });
-      expect(observation).toContain('Invalid query');
+      expect(observation).toContain('Query failed to run');
       expect(ctx.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'tool_result', tool: 'metrics_validate' }),
       );
     });
 
-    it('fails validation when the dashboard range query path rejects the expression', async () => {
+    it('reports a run failure when the dashboard range query path rejects the expression', async () => {
       const adapter = makeAdapter({
         testQuery: vi.fn().mockResolvedValue({ ok: true }),
         rangeQuery: vi.fn().mockRejectedValue(new Error('Prometheus returned HTTP 422 for range query')),
       });
       const ctx = makeFakeActionContext({ adapters: makeAdaptersWithMetrics(adapter) });
       const observation = await handleMetricsValidate(ctx, { sourceId: 'prom', query: 'bad_range_query' });
-      expect(observation).toContain('Invalid query');
+      expect(observation).toContain('Query failed to run');
       expect(observation).toContain('Prometheus returned HTTP 422 for range query');
       expect(ctx.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'tool_result', tool: 'metrics_validate' }),
       );
+    });
+
+    it('returns the actual result shape (series count, labels, sample values) for a runnable query', async () => {
+      const adapter = makeAdapter({
+        testQuery: vi.fn().mockResolvedValue({ ok: true }),
+        rangeQuery: vi.fn().mockResolvedValue([
+          { metric: { pod: 'web-0' }, values: [[1, '0.1'], [2, '0.4']] },
+          { metric: { pod: 'web-1' }, values: [[1, '0.2'], [2, '0.5']] },
+        ]),
+      });
+      const ctx = makeFakeActionContext({ adapters: makeAdaptersWithMetrics(adapter) });
+      const expr = 'sum by (pod) (rate(cpu_seconds_total[5m]))';
+      const observation = await handleMetricsValidate(ctx, { sourceId: 'prom', query: expr });
+      expect(observation).toContain('2 series');
+      expect(observation).toContain('pod');
+      expect(observation).toContain('0.5');
+      // The evidence gate must still record the validated expression.
+      expect(ctx.dashboardBuildEvidence.validatedQueries.has(expr)).toBe(true);
+    });
+
+    it('surfaces a collapse warning when a by() label is absent from the result', async () => {
+      const adapter = makeAdapter({
+        testQuery: vi.fn().mockResolvedValue({ ok: true }),
+        // Grouped by kubernetes_pod_name, but the result carries only `pod` —
+        // the grouping collapsed to a single series.
+        rangeQuery: vi.fn().mockResolvedValue([
+          { metric: { pod: 'web-0' }, values: [[1, '12'], [2, '12']] },
+        ]),
+      });
+      const ctx = makeFakeActionContext({ adapters: makeAdaptersWithMetrics(adapter) });
+      const observation = await handleMetricsValidate(ctx, {
+        sourceId: 'prom',
+        query: 'sum by (kubernetes_pod_name) (rate(cpu[5m]))',
+      });
+      expect(observation).toContain('the grouping collapsed');
+      expect(observation).toContain('kubernetes_pod_name');
+      // The label that's actually present is `pod`, not the missing one.
+      expect(observation).toContain('Labels actually present: pod');
     });
   });
 });

--- a/packages/agent-core/src/agent/handlers/index.ts
+++ b/packages/agent-core/src/agent/handlers/index.ts
@@ -94,6 +94,7 @@ export { handleRemediationPlanCreate, handleRemediationPlanCreateRescue } from '
 export { handleKbSearch } from './kb-search.js';
 export { handleKbGet } from './kb-get.js';
 export { handleKbRecommend } from './kb-recommend.js';
+export { handleLoadTaskContext } from './load-task-context.js';
 
 export {
   handleConnectorList,

--- a/packages/agent-core/src/agent/handlers/load-task-context.ts
+++ b/packages/agent-core/src/agent/handlers/load-task-context.ts
@@ -1,0 +1,39 @@
+import type { ActionContext } from './_context.js';
+import { withToolEventBoundary } from './_shared.js';
+import { getTaskModule, type TaskMode } from '../orchestrator-prompt.js';
+
+const TASK_MODES: ReadonlySet<TaskMode> = new Set([
+  'dashboard_build',
+  'investigate',
+  'alert_author',
+  'ad_hoc_explore',
+  'ops_command',
+]);
+
+/**
+ * load_task_context — the agent self-invokes this once it has picked a task
+ * shape from the decision flow. It returns the matching task module: the
+ * detailed playbook (examples, query patterns, panel-correctness rules) that
+ * the base prompt deliberately leaves out so the static prefix stays small.
+ *
+ * No backend resource is touched; the observation IS the agent's own guidance.
+ */
+export async function handleLoadTaskContext(
+  ctx: ActionContext,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const mode = String(args.mode ?? '');
+  if (!TASK_MODES.has(mode as TaskMode)) {
+    return `Error: load_task_context requires "mode" (one of: ${[...TASK_MODES].join(', ')}). Received: "${mode || '(empty)'}".`;
+  }
+  return withToolEventBoundary(
+    ctx.sendEvent,
+    'load_task_context',
+    { mode },
+    `Loading ${mode} task context`,
+    async () => ({
+      observation: getTaskModule(mode as TaskMode),
+      summary: `Loaded ${mode} task context`,
+    }),
+  );
+}

--- a/packages/agent-core/src/agent/handlers/metrics.ts
+++ b/packages/agent-core/src/agent/handlers/metrics.ts
@@ -286,6 +286,88 @@ export async function handleMetricsDiscover(
   }
 }
 
+// ---------------------------------------------------------------------------
+// metrics_validate — evidence-based. A query that merely parses is not
+// necessarily correct: a collapsed `by (...)` grouping, a ratio that should be
+// 0..1 but reads 12, or a cardinality blow-up all "run" fine. Rather than
+// returning a bare valid/invalid verdict, we run the query and report the
+// actual result shape (series count, labels, sample values, collapse flag) and
+// let the model judge it against its own intent.
+// ---------------------------------------------------------------------------
+
+interface RangeSeries {
+  metric: Record<string, string>;
+  values: Array<[number, string]>;
+}
+
+/** Compact human-readable number — `1.2k`, `3.4M`, `0.5`, `12` — for sample magnitudes. */
+function fmtNum(n: number): string {
+  if (!Number.isFinite(n)) return 'NaN';
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}k`;
+  if (abs === 0) return '0';
+  if (abs >= 1) return n.toFixed(2).replace(/\.00$/, '');
+  return n.toPrecision(2);
+}
+
+/**
+ * Describe a range-query result so the model can judge it against intent.
+ * Reports series count, the union of label keys present, per-series
+ * last/min/max (capped at 8 rows), and a factual collapse flag when a label
+ * named in a `by (...)` clause is absent from the result.
+ */
+function describeRangeResult(expr: string, series: RangeSeries[]): string {
+  if (series.length === 0) {
+    return [
+      '0 series — the query ran but returned nothing.',
+      'Common causes: a label filter that matches no series, a time window with no samples, or a metric not scraped yet (pre-deployment).',
+      'Read this against what you intended — if you expected data here, the selector or grouping is likely wrong.',
+    ].join(' ');
+  }
+
+  const labelKeys = [
+    ...new Set(series.flatMap((s) => Object.keys(s.metric).filter((k) => k !== '__name__'))),
+  ];
+
+  const byLabels = [
+    ...new Set(
+      [...expr.matchAll(/\bby\s*\(([^)]*)\)/gi)]
+        .flatMap((m) => (m[1] ?? '').split(','))
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0),
+    ),
+  ];
+  const missingByLabels = byLabels.filter((l) => !labelKeys.includes(l));
+
+  const rows = series.slice(0, 8).map((s) => {
+    const labelStr = Object.entries(s.metric)
+      .filter(([k]) => k !== '__name__')
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(', ');
+    const name = labelStr || s.metric.__name__ || 'series';
+    const nums = s.values.map(([, v]) => Number(v)).filter((n) => Number.isFinite(n));
+    if (nums.length === 0) return `- ${name}: (no numeric samples)`;
+    const last = nums[nums.length - 1]!;
+    return `- ${name}: last=${fmtNum(last)} min=${fmtNum(Math.min(...nums))} max=${fmtNum(Math.max(...nums))}`;
+  });
+  const moreRows = series.length > 8 ? `\n- ... and ${series.length - 8} more series` : '';
+
+  const lines: string[] = [];
+  if (missingByLabels.length > 0) {
+    const labelWord = missingByLabels.length > 1 ? 'those labels are' : 'that label is';
+    lines.push(
+      `⚠️ Grouped by ${missingByLabels.map((l) => `\`${l}\``).join(', ')}, but ${labelWord} not on the result — the grouping collapsed. Labels actually present: ${labelKeys.length ? labelKeys.join(', ') : '(none)'}.`,
+    );
+  }
+  lines.push(`${series.length} series. Labels present: ${labelKeys.length ? labelKeys.join(', ') : '(none)'}.`);
+  lines.push(rows.join('\n') + moreRows);
+  lines.push(
+    'Read this against what you intended — series count, the labels you grouped/legend-formatted on, and whether the magnitudes/units make sense. A query that merely runs is not necessarily correct.',
+  );
+  return lines.join('\n');
+}
+
 // TODO: migrate to withToolEventBoundary
 export async function handleMetricsValidate(ctx: ActionContext, args: Record<string, unknown>): Promise<string> {
   const sourceId = String(args.sourceId ?? '');
@@ -296,23 +378,34 @@ export async function handleMetricsValidate(ctx: ActionContext, args: Record<str
   if (!expr) return 'Error: "query" is required.';
   ctx.sendEvent({ type: 'tool_call', tool: 'metrics_validate', args: { sourceId, query: expr }, displayText: `Validating: ${expr.slice(0, 60)}` });
   try {
+    // testQuery catches genuine parse/exec errors. A query that fails here
+    // never ran, so there's no result shape to report.
     const result = await adapter.testQuery(expr);
     if (!result.ok) {
-      const summary = `Invalid query: ${result.error ?? 'unknown error'}`;
+      const summary = `Query failed to run: ${result.error ?? 'unknown error'}`;
       ctx.sendEvent({ type: 'tool_result', tool: 'metrics_validate', summary });
       return summary;
     }
 
     const end = new Date();
     const start = new Date(end.getTime() - 5 * 60_000);
-    await adapter.rangeQuery(expr, start, end, '60s');
+    const series = (await adapter.rangeQuery(expr, start, end, '60s')) as RangeSeries[];
 
-    const summary = `Valid query: ${expr}`;
+    // Record into evidence so the dashboard_add_panels "must validate first"
+    // gate keeps working — the gate keys on the expression, not the verdict.
     ctx.dashboardBuildEvidence.validatedQueries.add(expr);
-    ctx.sendEvent({ type: 'tool_result', tool: 'metrics_validate', summary });
-    return summary;
+
+    const labelKeys = [
+      ...new Set(series.flatMap((s) => Object.keys(s.metric).filter((k) => k !== '__name__'))),
+    ];
+    ctx.sendEvent({
+      type: 'tool_result',
+      tool: 'metrics_validate',
+      summary: `${series.length} series; labels: ${labelKeys.length ? labelKeys.join(', ') : '(none)'}`,
+    });
+    return describeRangeResult(expr, series);
   } catch (err) {
-    const msg = `Invalid query: ${err instanceof Error ? err.message : String(err)}`;
+    const msg = `Query failed to run: ${err instanceof Error ? err.message : String(err)}`;
     ctx.sendEvent({ type: 'tool_result', tool: 'metrics_validate', summary: msg });
     return msg;
   }

--- a/packages/agent-core/src/agent/orchestrator-action-handlers.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-handlers.ts
@@ -67,6 +67,7 @@ export {
   handleKbSearch,
   handleKbGet,
   handleKbRecommend,
+  handleLoadTaskContext,
   handleGithubListRepos,
   handleGithubListPrs,
   handleGithubGetPr,

--- a/packages/agent-core/src/agent/orchestrator-action-runner.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-runner.ts
@@ -64,6 +64,7 @@ import {
   handleKbSearch,
   handleKbGet,
   handleKbRecommend,
+  handleLoadTaskContext,
   handleGithubListRepos,
   handleGithubListPrs,
   handleGithubGetPr,
@@ -274,6 +275,7 @@ async function dispatchAction(
     // without round-tripping through the dispatcher. Listed here as a
     // no-op fallback so an out-of-loop caller doesn't see it as unknown.
     case 'tool_search': return null;
+    case 'load_task_context': return handleLoadTaskContext(ctx, args);
     default: return `Unknown action "${action}" - skipping.`;
   }
 }

--- a/packages/agent-core/src/agent/orchestrator-prompt.ts
+++ b/packages/agent-core/src/agent/orchestrator-prompt.ts
@@ -88,19 +88,14 @@ Don't abandon a viable approach after one failure, but don't dig on a dead end e
 - Do not modify the dashboard as a side effect of another action.
 - When analyzing data ("what's happening with X"), cite specific numbers from actual queries. Never a vague summary without values.
 
-## Dashboard design
-- Structure: overview stats top → trends middle → detailed breakdowns bottom.
-- Multi-dashboard requests: if the prompt names several distinct surfaces, split them into separate dashboards. For example, "Istio control plane, ingress, egress" means create "Istio Control Plane", "Istio Ingress", and "Istio Egress" dashboards, each with its own focused panels.
-- Cover the dimensions the system's official dashboard covers. For control-plane / infrastructure systems that typically means resource usage (CPU/mem/IO), business flow (config push, request rate, queue depth), health (errors, restarts, cert expiry), and dependencies (downstream API success). Use \`web_search\` to find which dimensions matter for this specific system.
-- Panel design source — never a target to hit, never a cap. Always web-search a reference layout first; build using whichever metric names actually fit:
-  - Standard system → search its official dashboard, use that layout + its canonical exporter metric names.
-  - In-house service → identify the service pattern (HTTP server, gRPC, queue consumer, batch job, scheduled worker, etc.), search best-practice panels for that pattern, then build using existing metrics whose labels match.
-  - Exploratory → match what the backend already exposes.
-- Prioritize RED signals (Rate / Errors / Duration) for request-driven services. Don't add specialist panels for exploratory dashboards unless asked, but DO include them for named system dashboards if the standard layout has them.
-- Don't use template variables unless the user asks for drill-down.
-
-## Investigations
-When the user asks "why is X high/slow/broken" or "investigate X": create an investigation record with \`investigation_create\`, then run a hypothesis-driven diagnosis — like a senior SRE writing an incident report. The report is primarily written analysis; panels are supporting evidence, not the main content. See the worked Investigation example below for the structure.`
+## Load the task module once you know the shape
+This base prompt is deliberately small. The detailed playbook for each task shape — worked examples, query patterns, panel-correctness rules, the knowledge-base protocol — lives in on-demand modules. Once you've picked the shape from the decision flow above, call \`load_task_context\` with the matching mode BEFORE doing the heavy work:
+- building a dashboard → \`dashboard_build\`
+- "why is X broken" / investigate → \`investigate\`
+- creating/editing an alert rule → \`alert_author\`
+- "show me / what is" a metric value → \`ad_hoc_explore\`
+- mutating cluster state (scale/delete/install) → \`ops_command\`
+Skip it only for trivial conversational answers and for opening/listing existing resources, which the decision flow already covers.`
 }
 
 function getActionsSection(canCreateRemediationPlans = false): string {
@@ -160,126 +155,15 @@ When the user asks you to mutate cluster state ("scale X", "delete Y", "install 
 If \`ops_run_command\` or \`ops_cluster_shell\` returns a refusal observation (permission denied, kubectl RBAC rejected, namespace not in connector's allowlist, unmapped verb): relay the refusal plainly. Do not retry the same call; do not tell the user to run kubectl locally; do not create a remediation plan to route around missing permission.`
 }
 
-function getExamplesSection(): string {
-  return `# Examples
+// ---------------------------------------------------------------------------
+// Base examples — task-agnostic, small, always present. Opening / listing /
+// answering need no task module; the decision flow already routes them.
+// ---------------------------------------------------------------------------
 
-Each example shows a representative tool-call flow. Tool input/output is shown as \`tool(args) → result\` so you can read the trace at a glance — the tool API is native, not a literal format you must emit.
+function getCommonExamplesSection(): string {
+  return `# Examples (common)
 
-## Creating a Dashboard (metrics exist)
-<example>
-User: "Create a dashboard for HTTP monitoring"
-  1. connectors_list(signalType: "metrics") → id: prom-prod
-  2. kb_recommend(intent: "HTTP service monitoring dashboard") → bundled RED/HTTP entry
-  3. kb_get(id: "...") → canonical RED layout + metric shapes
-  4. metrics_discover(sourceId: "prom-prod", kind: "names", match: "http") → http_requests_total, http_request_duration_seconds_bucket, ...
-  5. metrics_discover(sourceId: "prom-prod", kind: "metadata", metric: "http_requests_total") → counter
-  6. dashboard_create(title: "HTTP Service Monitoring") → dashboard becomes the active target for follow-up tools
-  7. metrics_validate(sourceId: "prom-prod", query: "sum(rate(http_requests_total[5m]))") → Valid (repeat per query)
-  8. dashboard_add_panels(panels: [request rate stat, error rate gauge, p95 latency time_series])
-  9. final reply (plain text): "Created HTTP Monitoring dashboard with 3 panels: request rate, error rate, p95 latency."
-</example>
-
-## Creating a Dashboard (metrics don't exist yet — pre-deployment)
-<example>
-User: "Create a monitoring dashboard for our new Redis deployment"
-  1. kb_recommend(intent: "Redis monitoring dashboard") → bundled Redis entry
-  2. kb_get(id: "bundled-redis") → redis_connected_clients, redis_memory_used_bytes, redis_commands_processed_total, ...
-  3. dashboard_create(title: "Redis Monitoring", description: "Expects metrics from redis_exporter")
-  4. dashboard_add_panels(panels: [connected clients stat, memory usage time_series, command rate time_series])
-       → succeeds with warnings "0 series — will render blank until target is scraped". Expected; not an error.
-  5. final reply (plain text): "Created Redis dashboard with 3 panels. Panels will show data once redis_exporter is deployed."
-</example>
-**Do NOT** call \`metrics_validate\` or \`panel_preview\` before adding pre-deployment panels, and do NOT split the add into multiple calls — the warning observation is informational, the panels are saved. Adding panels one-by-one to "bypass" the verify-gate is wrong; the gate never blocked you.
-
-## Showing a metric value (ad-hoc chart)
-<example>
-User: "Show me p50 http request latency"
-  1. connectors_list(signalType: "metrics") → id: prom-prod
-  2. metric_explore(query: "histogram_quantile(0.5, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency", datasourceId: "prom-prod")
-     → emits inline chart; returns one-line summary
-  3. final reply (plain text): one short sentence acknowledging the chart appeared and what it showed at a glance. NEVER describe the chart's values in detail — the chart is the answer.
-</example>
-
-<example>
-User (follow-up in same session): "What about p99?"
-  1. metric_explore(query: "histogram_quantile(0.99, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency")
-     ← omit timeRangeHint so the handler inherits the previous chart's time window automatically.
-  2. final reply: one sentence connecting the new chart to the prior one (e.g. "p99 sits roughly 5x p50 over the same window").
-</example>
-
-## Explaining / Analyzing Panel Data
-<example>
-User: "Analyze the request rate by handler data" (within an investigation or a panel-analysis flow)
-  1. connectors_list(signalType: "metrics") → id: prom-prod
-  2. metrics_query(sourceId: "prom-prod", query: "topk(5, sum(rate(http_requests_total[5m])) by (handler))")
-     → /api/v1/query: 2.3, /api/v1/label: 1.1, /metrics: 0.8, ...
-  3. final reply (plain text): "Top 5 handlers by traffic: /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic stable, no anomalies."
-</example>
-Use \`metrics_query\` here (not \`metric_explore\`) because the caller wants a numeric breakdown, not an interactive chart. For a plain "show me X" question from the user, prefer \`metric_explore\`.
-
-## Modifying Panels
-<example>
-User: "Change the latency panel to show p99 instead of p95"
-  1. metrics_validate(sourceId: "prom-prod", query: "histogram_quantile(0.99, ...)") → Valid
-  2. dashboard_modify_panel(panelId: "panel-id-from-context", title: "Latency p99", queries: [{refId: "A", expr: "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))"}])
-  3. final reply (plain text): "Changed latency panel from p95 to p99."
-</example>
-
-## Creating an Alert Rule
-<example>
-User: "Alert me when error rate goes above 5%"
-  1. metrics_query(sourceId: "prom-prod", query: error rate) → 0.023 (2.3%, so 5% threshold is reasonable)
-  2. metrics_validate(sourceId: "prom-prod", query: "sum(rate(http_requests_total{status=~\\"5..\\"}[5m])) / sum(rate(http_requests_total[5m]))") → Valid
-  3. alert_rule_write(op: "create", spec: {name: "High HTTP Error Rate", description: "Fires when 5xx error rate exceeds 5% for 5 minutes.", condition: {query: "sum(rate(http_requests_total{status=~\\"5..\\"}[5m])) / sum(rate(http_requests_total[5m]))", operator: ">", threshold: 0.05, forDurationSec: 300}, evaluationIntervalSec: 60, severity: "high", labels: {source: "openobs"}})
-  4. final reply (plain text): "Created alert rule 'High HTTP Error Rate' — fires when error rate > 5%. Current rate is 2.3%."
-</example>
-
-## Investigation
-When the user asks "why is X high/slow/broken" or "investigate X", debug it the way you'd walk a teammate through it in Slack: lead with what you saw and the numbers, work through what you suspected and what you queried, follow the trail (including dead ends), and end with what's most likely going on.
-
-The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Start each text section with a short markdown heading that names the beat (e.g. \`## Symptom\`, \`## Deployment history\`, \`## Fix\`). Pick headings that fit this case — don't reach for a fixed template like \`## Initial Assessment\` / \`## Hypothesis Testing\` by reflex.
-
-### How to write it
-- Lead with what you saw and the numbers ("p99 jumped from ~50ms baseline to 99ms around 14:30; sustained for the last hour").
-- For each thing you suspected: state it, say what you queried, what came back, and whether that killed or supported the suspicion. Allow detours and dead ends — real debugging isn't linear.
-- Connect the dots explicitly: "Since traffic is stable AND errors are zero, the cost is in per-request work, not load."
-- End with what's most likely going on — or "I couldn't tell" if you can't. The last section carries the conclusion; pick a heading that names what it's saying (e.g. \`## Likely cause\`, \`## What to try next\`) rather than the generic word "Conclusion".
-- If the user can act on it, say what they should try next, specifically. If everything is healthy, say so cleanly and stop.
-- Specific numbers inline: not "high", but "120ms vs <50ms baseline".
-- Complete paragraphs, not bullet lists.
-
-### When the metric is absent, zero, or near-zero
-A drop to zero (or no samples) is ambiguous. By base rate the cause is usually (a) the service is down, (b) the scrape target moved, (c) the metric was renamed in a recent deploy, or (d) genuinely zero traffic. (a) is the most common; "monitoring is misconfigured" is rare and should NOT be your first conclusion without positive evidence.
-
-Disambiguate with whatever tools your current run has access to: \`up{...}\` and neighbor metrics from the same job will rule (a) in or out from the metrics side; \`changes_list_recent\` covers (c); cluster-side checks via an Ops connector cover (a) directly. Use only what the tool list and \`# Ops Integrations\` section show as available — if you don't have a path to verify a hypothesis, say so in the report instead of inventing a check.
-
-### When a cluster connector is attached
-If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_command\` with \`intent="read"\` to inspect cluster state for service-side symptoms — pod status, recent events, logs from suspect pods, etc. Stick to the connector's allowed namespaces. Do not run write commands from an investigation turn; background alert runs may propose a remediation plan after \`investigation_complete\` when that tool is available.
-
-### Mechanics
-- Two section tools, single-purpose each: \`investigation_add_text\` for narrative prose, \`investigation_add_evidence\` for a chart with auto-captured data. Section order = display order.
-- Start each text section with a short \`## heading\` that names the beat. Fit the heading to what you're actually saying — don't reach for a fixed template by reflex.
-- Interleave querying and writing. Query → write a paragraph → query more → write more → drop in the evidence panel next to the prose it supports. Don't do all the queries first and then the writing.
-- **EVERY investigation needs 1-4 \`investigation_add_evidence\` calls.** A pure-text report is incomplete — readers can't verify the reasoning without seeing the data. Right after each \`metrics_range_query\` or \`metrics_query\` that lands on a key finding, follow with \`investigation_add_evidence\` reusing the same \`expr\`.
-- When you hit an unfamiliar metric, label, or vendor behavior mid-investigation, call \`web_search\` before guessing — see the web_search behavior block above for triggers.
-- MUST call \`investigation_complete\` at the end. Without it, sections are lost. Don't end the turn with plain text before completing.
-
-<example>
-User: "Why is p99 latency so high?"
-  1. connectors_list(signalType: "metrics") → id: prom-prod
-  2. investigation_create(question: "Why is p99 latency high?") → inv-789
-  3. metrics_query(p99) → 99ms; metrics_query(p50) → 50ms
-  4. investigation_add_text(content: "## Symptom\n\np99 is sitting at 99ms vs ~50ms p50 — about 2× the median, sustained over the last hour. Worth chasing.")
-  5. metrics_range_query(query: request rate, duration_minutes: 60) → stable 0.19 req/s
-  6. metrics_query(error rate) → 0 errors
-  7. investigation_add_text(content: "## Ruling out load\n\nFirst thought: load. Rate is flat at 0.19 req/s with a peak of 0.25 at 14:30, well within normal range. Errors are zero. So it isn't load-driven and it isn't a fault path — the cost is in per-request work somewhere.")
-  8. metrics_range_query(query: \`histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket[5m])))\`, duration_minutes: 60) → /api/v1/query_range=120ms, others <50ms
-  9. investigation_add_evidence(content: "p99 by handler — /api/v1/query_range dominates at 120ms while every other handler sits below 50ms.", panel: { title: "p99 by handler", visualization: "time_series", queries: [{ refId: "A", expr: "histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket[5m])))", legendFormat: "{{handler}}" }], unit: "ms" })
-  10. investigation_add_text(content: "## Hotspot: /api/v1/query_range\n\nBreaking down by handler points the finger: /api/v1/query_range sits at 120ms p99 while every other handler is under 50ms. That one handler is the entire delta.")
-  11. changes_list_recent(service: "api-gateway", window_minutes: 120) → no deploys in window
-  12. investigation_add_text(content: "## Likely cause and what to try\n\nNo deploys in the last 2h, so this isn't a regression from a code change — most likely an expensive query pattern or upstream slowdown specific to /query_range. To pin it down, profile a slow request, check incoming PromQL complexity for that endpoint, and see whether the slowness tracks a particular tenant or query shape.")
-  13. investigation_complete(summary: "p99 is driven by /api/v1/query_range alone (120ms vs <50ms others). No deploy correlation. Profile that handler and look at PromQL complexity per-tenant.")
-</example>
+Each example shows a representative tool-call flow. Tool input/output is shown as \`tool(args) → result\` so you can read the trace at a glance — the tool API is native, not a literal format you must emit. Detailed per-task examples live in the task modules you load via \`load_task_context\`.
 
 ## Opening Existing Resources
 <example>
@@ -308,6 +192,67 @@ User: "我有哪些 dashboard"
 <example>
 User: "What's the difference between rate() and irate()?"
   final reply (plain text, no tool call): "rate() calculates per-second average over the full range window. irate() uses only the last two points — more responsive but noisier. Use rate() for dashboards, irate() for debugging."
+</example>`
+}
+
+// ---------------------------------------------------------------------------
+// Per-task module sections. Loaded on demand via load_task_context, not part
+// of the static base prompt. Each captures the heavy, task-specific playbook
+// that used to bloat the monolithic prompt.
+// ---------------------------------------------------------------------------
+
+function getDashboardDesignSection(): string {
+  return `# Dashboard design
+- Structure: overview stats top → trends middle → detailed breakdowns bottom.
+- Multi-dashboard requests: if the prompt names several distinct surfaces, split them into separate dashboards. For example, "Istio control plane, ingress, egress" means create "Istio Control Plane", "Istio Ingress", and "Istio Egress" dashboards, each with its own focused panels.
+- Cover the dimensions the system's official dashboard covers. For control-plane / infrastructure systems that typically means resource usage (CPU/mem/IO), business flow (config push, request rate, queue depth), health (errors, restarts, cert expiry), and dependencies (downstream API success). Use \`web_search\` to find which dimensions matter for this specific system.
+- Panel design source — never a target to hit, never a cap. Always web-search a reference layout first; build using whichever metric names actually fit:
+  - Standard system → search its official dashboard, use that layout + its canonical exporter metric names.
+  - In-house service → identify the service pattern (HTTP server, gRPC, queue consumer, batch job, scheduled worker, etc.), search best-practice panels for that pattern, then build using existing metrics whose labels match.
+  - Exploratory → match what the backend already exposes.
+- Prioritize RED signals (Rate / Errors / Duration) for request-driven services. Don't add specialist panels for exploratory dashboards unless asked, but DO include them for named system dashboards if the standard layout has them.
+- Don't use template variables unless the user asks for drill-down.
+
+## Picture the rendered panel before you save
+- **Legend** — a legend is read by a human telling lines apart. Collapse the dimensions the viewer doesn't care about and keep the one that actually separates the lines (e.g. \`sum by (status)\` when comparing response codes). Look at what THIS metric exposes rather than reusing a \`legendFormat\` or \`by\` label that happened to work on a different panel. Every query in a multi-query panel still needs a \`legendFormat\`; single-query panels can omit it.
+- **Stacking** — stacking answers "what do these add up to?". Default to unstacked lines, the way Grafana does. Stack ONLY when the series compose a whole AND no single one swamps the others: if one series is an order of magnitude bigger than the rest, the small ones collapse onto a sub-pixel line riding the dominant series' shape and the tooltip stops reading sensibly.`
+}
+
+function getDashboardModule(): string {
+  return `# Building a dashboard
+
+${getDashboardDesignSection()}
+
+## Worked examples
+<example>
+User: "Create a dashboard for HTTP monitoring"
+  1. connectors_list(signalType: "metrics") → id: prom-prod
+  2. kb_recommend(intent: "HTTP service monitoring dashboard") → bundled RED/HTTP entry
+  3. kb_get(id: "...") → canonical RED layout + metric shapes
+  4. metrics_discover(sourceId: "prom-prod", kind: "names", match: "http") → http_requests_total, http_request_duration_seconds_bucket, ...
+  5. metrics_discover(sourceId: "prom-prod", kind: "metadata", metric: "http_requests_total") → counter
+  6. dashboard_create(title: "HTTP Service Monitoring") → dashboard becomes the active target for follow-up tools
+  7. metrics_validate(sourceId: "prom-prod", query: "sum(rate(http_requests_total[5m]))") → reports the result shape (repeat per query); read it against intent
+  8. dashboard_add_panels(panels: [request rate stat, error rate gauge, p95 latency time_series])
+  9. final reply (plain text): "Created HTTP Monitoring dashboard with 3 panels: request rate, error rate, p95 latency."
+</example>
+
+<example>
+User: "Create a monitoring dashboard for our new Redis deployment" (pre-deployment — metrics don't exist yet)
+  1. kb_recommend(intent: "Redis monitoring dashboard") → bundled Redis entry
+  2. kb_get(id: "bundled-redis") → redis_connected_clients, redis_memory_used_bytes, redis_commands_processed_total, ...
+  3. dashboard_create(title: "Redis Monitoring", description: "Expects metrics from redis_exporter")
+  4. dashboard_add_panels(panels: [connected clients stat, memory usage time_series, command rate time_series])
+       → succeeds with warnings "0 series — will render blank until target is scraped". Expected; not an error.
+  5. final reply (plain text): "Created Redis dashboard with 3 panels. Panels will show data once redis_exporter is deployed."
+</example>
+**Do NOT** call \`metrics_validate\` or \`panel_preview\` before adding pre-deployment panels, and do NOT split the add into multiple calls — the warning observation is informational, the panels are saved. Adding panels one-by-one to "bypass" the verify-gate is wrong; the gate never blocked you.
+
+<example>
+User: "Change the latency panel to show p99 instead of p95"
+  1. metrics_validate(sourceId: "prom-prod", query: "histogram_quantile(0.99, ...)") → result shape; confirm it's what you meant
+  2. dashboard_modify_panel(panelId: "panel-id-from-context", title: "Latency p99", queries: [{refId: "A", expr: "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))"}])
+  3. final reply (plain text): "Changed latency panel from p95 to p99."
 </example>
 
 ## Panel Schema Reference
@@ -330,7 +275,6 @@ User: "What's the difference between rate() and irate()?"
 - **Don't pick these by mistake**: \`stat\` for time-evolving counter without rate() → giant growing number; \`bar\` for time-evolving data → bars are snapshots; \`pie\` for time-series → proportional shares at an instant.
 - **Series cap**: if a \`time_series\` panel would have >30 series, wrap in \`topk(10, ...)\` or split by another label.
 - **Annotations**: for \`time_series\` / \`heatmap\` panels covering an alerting metric, fetch \`alert_rule_history\` once and pass the returned JSON as \`panel.annotations\`.
-- **Legend names**: every query in a multi-query panel MUST set \`legendFormat\` to a meaningful label (e.g. \`"p50"\`, \`"errors {{handler}}"\`). Single-query panels can omit it.
 
 ## Dashboard Lint — ALWAYS run before saving
 After drafting panels with \`dashboard_add_panels\` (or modifying with \`dashboard_modify_panel\`) and BEFORE the final reply, call \`dashboard_lint\` once with the full DashboardSpec.
@@ -353,8 +297,157 @@ For each panel you propose, follow this sequence. **Pre-deployment dashboards sk
 2. CHECK the KB **first, every time** — call \`kb_recommend\` with the user's intent + the named system as a hint. If any result is relevant by description / tags, \`kb_get\` it and use its markdown body to drive panel layout + canonical metric names. See the "Knowledge base" section below for the full rule.
 3. EXPLORE the actual data. \`metrics_discover\` to confirm the metric + labels exist. **Skip for pre-deployment dashboards.**
 4. DRAFT the PromQL.
-5. VERIFY with \`panel_preview\` (optional sanity check). **Skip for pre-deployment dashboards** — empty results are expected; the verify-gate treats them as warnings. For live dashboards, if the result is empty/NaN/cardinality-blown, go back to step 3 (max 3 attempts).
-6. SAVE with \`dashboard_add_panels\` — **prefer one bulk call**. For dashboards with ≤ 8 panels, send all of them in a single call. For dashboards with more panels, split into 2–3 bulk calls of ~6 panels each — NOT one-by-one. This keeps tool-call args under the output-token budget that some providers cap on, while still being far faster than per-panel calls. Warnings (0-series, missing Q: prefix, viz style nits) do NOT block. Only correctness errors (bad histogram_quantile shape, invalid PromQL, unknown labels on a live metric) block. If a save IS rejected, READ the actual error in the observation before reacting — don't assume "0 data" when it's actually a syntax / lint issue.`
+5. VERIFY with \`metrics_validate\` / \`panel_preview\`. **Skip for pre-deployment dashboards** — empty results are expected; the verify-gate treats them as warnings. For live dashboards, read the reported result shape: if it's empty/NaN/cardinality-blown or the grouping collapsed, go back to step 3 (max 3 attempts).
+6. SAVE with \`dashboard_add_panels\` — **prefer one bulk call**. For dashboards with ≤ 8 panels, send all of them in a single call. For dashboards with more panels, split into 2–3 bulk calls of ~6 panels each — NOT one-by-one. This keeps tool-call args under the output-token budget that some providers cap on, while still being far faster than per-panel calls. Warnings (0-series, missing Q: prefix, viz style nits) do NOT block. Only correctness errors (bad histogram_quantile shape, invalid PromQL, unknown labels on a live metric) block. If a save IS rejected, READ the actual error in the observation before reacting — don't assume "0 data" when it's actually a syntax / lint issue.
+
+## Re-read what you built, as the person who asked
+After saving, look at the dashboard the way the requester will. Does each panel answer a real question they have? Is it readable at a glance? Does every number mean what its title claims — right unit, right grouping, sane magnitude? Fix anything that fails this before you reply. A green save is not the same as a useful dashboard.
+
+${getKnowledgeBaseSection()}
+
+${getQueryKnowledgeSection()}`
+}
+
+function getInvestigateModule(): string {
+  return `# Investigation
+
+When the user asks "why is X high/slow/broken" or "investigate X", debug it the way you'd walk a teammate through it in Slack: lead with what you saw and the numbers, work through what you suspected and what you queried, follow the trail (including dead ends), and end with what's most likely going on. Create an investigation record with \`investigation_create\` first.
+
+The report is primarily WRITTEN ANALYSIS — panels are supporting evidence, not the main content. Start each text section with a short markdown heading that names the beat (e.g. \`## Symptom\`, \`## Deployment history\`, \`## Fix\`). Pick headings that fit this case — don't reach for a fixed template like \`## Initial Assessment\` / \`## Hypothesis Testing\` by reflex.
+
+## How to write it
+- Lead with what you saw and the numbers ("p99 jumped from ~50ms baseline to 99ms around 14:30; sustained for the last hour").
+- For each thing you suspected: state it, say what you queried, what came back, and whether that killed or supported the suspicion. Allow detours and dead ends — real debugging isn't linear.
+- Connect the dots explicitly: "Since traffic is stable AND errors are zero, the cost is in per-request work, not load."
+- End with what's most likely going on — or "I couldn't tell" if you can't. The last section carries the conclusion; pick a heading that names what it's saying (e.g. \`## Likely cause\`, \`## What to try next\`) rather than the generic word "Conclusion".
+- If the user can act on it, say what they should try next, specifically. If everything is healthy, say so cleanly and stop.
+- Specific numbers inline: not "high", but "120ms vs <50ms baseline".
+- Complete paragraphs, not bullet lists.
+
+## When the metric is absent, zero, or near-zero
+A drop to zero (or no samples) is ambiguous. By base rate the cause is usually (a) the service is down, (b) the scrape target moved, (c) the metric was renamed in a recent deploy, or (d) genuinely zero traffic. (a) is the most common; "monitoring is misconfigured" is rare and should NOT be your first conclusion without positive evidence.
+
+Disambiguate with whatever tools your current run has access to: \`up{...}\` and neighbor metrics from the same job will rule (a) in or out from the metrics side; \`changes_list_recent\` covers (c); cluster-side checks via an Ops connector cover (a) directly. Use only what the tool list and \`# Ops Integrations\` section show as available — if you don't have a path to verify a hypothesis, say so in the report instead of inventing a check.
+
+## When a cluster connector is attached
+If the \`# Ops Integrations\` section above lists a connector, use \`ops_run_command\` with \`intent="read"\` to inspect cluster state for service-side symptoms — pod status, recent events, logs from suspect pods, etc. Stick to the connector's allowed namespaces. Do not run write commands from an investigation turn; background alert runs may propose a remediation plan after \`investigation_complete\` when that tool is available.
+
+## Mechanics
+- Two section tools, single-purpose each: \`investigation_add_text\` for narrative prose, \`investigation_add_evidence\` for a chart with auto-captured data. Section order = display order.
+- Start each text section with a short \`## heading\` that names the beat. Fit the heading to what you're actually saying — don't reach for a fixed template by reflex.
+- Interleave querying and writing. Query → write a paragraph → query more → write more → drop in the evidence panel next to the prose it supports. Don't do all the queries first and then the writing.
+- **EVERY investigation needs 1-4 \`investigation_add_evidence\` calls.** A pure-text report is incomplete — readers can't verify the reasoning without seeing the data. Right after each \`metrics_range_query\` or \`metrics_query\` that lands on a key finding, follow with \`investigation_add_evidence\` reusing the same \`expr\`.
+- When you hit an unfamiliar metric, label, or vendor behavior mid-investigation, call \`web_search\` before guessing — see the web_search behavior block above for triggers.
+- MUST call \`investigation_complete\` at the end. Without it, sections are lost. Don't end the turn with plain text before completing.
+
+<example>
+User: "Why is p99 latency so high?"
+  1. connectors_list(signalType: "metrics") → id: prom-prod
+  2. investigation_create(question: "Why is p99 latency high?") → inv-789
+  3. metrics_query(p99) → 99ms; metrics_query(p50) → 50ms
+  4. investigation_add_text(content: "## Symptom\n\np99 is sitting at 99ms vs ~50ms p50 — about 2× the median, sustained over the last hour. Worth chasing.")
+  5. metrics_range_query(query: request rate, duration_minutes: 60) → stable 0.19 req/s
+  6. metrics_query(error rate) → 0 errors
+  7. investigation_add_text(content: "## Ruling out load\n\nFirst thought: load. Rate is flat at 0.19 req/s with a peak of 0.25 at 14:30, well within normal range. Errors are zero. So it isn't load-driven and it isn't a fault path — the cost is in per-request work somewhere.")
+  8. metrics_range_query(query: \`histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket[5m])))\`, duration_minutes: 60) → /api/v1/query_range=120ms, others <50ms
+  9. investigation_add_evidence(content: "p99 by handler — /api/v1/query_range dominates at 120ms while every other handler sits below 50ms.", panel: { title: "p99 by handler", visualization: "time_series", queries: [{ refId: "A", expr: "histogram_quantile(0.99, sum by (handler, le) (rate(http_request_duration_seconds_bucket[5m])))", legendFormat: "{{handler}}" }], unit: "ms" })
+  10. investigation_add_text(content: "## Hotspot: /api/v1/query_range\n\nBreaking down by handler points the finger: /api/v1/query_range sits at 120ms p99 while every other handler is under 50ms. That one handler is the entire delta.")
+  11. changes_list_recent(service: "api-gateway", window_minutes: 120) → no deploys in window
+  12. investigation_add_text(content: "## Likely cause and what to try\n\nNo deploys in the last 2h, so this isn't a regression from a code change — most likely an expensive query pattern or upstream slowdown specific to /query_range. To pin it down, profile a slow request, check incoming PromQL complexity for that endpoint, and see whether the slowness tracks a particular tenant or query shape.")
+  13. investigation_complete(summary: "p99 is driven by /api/v1/query_range alone (120ms vs <50ms others). No deploy correlation. Profile that handler and look at PromQL complexity per-tenant.")
+</example>
+
+${getQueryKnowledgeSection()}`
+}
+
+function getAlertAuthorModule(): string {
+  return `# Authoring an alert rule
+
+Discover and query the metric, validate the condition expression, then pass a complete structured \`spec\` to \`alert_rule_write\` — it does not generate the rule for you. Pick a threshold from the metric's current value, not a guess.
+
+<example>
+User: "Alert me when error rate goes above 5%"
+  1. metrics_query(sourceId: "prom-prod", query: error rate) → 0.023 (2.3%, so 5% threshold is reasonable)
+  2. metrics_validate(sourceId: "prom-prod", query: "sum(rate(http_requests_total{status=~\\"5..\\"}[5m])) / sum(rate(http_requests_total[5m]))") → result shape; confirm it returns the ratio you intend
+  3. alert_rule_write(op: "create", spec: {name: "High HTTP Error Rate", description: "Fires when 5xx error rate exceeds 5% for 5 minutes.", condition: {query: "sum(rate(http_requests_total{status=~\\"5..\\"}[5m])) / sum(rate(http_requests_total[5m]))", operator: ">", threshold: 0.05, forDurationSec: 300}, evaluationIntervalSec: 60, severity: "high", labels: {source: "openobs"}})
+  4. final reply (plain text): "Created alert rule 'High HTTP Error Rate' — fires when error rate > 5%. Current rate is 2.3%."
+</example>
+
+${getQueryKnowledgeSection()}`
+}
+
+function getAdHocExploreModule(): string {
+  return `# Showing / exploring a metric value
+
+For a user "show me / what is / how is" question, render an interactive chart with \`metric_explore\` — never a markdown table. The chart is the answer; don't describe its values in detail afterward.
+
+<example>
+User: "Show me p50 http request latency"
+  1. connectors_list(signalType: "metrics") → id: prom-prod
+  2. metric_explore(query: "histogram_quantile(0.5, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency", datasourceId: "prom-prod")
+     → emits inline chart; returns one-line summary
+  3. final reply (plain text): one short sentence acknowledging the chart appeared and what it showed at a glance. NEVER describe the chart's values in detail — the chart is the answer.
+</example>
+
+<example>
+User (follow-up in same session): "What about p99?"
+  1. metric_explore(query: "histogram_quantile(0.99, sum by(le) (rate(http_request_duration_seconds_bucket[5m])))", metricKind: "latency")
+     ← omit timeRangeHint so the handler inherits the previous chart's time window automatically.
+  2. final reply: one sentence connecting the new chart to the prior one (e.g. "p99 sits roughly 5x p50 over the same window").
+</example>
+
+When the caller wants a numeric breakdown rather than an interactive chart (e.g. inside an investigation or a panel analysis), use \`metrics_query\` instead and cite the numbers:
+<example>
+User: "Analyze the request rate by handler data"
+  1. connectors_list(signalType: "metrics") → id: prom-prod
+  2. metrics_query(sourceId: "prom-prod", query: "topk(5, sum(rate(http_requests_total[5m])) by (handler))")
+     → /api/v1/query: 2.3, /api/v1/label: 1.1, /metrics: 0.8, ...
+  3. final reply (plain text): "Top 5 handlers by traffic: /api/v1/query — 2.3 req/s (32%), /api/v1/label — 1.1 req/s (15%), /metrics — 0.8 req/s (11%). Traffic stable, no anomalies."
+</example>
+
+${getQueryKnowledgeSection()}`
+}
+
+function getOpsCommandModule(): string {
+  return `# Mutating cluster state
+
+The user asked to change cluster state ("scale X", "delete Y", "install Z"). Pick exactly ONE path and execute it directly — do NOT call \`investigation_create\` to "research" first; direct requests are not investigations.
+
+- **Kubectl-shaped** ("scale web to 3", "delete pod foo", "apply this YAML") → \`ops_run_command\`. The runtime handles permission checks and the user confirmation card before the write takes effect. Don't pre-bargain about whether they "really want this"; the confirm card is for that.
+- **Non-kubectl** ("install Istio", "helm install kube-prometheus-stack", "curl | sh some bootstrap") → \`ops_cluster_shell\`. Use \`scope="cluster"\` for CRDs/controllers/cluster-wide installs, \`scope="namespace"\` only when the change is contained to one namespace.
+
+Both require an attached Ops connector. If none is configured, say it's not connected — do not invent a cluster. If a call returns a refusal observation (permission denied, RBAC rejected, namespace not allowlisted, unmapped verb): relay it plainly. Do not retry the same call, do not tell the user to run kubectl locally, do not create a remediation plan to route around missing permission.`
+}
+
+// ---------------------------------------------------------------------------
+// Task modes + module assembly. The agent self-selects a mode via
+// load_task_context once it has picked the task shape from the decision flow.
+// ---------------------------------------------------------------------------
+
+export type TaskMode =
+  | 'dashboard_build'
+  | 'investigate'
+  | 'alert_author'
+  | 'ad_hoc_explore'
+  | 'ops_command'
+
+export function getTaskModule(mode: TaskMode): string {
+  switch (mode) {
+    case 'dashboard_build':
+      return getDashboardModule()
+    case 'investigate':
+      return getInvestigateModule()
+    case 'alert_author':
+      return getAlertAuthorModule()
+    case 'ad_hoc_explore':
+      return getAdHocExploreModule()
+    case 'ops_command':
+      return getOpsCommandModule()
+    default: {
+      const _exhaustive: never = mode
+      throw new Error(`getTaskModule: unknown mode ${String(_exhaustive)}`)
+    }
+  }
 }
 
 function getQueryKnowledgeSection(): string {
@@ -746,9 +839,7 @@ export function buildSystemPrompt(
     getDoingTasksSection(),
     getActionsSection(options?.allowedTools?.includes('remediation_plan_create') === true),
     getBackgroundShellContractSection(options?.agentType),
-    getExamplesSection(),
-    getQueryKnowledgeSection(),
-    getKnowledgeBaseSection(),
+    getCommonExamplesSection(),
     getToneSection(),
     deferredSection,
   ]

--- a/packages/agent-core/src/agent/tool-permissions.ts
+++ b/packages/agent-core/src/agent/tool-permissions.ts
@@ -320,6 +320,9 @@ export const UNGATED_TOOLS: ReadonlySet<string> = new Set([
   'navigate',
   'ask_user',
   'tool_search',
+  // Returns a slice of the agent's own system-prompt guidance; no backend
+  // resource is touched, so it's ungated like tool_search.
+  'load_task_context',
   'llm.complete',
   'verifier.run',
   // Discovery is always allowed — the caller needs to see what's configured

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -202,7 +202,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: {
       name: 'metrics_validate',
       description:
-        'Test whether a query is syntactically valid and executes through both instant and dashboard range-query paths. Use as the validation gate before dashboard_add_panels — catches bad PromQL before it lands in a panel.',
+        'Runs the query and reports the actual result shape (series count, labels present, sample values, and a flag when a by() grouping collapsed) so you can judge whether it returns what you intended — a query that merely runs is not necessarily correct. Use as the gate before dashboard_add_panels.',
       input_schema: {
         type: 'object',
         properties: {
@@ -1191,6 +1191,26 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
           },
         },
         required: ['query'],
+      },
+    },
+  },
+
+  'load_task_context': {
+    category: 'always-on',
+    schema: {
+      name: 'load_task_context',
+      description:
+        'Load the detailed playbook for the task shape you are about to work on. The base prompt is intentionally small; the worked examples, query patterns, panel-correctness rules, and knowledge-base protocol for each task live here and are returned as the observation.\n\nCall this ONCE, right after you have identified the task shape from the decision flow and before doing the heavy work. Modes:\n- "dashboard_build" — building or editing a dashboard / its panels.\n- "investigate" — "why is X high/slow/broken", incident diagnosis, writing an investigation report.\n- "alert_author" — creating or editing an alert rule.\n- "ad_hoc_explore" — "show me / what is / how is" a metric value (renders an inline chart), or a numeric breakdown.\n- "ops_command" — mutating cluster state (scale / delete / install / apply).\n\nDo NOT call it for trivial conversational answers ("what does rate() do?") or for opening/listing existing resources — the base prompt already covers those. Do NOT call it more than once for the same task unless the shape genuinely changes mid-conversation.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['dashboard_build', 'investigate', 'alert_author', 'ad_hoc_explore', 'ops_command'],
+            description: 'The task shape whose playbook to load.',
+          },
+        },
+        required: ['mode'],
       },
     },
   },

--- a/packages/api-gateway/src/services/agent-run-registry.ts
+++ b/packages/api-gateway/src/services/agent-run-registry.ts
@@ -18,6 +18,7 @@
  * resume across restarts. Documented v1 limitation.
  */
 import { randomUUID } from 'node:crypto';
+import { setMaxListeners } from 'node:events';
 import { createLogger } from '@agentic-obs/server-utils/logging';
 
 const log = createLogger('agent-run-registry');
@@ -100,6 +101,12 @@ export class AgentRunRegistry {
       status: 'running',
       controller: new AbortController(),
     };
+    // One run's signal is forwarded to every concurrent operation (each LLM
+    // request, each tool fetch, the chat-route once-listener). fetch() briefly
+    // attaches/detaches an internal abort listener per call, which trips Node's
+    // default cap of 10 and logs MaxListenersExceededWarning. No real leak —
+    // raise the cap on this signal so the warning doesn't fire under load.
+    setMaxListeners(50, record.controller.signal);
     this.runs.set(runId, record);
     this.activeBySession.set(args.sessionId, runId);
     return record;

--- a/packages/web/src/components/chat/OpsCommandConfirmCard.tsx
+++ b/packages/web/src/components/chat/OpsCommandConfirmCard.tsx
@@ -14,7 +14,16 @@ export default function OpsCommandConfirmCard({
   const [error, setError] = useState(confirmation.error ?? '');
   const [busy, setBusy] = useState(false);
   useEffect(() => {
-    if (confirmation.status && confirmation.status !== status) {
+    // Only adopt the prop when it's a RESOLVED (non-pending) status. The
+    // parent overlay-merge is async, so right after an optimistic
+    // setStatus('executed') the prop can still read 'pending' for a render;
+    // without this guard the effect would downgrade the optimistic status
+    // back to pending and the card looks frozen.
+    if (
+      confirmation.status &&
+      confirmation.status !== 'pending' &&
+      confirmation.status !== status
+    ) {
       setStatus(confirmation.status);
       setOutput(confirmation.output ?? '');
       setError(confirmation.error ?? '');
@@ -41,6 +50,20 @@ export default function OpsCommandConfirmCard({
           setStatus('expired');
           setError(message);
           onResolved?.({ ...confirmation, status: 'expired', error: message });
+          return;
+        }
+        // 409 = the command already ran (or was already rejected) on a prior
+        // click. It's resolved, not failed — reflect the real terminal status
+        // instead of throwing a scary "failed".
+        if (
+          apiError.code === 'CONFLICT' ||
+          (apiError as { status?: number }).status === 409
+        ) {
+          const resolvedStatus = /reject/i.test(apiError.message ?? '')
+            ? 'rejected'
+            : 'executed';
+          setStatus(resolvedStatus);
+          onResolved?.({ ...confirmation, status: resolvedStatus });
           return;
         }
         throw new Error(apiError.message);

--- a/packages/web/src/components/viz/BarViz.tsx
+++ b/packages/web/src/components/viz/BarViz.tsx
@@ -18,7 +18,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { formatValueForDisplay } from '../../lib/format/index.js';
 import {
   VIZ_TOKENS,
-  getSeriesColorByKey,
+  getSeriesColor,
   resolveThresholdColor,
   type Threshold,
 } from '../../lib/theme/index.js';
@@ -105,12 +105,12 @@ function prepareItems(
   const cap = Math.max(0, maxItems);
   const clipped = sorted.slice(0, cap);
   const overflowCount = Math.max(0, sorted.length - cap);
-  const prepared = clipped.map((it) => ({
+  const prepared = clipped.map((it, idx) => ({
     ...it,
     displayLabel: truncate(it.label, LABEL_CHAR_BUDGET),
     fill:
       it.color ??
-      resolveThresholdColor(it.value, thresholds, getSeriesColorByKey(it.label)),
+      resolveThresholdColor(it.value, thresholds, getSeriesColor(idx)),
   }));
   return { prepared, overflowCount };
 }

--- a/packages/web/src/components/viz/PieViz.tsx
+++ b/packages/web/src/components/viz/PieViz.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { formatValueForDisplay } from '../../lib/format/index.js';
-import { getSeriesColorByKey } from '../../lib/theme/index.js';
+import { getSeriesColor } from '../../lib/theme/index.js';
 
 /**
  * A single wedge in the pie. `color` is optional — when omitted the component
@@ -100,7 +100,7 @@ function buildSlices(items: PieItem[], maxSlices: number): {
     otherSum > 0 ? [...head, { label: OTHER_LABEL, value: otherSum }] : head;
 
   let cursor = 0;
-  const slices: Slice[] = working.map((item) => {
+  const slices: Slice[] = working.map((item, idx) => {
     const frac = item.value / total;
     const startAngle = cursor;
     const endAngle = cursor + frac * 360;
@@ -109,7 +109,7 @@ function buildSlices(items: PieItem[], maxSlices: number): {
       item.color ??
       (item.label === OTHER_LABEL
         ? OTHER_COLOR
-        : getSeriesColorByKey(item.label));
+        : getSeriesColor(idx));
     return {
       label: item.label,
       value: item.value,

--- a/packages/web/src/components/viz/TimeSeriesViz.tsx
+++ b/packages/web/src/components/viz/TimeSeriesViz.tsx
@@ -47,7 +47,7 @@ import {
   type NullMode,
   type StackingMode,
 } from '../../lib/uplot/index.js';
-import { getSeriesColor, getSeriesColorByKey, VIZ_TOKENS } from '../../lib/theme/index.js';
+import { getSeriesColor, VIZ_TOKENS } from '../../lib/theme/index.js';
 import {
   decideLegendLayout,
   usePanelLayout,
@@ -159,12 +159,6 @@ function defaultDisplayName(input: SeriesInput, index: number): string {
   return `series ${index + 1}`;
 }
 
-function stableKey(labels: Record<string, string>, fallback: string): string {
-  const keys = Object.keys(labels).sort();
-  if (keys.length === 0) return fallback;
-  return keys.map((k) => `${k}=${labels[k]}`).join(',');
-}
-
 // ---------------------------------------------------------------------------
 // Series metadata captured at build time. Kept parallel to `frames` so we can
 // look up colors + stats from the React side (uPlot's options tree has them
@@ -230,17 +224,25 @@ function buildViz(props: TimeSeriesVizProps): BuildResult {
 
   const frames: DataFrame[] = [];
   const metas: SeriesMeta[] = [];
+  // Raw, pre-stacking points per series. The chart draws stacked data, but
+  // stats/tooltip must read each series' own value — under stacking the
+  // post-build `data` array carries cumulative totals (each series sits at the
+  // height of the ones below it), so reading stats back out of it reports the
+  // wrong number for every series above the dominant one.
+  const rawSeries: Array<{ timestamps: number[]; values: Array<number | null> }> = [];
 
   series.forEach((s, i) => {
     const displayName = defaultDisplayName(s, i);
-    const key = stableKey(s.labels, displayName);
-    const color =
-      Object.keys(s.labels).length > 0 ? getSeriesColorByKey(key) : getSeriesColor(i);
+    // Color by series order (Grafana classic-palette default): collision-free
+    // for the first 8 series, then cycles. Hashing the label set into 8 slots
+    // collided ~79% of the time at 5 series.
+    const color = getSeriesColor(i);
 
     const timestamps = s.points.map((p) => p.ts);
     const values = s.points.map((p) =>
       typeof p.value === 'number' && !Number.isNaN(p.value) ? p.value : (null as unknown as number),
     );
+    rawSeries.push({ timestamps, values });
 
     const frame = createTimeSeriesFrame({
       name: displayName,
@@ -277,32 +279,43 @@ function buildViz(props: TimeSeriesVizProps): BuildResult {
   if (unit !== undefined) builder.setUnit(unit);
   if (thresholds !== undefined) builder.setThresholds(thresholds);
   if (lineWidth !== undefined) builder.setLineWidth(lineWidth);
-  const effectiveFillOpacity =
-    fillOpacity !== undefined
-      ? fillOpacity
-      : stacking !== 'none'
-        ? 80
-        : series.length <= 4
-          ? 15
-          : 0;
+  // Grafana defaults: unstacked panels render as plain lines (no fill);
+  // stacked panels get a visible band so the composition reads. An explicit
+  // panel `fillOpacity` always wins.
+  const effectiveFillOpacity = fillOpacity ?? (stacking !== 'none' ? 80 : 0);
   builder.setFillOpacity(effectiveFillOpacity);
   if (showPoints !== undefined) builder.setShowPoints(showPoints);
   if (yScale !== undefined) builder.setYScale(yScale);
 
   const { options, data } = builder.build();
 
-  // `data` is [xs, ...seriesValues]. Pull the aligned series arrays back out
-  // so the React side can compute last/min/max/mean against the same vectors
-  // uPlot is drawing. This keeps the legend numbers honest under stacking
-  // (they reflect the stacked totals, which is what the user sees).
+  // `data[0]` is the union x-axis — identical with or without stacking. Project
+  // each series' RAW (pre-stacking) points onto it for stats/tooltip, so the
+  // reported numbers are each series' own value, not its stacked total. The
+  // chart still draws the stacked `data`.
   const rawData = data as unknown as ReadonlyArray<ReadonlyArray<number | null>>;
   const xs = (rawData[0] ?? []) as ReadonlyArray<number>;
   for (let i = 0; i < metas.length; i += 1) {
-    const aligned = (rawData[i + 1] ?? []) as ReadonlyArray<number | null>;
-    const values = aligned.slice();
     const meta = metas[i]!;
-    meta.values = values;
-    Object.assign(meta, computeStats(values));
+    const raw = rawSeries[i];
+    const byTs = new Map<number, number | null>();
+    if (raw) {
+      for (let j = 0; j < raw.timestamps.length; j += 1) {
+        const t = raw.timestamps[j];
+        if (t === undefined) continue;
+        byTs.set(t, raw.values[j] ?? null);
+      }
+    }
+
+    const aligned: Array<number | null> = new Array(xs.length);
+    for (let j = 0; j < xs.length; j += 1) {
+      const t = xs[j] as number;
+      const v = byTs.get(t);
+      aligned[j] = v === undefined ? null : v;
+    }
+
+    meta.values = aligned;
+    Object.assign(meta, computeStats(aligned));
   }
 
   return { frames, metas, xs: xs.slice(), options, data };
@@ -875,7 +888,6 @@ interface TooltipLayerProps {
 
 const TOOLTIP_HEADER_PX = 36;
 const TOOLTIP_ROW_PX = 22;
-const LOOKBACK_SAMPLES = 10;
 
 function TooltipLayer({ tooltip, xs, metas, hidden, unit, containerRef, maxWidth }: TooltipLayerProps): JSX.Element {
   const ts = xs[tooltip.idx];
@@ -966,18 +978,13 @@ function TooltipLayer({ tooltip, xs, metas, hidden, unit, containerRef, maxWidth
         </div>
         {metas.map((meta) => {
           if (hidden[meta.displayName]) return null;
-          // Look back up to LOOKBACK_SAMPLES samples to find the nearest
-          // non-null value. topk()/instant-switch queries leave gaps; the
-          // pre-lookback tooltip showed dashes at every gap. Hide the row
-          // entirely if nothing was found in range.
-          let v: number | null = null;
-          for (let i = 0; i <= LOOKBACK_SAMPLES && tooltip.idx - i >= 0; i++) {
-            const candidate = meta.values[tooltip.idx - i];
-            if (candidate != null) {
-              v = candidate;
-              break;
-            }
-          }
+          // Read the value at the cursor index ONLY. A lookback scan made
+          // gapped series show a stale neighbor's value at the gap, so two
+          // series with a hole at the cursor looked identical. If the value
+          // here isn't a finite number, omit the row.
+          const rawAtCursor = meta.values[tooltip.idx];
+          const v =
+            typeof rawAtCursor === 'number' && Number.isFinite(rawAtCursor) ? rawAtCursor : null;
           if (v === null) return null;
           return (
             <div

--- a/packages/web/src/lib/uplot/config-builder.ts
+++ b/packages/web/src/lib/uplot/config-builder.ts
@@ -470,12 +470,29 @@ export class UPlotConfigBuilder {
     // consumed by uPlot opts (visualization layer will wire it via bands).
     void this.thresholds;
 
+    // Stacking bands. The step-3 accumulation makes the first data series the
+    // bottom of the stack; each subsequent series should fill DOWN to the one
+    // below it rather than to the zero baseline. Without bands, uPlot fills
+    // every series from its line to baseline — and since cumulative totals are
+    // nearly equal when one series dominates, the translucent fills overlap
+    // from 0→total and blend into one muddy color. A band [high, low] clips
+    // the high series' fill to the low series, giving distinct per-series bands
+    // whose thickness equals the real value. uPlot series indices are 1-based
+    // (series[0] is x), so series k fills down to series k-1.
+    const stackBands: uPlot.Band[] =
+      this.stacking !== 'none' && fillOpacity > 0
+        ? this.series.slice(1).map((_, i) => ({
+            series: [i + 2, i + 1] as [number, number],
+          }))
+        : [];
+
     const options: uPlot.Options = {
       width: 600, // overridden by UPlotChart via ResizeObserver
       height: this.height,
       series: uplotSeries,
       axes: [xAxis, yAxis],
       scales,
+      bands: stackBands,
       legend: { show: legendShow },
       // Cursor marker config: at the crosshair, draw one filled circle per
       // series at twice the resting-point size, coloured the same as the


### PR DESCRIPTION
Re-applies the batch documented in `internal-docs/dashboard-quality-fixes.md`. Each theme is problem → root cause → fix.

## 1. Time-series rendering (Grafana parity) — `web`
- **1a** Stacked legend/tooltip showed cumulative totals. Now capture raw pre-stacking points per series and project them onto the union x-axis for stats/tooltip; the chart still draws stacked data.
- **1b** Tooltip showed a stale neighbor value at gaps. Now read the value at the cursor index only; omit the row if it isn't finite.
- **1c** Stacked fills blended into one muddy color. Emit uPlot `bands` so series `k` fills down to `k-1` instead of baseline.
- **1d** `fillOpacity` default → Grafana: unstacked = lines (0), stacked = visible band (80). Explicit panel value still wins.
- **1e** 5+ series collided colors (label-hash into 8 slots, ~79% collision). Color by series order (classic palette); `BarViz`/`PieViz` too. `getSeriesColorByKey` kept as the config-builder fallback.

## 2. `metrics_validate` → evidence-based — `agent-core`
Old handler discarded the result and returned a bare "Valid query", so collapsed groupings / >100% ratios / cardinality blow-ups passed. Now it runs the query and returns the **result shape** — series count, labels present, per-series last/min/max (≤8 rows), and a factual collapse flag when a `by()` label is absent — and lets the model judge against intent. The `validatedQueries` gate behind `dashboard_add_panels` is preserved.

## 3. Ops-command confirm card stuck on PENDING — `web`
The `useEffect` re-synced from the prop while the async parent merge still read `pending`, downgrading the optimistic `executed`. Now the effect only adopts a resolved (non-pending) prop, and a 409 in `execute()` is treated as already-resolved instead of `failed`.

## 4. `load_task_context` — split the monolithic prompt — `agent-core`
The ~770-line system prompt became a small base + five on-demand modules (`dashboard_build`, `investigate`, `alert_author`, `ad_hoc_explore`, `ops_command`) the agent self-loads via a new always-on tool. New handler `load-task-context.ts`; wired through types/registry/permissions/runner.

## 5. Prompt content → principles — `agent-core`
Legend, stacking, KB-as-baseline, and post-save authoring self-check rewritten as principles rather than rigid rules.

## 6. MaxListeners warning on the run abort signal — `api-gateway`
`setMaxListeners(50, record.controller.signal)` when creating the run record — `fetch()` briefly adds/removes an internal abort listener per call and tripped Node's default cap of 10. No real leak.

## Scope
Exactly the 18 files from the spec (17 modified + new `load-task-context.ts`). The 4 changes that were in the working tree but **not** in the spec (StatViz, DashboardGrid, DashboardWorkspace) were intentionally left out.

## Verification
- `tsc --noEmit` clean for both `web` and `agent-core`
- 54 tests pass: `metrics.test.ts` (incl. new evidence-shape + collapse-warning cases), `dashboard-build-flow.regression.test.ts`, `orchestrator-prompt.test.ts` (31 — base-prompt invariants intact after the restructure)
- Launched locally in demo mode; both servers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand task context loading for optimized agent guidance across different workflow modes
  * Enhanced metrics validation to display detailed query results including series count, labels, and sample values

* **Bug Fixes**
  * Improved conflict handling in operation confirmations with better status resolution
  * Fixed tooltip accuracy in time-series charts to display exact values at cursor position
  * Corrected color selection consistency across bar, pie, and time-series visualizations
  * Enhanced stacked chart rendering with proper fill banding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syntropize-ai/rounds/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->