### PR TITLE
Defer resource creation until content is ready

### DIFF
--- a/packages/agent-core/src/agent/factory.test.ts
+++ b/packages/agent-core/src/agent/factory.test.ts
@@ -19,7 +19,7 @@ import { AdapterRegistry } from '../adapters/index.js';
 import { ActionExecutor } from './action-executor.js';
 import { buildActionContext } from './orchestrator-action-context.js';
 import { createAgentRunner } from './factory.js';
-import { handleDashboardCreate } from './handlers/dashboard.js';
+import { handleDashboardAddPanels, handleDashboardCreate } from './handlers/dashboard.js';
 import type { IAuditWriter } from './types-permissions.js';
 
 function makeIdentity(): Identity {
@@ -66,23 +66,26 @@ describe('audit-writer bridge', () => {
 
     // Build context the same way the factory-built runner does: route the
     // structured writer through the bridge.
-    const ctx = buildActionContext(
-      makeContextDeps({
-        auditEntryWriter: (entry) => writer.log(entry),
-      }),
-      makeContextRuntime(),
-    );
+    const deps = makeContextDeps({
+      auditEntryWriter: (entry) => writer.log(entry),
+    });
+    const runtime = makeContextRuntime();
+    runtime.actionExecutor = new ActionExecutor(deps.store, deps.sendEvent);
+    const ctx = buildActionContext(deps, runtime);
 
     expect(ctx.auditWriter).toBeDefined();
 
-    // Invoke the dashboard.create handler and assert the audit row reached
-    // the underlying AuditWriter.
+    // Invoke create + first panel write and assert the audit row reached
+    // the underlying AuditWriter when the dashboard is actually persisted.
     const result = await handleDashboardCreate(ctx, {
       title: 'Latency overview',
       datasourceId: 'ds-prod',
     });
+    await handleDashboardAddPanels(ctx, {
+      panels: [{ title: 'p1', description: 'Q: status?', visualization: 'time_series', queries: [] }],
+    });
 
-    expect(result).toContain('Created dashboard');
+    expect(result).toContain('Prepared dashboard');
     // The handler fires-and-forgets; give the microtask queue a tick.
     await new Promise((r) => setTimeout(r, 0));
 
@@ -110,15 +113,30 @@ function makeContextDeps(overrides: {
     id: 'dash-1',
     title: 'Latency overview',
     workspaceId: 'org1',
+    description: '',
+    prompt: '',
+    panels: [],
+    variables: [],
+    source: 'ai_generated',
   };
+  const dashboards = new Map<string, Record<string, unknown>>();
   return {
     gateway: {} as never,
     model: 'test-model',
     store: {
-      create: vi.fn(async (input: Record<string, unknown>) => ({
-        ...input,
-        ...created,
-      })),
+      create: vi.fn(async (input: Record<string, unknown>) => {
+        const dashboard = { ...input, ...created };
+        dashboards.set(String(dashboard.id), dashboard);
+        return dashboard;
+      }),
+      findById: vi.fn(async (id: string) => dashboards.get(id)),
+      updatePanels: vi.fn(async (id: string, panels: unknown[]) => {
+        const dashboard = dashboards.get(id);
+        if (dashboard) dashboard.panels = panels;
+      }),
+      updateVariables: vi.fn(),
+      update: vi.fn(),
+      updateStatus: vi.fn(),
     } as never,
     conversationStore: {} as never,
     investigationReportStore: {} as never,
@@ -147,6 +165,8 @@ function makeContextRuntime(): Parameters<typeof buildActionContext>[1] {
     recordCreatedResource: () => undefined,
     investigationSections: new Map(),
     investigationProvenance: new Map(),
+    pendingDashboardCreates: new Map(),
+    pendingInvestigationCreates: new Map(),
     activeInvestigationIdRef: { current: null },
     activeDashboardIdRef: { current: null },
     freshlyCreatedDashboards: new Set<string>(),

--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard-build-flow.regression.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard-build-flow.regression.test.ts
@@ -122,14 +122,15 @@ describe('regression: dashboard build flow (connectors -> discover -> validate -
     expect(validate).toMatch(/\d+ series/);
     expect(ctx.dashboardBuildEvidence.validatedQueries.has(expr)).toBe(true);
 
-    // 4) Create dashboard — sets activeDashboardId and marks it freshly created.
+    // 4) Prepare dashboard — sets a draft activeDashboardId without creating
+    //    the row until panel content is ready.
     const create = await handleDashboardCreate(ctx, {
       title: 'Latency',
       datasourceId: 'prom',
     });
-    expect(create).toContain('Created dashboard "Latency"');
-    expect(ctx.activeDashboardId).toBe('dash-1');
-    expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(true);
+    expect(create).toContain('Prepared dashboard "Latency"');
+    expect(ctx.activeDashboardId).toMatch(/^draft_dashboard_/);
+    expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(false);
 
     // 5) Add panels with the validated expression — passes both the
     //    research gate (metricDiscoveryCount > 0) AND the validation gate
@@ -145,6 +146,8 @@ describe('regression: dashboard build flow (connectors -> discover -> validate -
       ],
     });
     expect(addPanels).toContain('Added 1 panel(s): Request rate');
+    expect(ctx.activeDashboardId).toBe('dash-1');
+    expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(true);
     expect(ctx.actionExecutor.execute).toHaveBeenCalledWith(
       'dash-1',
       [expect.objectContaining({ type: 'add_panels' })],

--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
@@ -15,7 +15,7 @@ import { makeTestIdentity } from '../../test-helpers.js';
 
 describe('dashboard handlers', () => {
   describe('handleDashboardCreate', () => {
-    it('creates a dashboard scoped to the caller orgId and emits tool_call/result', async () => {
+    it('prepares a dashboard draft and emits tool_call/result without persisting yet', async () => {
       const create = vi.fn().mockResolvedValue({
         id: 'dash-1',
         title: 'My Dashboard',
@@ -27,17 +27,18 @@ describe('dashboard handlers', () => {
 
       const observation = await handleDashboardCreate(ctx, { title: 'My Dashboard', datasourceId: 'prom-test' });
 
-      expect(create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'My Dashboard',
-          workspaceId: 'org-7',
-        }),
-      );
-      expect(observation).toContain('Created dashboard "My Dashboard"');
+      expect(create).not.toHaveBeenCalled();
+      expect(observation).toContain('Prepared dashboard "My Dashboard"');
       // Active id is set so the next add_panels / modify_panel call in the
       // same ReAct loop can target this dashboard implicitly.
-      expect(ctx.activeDashboardId).toBe('dash-1');
-      expect(ctx.setNavigateTo).toHaveBeenCalledWith('/dashboards/dash-1');
+      expect(ctx.activeDashboardId).toMatch(/^draft_dashboard_/);
+      expect(ctx.pendingDashboardCreates.get(ctx.activeDashboardId!)).toEqual(
+        expect.objectContaining({
+          title: 'My Dashboard',
+          datasourceId: 'prom-test',
+        }),
+      );
+      expect(ctx.setNavigateTo).not.toHaveBeenCalled();
       expect(ctx.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'tool_call', tool: 'dashboard_create' }),
       );
@@ -56,15 +57,39 @@ describe('dashboard handlers', () => {
       expect(ctx.sendEvent).not.toHaveBeenCalled();
     });
 
-    it('emits tool_result with success: false and rethrows when the store create throws', async () => {
-      const create = vi.fn().mockRejectedValue(new Error('db down'));
+    it('persists the draft when panels are ready', async () => {
       const ctx = makeFakeActionContext({
-        store: { create, findById: vi.fn(), update: vi.fn(), updatePanels: vi.fn(), updateVariables: vi.fn() } as never,
+        store: {
+          create: vi.fn().mockResolvedValue({ id: 'dash-1', title: 'My Dashboard' }),
+          findById: vi.fn(),
+          update: vi.fn(),
+          updatePanels: vi.fn(),
+          updateVariables: vi.fn(),
+          updateStatus: vi.fn(),
+        } as never,
+        identity: makeTestIdentity({ orgId: 'org-7' }),
       });
-      await expect(handleDashboardCreate(ctx, { title: 'X', datasourceId: 'prom-test' })).rejects.toThrow('db down');
-      expect(ctx.sendEvent).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'tool_result', tool: 'dashboard_create', summary: 'db down' }),
+      await handleDashboardCreate(ctx, { title: 'My Dashboard', datasourceId: 'prom-test' });
+
+      const observation = await handleDashboardAddPanels(ctx, {
+        panels: [{ title: 'p1', description: 'Q: status?', visualization: 'time_series', queries: [] }],
+      });
+
+      expect(ctx.store.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'My Dashboard',
+          workspaceId: 'org-7',
+          datasourceIds: ['prom-test'],
+        }),
       );
+      expect(ctx.actionExecutor.execute).toHaveBeenCalledWith('dash-1', [
+        expect.objectContaining({ type: 'add_panels' }),
+      ]);
+      expect(ctx.pendingDashboardCreates.size).toBe(0);
+      expect(ctx.activeDashboardId).toBe('dash-1');
+      expect(ctx.setNavigateTo).toHaveBeenCalledWith('/dashboards/dash-1');
+      expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(true);
+      expect(observation).toContain('Added 1 panel(s): p1');
     });
   });
 
@@ -570,6 +595,10 @@ describe('dashboard handlers', () => {
         store: { create, findById: vi.fn(), update: vi.fn(), updatePanels: vi.fn(), updateVariables: vi.fn() } as never,
       });
       await handleDashboardCreate(ctx, { title: 'My Dashboard', datasourceId: 'prom-test' });
+      expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(false);
+      await handleDashboardAddPanels(ctx, {
+        panels: [{ title: 'p1', description: 'Q: status?', visualization: 'time_series', queries: [] }],
+      });
       expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(true);
       // Now a follow-up modify should apply directly (no pending).
       await handleDashboardAddVariable(ctx, { name: 'env', type: 'custom' });

--- a/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts
@@ -88,6 +88,7 @@ describe('dashboard handlers', () => {
       expect(ctx.pendingDashboardCreates.size).toBe(0);
       expect(ctx.activeDashboardId).toBe('dash-1');
       expect(ctx.setNavigateTo).toHaveBeenCalledWith('/dashboards/dash-1');
+      expect(ctx.sendEvent).toHaveBeenCalledWith({ type: 'navigate', path: '/dashboards/dash-1' });
       expect(ctx.freshlyCreatedDashboards.has('dash-1')).toBe(true);
       expect(observation).toContain('Added 1 panel(s): p1');
     });

--- a/packages/agent-core/src/agent/handlers/__tests__/github-tools.test.ts
+++ b/packages/agent-core/src/agent/handlers/__tests__/github-tools.test.ts
@@ -32,6 +32,8 @@ function makeCtx(overrides: Partial<ActionContext> = {}): ActionContext {
     recordCreatedResource: vi.fn(),
     investigationSections: new Map(),
     investigationProvenance: new Map(),
+    pendingDashboardCreates: new Map(),
+    pendingInvestigationCreates: new Map(),
     activeInvestigationId: null,
     activeDashboardId: null,
     freshlyCreatedDashboards: new Set(),

--- a/packages/agent-core/src/agent/handlers/_context.ts
+++ b/packages/agent-core/src/agent/handlers/_context.ts
@@ -38,6 +38,17 @@ import type { IPanelEventRepository } from '../panel-event-recorder.js';
 import type { IPendingChangeRepository } from '@agentic-obs/data-layer';
 import type { AuditVerdict } from '../auditor-prompt.js';
 
+export interface PendingDashboardCreate {
+  title: string;
+  description: string;
+  prompt: string;
+  datasourceId: string;
+}
+
+export interface PendingInvestigationCreate {
+  question: string;
+}
+
 /** Shared context passed to every action handler. */
 export interface ActionContext {
   gateway: LLMGateway;
@@ -190,6 +201,17 @@ export interface ActionContext {
    * fields are missing.
    */
   investigationProvenance: Map<string, Provenance & { startedAt?: number; auditorRounds?: number; reportId?: string }>;
+  /**
+   * Dashboard create requests held in memory until the first panel write.
+   * This avoids showing an empty dashboard shell while the agent is still
+   * researching and validating the content.
+   */
+  pendingDashboardCreates: Map<string, PendingDashboardCreate>;
+  /**
+   * Investigation create requests held in memory until completion. Sections
+   * still accumulate against the draft id, then move to the persisted id.
+   */
+  pendingInvestigationCreates: Map<string, PendingInvestigationCreate>;
   /**
    * Active investigation id for this session. Set by `investigation_create`,
    * cleared by `investigation_complete`. `add_section` and `complete` read

--- a/packages/agent-core/src/agent/handlers/_test-helpers.ts
+++ b/packages/agent-core/src/agent/handlers/_test-helpers.ts
@@ -74,6 +74,8 @@ export function makeFakeActionContext(
     recordCreatedResource,
     investigationSections: new Map(),
     investigationProvenance: new Map(),
+    pendingDashboardCreates: new Map(),
+    pendingInvestigationCreates: new Map(),
     activeInvestigationId: null,
     activeDashboardId: null,
     freshlyCreatedDashboards: new Set<string>(),

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -704,6 +704,7 @@ async function runAddPanels(
     ctx.activeDashboardId = created.id;
     ctx.freshlyCreatedDashboards.add(created.id);
     ctx.setNavigateTo(`/dashboards/${created.id}`);
+    ctx.sendEvent({ type: 'navigate', path: `/dashboards/${created.id}` });
     ctx.recordCreatedResource('dashboard', created.id);
     void ctx.auditWriter?.({
       action: AuditAction.DashboardCreate,
@@ -746,7 +747,7 @@ async function runAddPanels(
   for (const panel of panelConfigs) {
     ctx.sendEvent({ type: 'panel_added', panel } as never);
   }
-  ctx.emitAgentEvent(ctx.makeAgentEvent('agent.tool_completed', { tool: 'dashboard_add_panels', summary: observationText }));
+  ctx.emitAgentEvent(ctx.makeAgentEvent('agent.tool_completed', { tool: 'dashboard_add_panels', dashboardId: targetDashboardId, summary: observationText }));
   return observationText;
 }
 

--- a/packages/agent-core/src/agent/handlers/dashboard.ts
+++ b/packages/agent-core/src/agent/handlers/dashboard.ts
@@ -363,70 +363,30 @@ export async function handleDashboardCreate(
     return 'Error: "datasourceId" is required. Call connectors_list (or connectors_suggest) first to choose the primary connector for this dashboard.';
   }
 
-  let createdId = '';
+  let draftId = '';
   let observationText = '';
   await withToolEventBoundary(
     ctx.sendEvent,
     'dashboard_create',
     { title, datasourceId },
-    `Creating dashboard: "${title}"`,
+    `Preparing dashboard: "${title}"`,
     async () => {
-      // Scope the new dashboard to the caller's org; the detail route enforces
-      // workspaceId equality, so missing this field makes the redirect land on
-      // "Dashboard not found" even though the row is in the store.
-      const dashboard = await ctx.store.create!(
-        withWorkspaceScope(ctx.identity, {
-          title,
-          description,
-          prompt,
-          userId: 'agent',
-          // Stored as an array (dashboards may bind multiple sources for cross-
-          // env comparison panels); the first id is the dashboard's primary
-          // and acts as the fallback for any query that omits its own ds id.
-          datasourceIds: [datasourceId],
-          sessionId: ctx.sessionId,
-          // Agent-tool created — see writable-gate.ts for source taxonomy.
-          source: 'ai_generated',
-        }),
-      );
-
-      // Navigate to the new dashboard so the user can see panels being added.
-      // Separately record the create relationship — `setNavigateTo` only
-      // remembers the latest URL, so multi-create turns (LLM asked for two
-      // dashboards in one message) would otherwise leave the non-navigated
-      // dashboard without a chat-session linkage and the chat panel would
-      // render blank when the user opened it.
-      ctx.setNavigateTo(`/dashboards/${dashboard.id}`);
-      ctx.recordCreatedResource('dashboard', dashboard.id);
-
-      createdId = dashboard.id;
-      void ctx.auditWriter?.({
-        action: AuditAction.DashboardCreate,
-        actorType: 'user',
-        actorId: ctx.identity.userId,
-        orgId: ctx.identity.orgId,
-        targetType: 'dashboard',
-        targetId: dashboard.id,
-        targetName: dashboard.title,
-        outcome: 'success',
-        metadata: { datasourceId, via: 'agent_tool' },
+      draftId = `draft_dashboard_${randomUUID()}`;
+      ctx.pendingDashboardCreates.set(draftId, {
+        title,
+        description,
+        prompt,
+        datasourceId,
       });
-      // Mark this dashboard as the active one for the session — subsequent
-      // dashboard_add_panels / modify_panel / etc. calls in this ReAct loop
-      // pick it up implicitly instead of taking a (truncatable) id param.
-      ctx.activeDashboardId = createdId;
-      // Task 09 — initial population (add_panels, etc.) on a freshly-created
-      // dashboard applies directly; only mutations to pre-existing dashboards
-      // funnel through pendingChanges.
-      ctx.freshlyCreatedDashboards.add(createdId);
-      observationText = `Created dashboard "${dashboard.title}" (id: ${dashboard.id}).`;
+      ctx.activeDashboardId = draftId;
+      observationText = `Prepared dashboard "${title}" (draft id: ${draftId}). It will be created when panels are ready.`;
       return observationText;
     },
   );
   ctx.emitAgentEvent(
     ctx.makeAgentEvent('agent.tool_completed', {
       tool: 'dashboard_create',
-      dashboardId: createdId,
+      dashboardId: draftId,
       summary: observationText,
     }),
   );
@@ -625,7 +585,14 @@ export async function handleDashboardAddPanels(
     // message so the UI can render an actionable state, then rethrow so
     // the orchestrator's outer error handling still runs.
     const msg = err instanceof Error ? err.message : String(err);
-    await tryUpdateDashboardStatus(ctx, dashboardId, 'failed', msg);
+    const failureDashboardId = ctx.pendingDashboardCreates.has(dashboardId)
+      ? null
+      : dashboardId.startsWith('draft_dashboard_')
+        ? ctx.activeDashboardId
+        : dashboardId;
+    if (failureDashboardId && !failureDashboardId.startsWith('draft_dashboard_')) {
+      await tryUpdateDashboardStatus(ctx, failureDashboardId, 'failed', msg);
+    }
     ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_panels', summary: msg });
     throw err;
   }
@@ -718,25 +685,57 @@ async function runAddPanels(
 
   // Apply auto-layout, then offset below existing panels
   const laidOut = applyLayout(rawPanels);
-  const existing = await ctx.store.findById(dashboardId);
+  const pendingCreate = ctx.pendingDashboardCreates.get(dashboardId);
+  let targetDashboardId = dashboardId;
+  if (pendingCreate) {
+    const created = await ctx.store.create!(
+      withWorkspaceScope(ctx.identity, {
+        title: pendingCreate.title,
+        description: pendingCreate.description,
+        prompt: pendingCreate.prompt,
+        userId: 'agent',
+        datasourceIds: [pendingCreate.datasourceId],
+        sessionId: ctx.sessionId,
+        source: 'ai_generated',
+      }),
+    );
+    targetDashboardId = created.id;
+    ctx.pendingDashboardCreates.delete(dashboardId);
+    ctx.activeDashboardId = created.id;
+    ctx.freshlyCreatedDashboards.add(created.id);
+    ctx.setNavigateTo(`/dashboards/${created.id}`);
+    ctx.recordCreatedResource('dashboard', created.id);
+    void ctx.auditWriter?.({
+      action: AuditAction.DashboardCreate,
+      actorType: 'user',
+      actorId: ctx.identity.userId,
+      orgId: ctx.identity.orgId,
+      targetType: 'dashboard',
+      targetId: created.id,
+      targetName: created.title,
+      outcome: 'success',
+      metadata: { datasourceId: pendingCreate.datasourceId, via: 'agent_tool' },
+    });
+  }
+  const existing = pendingCreate ? null : await ctx.store.findById(targetDashboardId);
   const startRow = existing
     ? Math.max(0, ...existing.panels.map((p) => p.row + p.height))
     : 0;
   const panelConfigs = laidOut.map((p) => ({ ...p, row: p.row + startRow }));
 
-  await ctx.actionExecutor.execute(dashboardId, [{ type: 'add_panels', panels: panelConfigs }]);
+  await ctx.actionExecutor.execute(targetDashboardId, [{ type: 'add_panels', panels: panelConfigs }]);
 
   // Flip the dashboard out of its initial 'generating' state once it has
   // real panels — the list page shows a yellow "GENERATING" badge until
   // status becomes 'ready', which looked wrong for a dashboard the user
   // can already open and see populated. tryUpdateDashboardStatus logs +
   // emits an SSE error if the status write itself fails.
-  await tryUpdateDashboardStatus(ctx, dashboardId, 'ready');
+  await tryUpdateDashboardStatus(ctx, targetDashboardId, 'ready');
 
   // Fire panel_events rows for the freshly-added panels. The Express route
   // does not see this path (agent CRUD bypasses POST /api/dashboards), so
   // without this hook agent-only sessions leave panel_events empty.
-  recordPanelEvents(ctx, dashboardId, panelConfigs, 'created');
+  recordPanelEvents(ctx, targetDashboardId, panelConfigs, 'created');
 
   const observationText = `Added ${panelConfigs.length} panel(s): ${panelConfigs.map((p) => p.title).join(', ')}`;
   ctx.sendEvent({ type: 'tool_result', tool: 'dashboard_add_panels', summary: observationText });

--- a/packages/agent-core/src/agent/handlers/investigation.test.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.test.ts
@@ -111,6 +111,7 @@ describe('investigation handlers', () => {
     expect(reportStore.save).toHaveBeenCalledOnce();
     expect(store.updateStatus).toHaveBeenCalledWith('inv_1', 'completed');
     expect(ctx.setNavigateTo).toHaveBeenCalledWith('/investigations/inv_1');
+    expect(ctx.sendEvent).toHaveBeenCalledWith({ type: 'navigate', path: '/investigations/inv_1' });
     // active id cleared so the next investigation_create starts a fresh one
     expect(ctx.activeInvestigationId).toBeNull();
   });

--- a/packages/agent-core/src/agent/handlers/investigation.test.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.test.ts
@@ -145,7 +145,7 @@ describe('investigation handlers', () => {
     expect(ctx.investigationSections.get('inv_1')?.length).toBe(2);
   });
 
-  it('investigation_create sets ctx.activeInvestigationId on success', async () => {
+  it('investigation_create sets a draft activeInvestigationId without persisting yet', async () => {
     const created: Investigation = {
       id: 'inv_new',
       sessionId: 'ses_1',
@@ -175,7 +175,9 @@ describe('investigation handlers', () => {
 
     await handleInvestigationCreate(ctx, { question: 'why is X slow?' });
 
-    expect(ctx.activeInvestigationId).toBe('inv_new');
+    expect(store.create).not.toHaveBeenCalled();
+    expect(ctx.activeInvestigationId).toMatch(/^draft_investigation_/);
+    expect(ctx.pendingInvestigationCreates.get(ctx.activeInvestigationId!)).toEqual({ question: 'why is X slow?' });
   });
 
   // ── Provenance (Task 10) ────────────────────────────────────────────────
@@ -208,9 +210,10 @@ describe('investigation handlers', () => {
     const ctx = makeFakeActionContext({ investigationStore: store });
     await handleInvestigationCreate(ctx, { question: 'why' });
 
-    const prov = ctx.investigationProvenance.get('inv_p1');
+    const draftId = ctx.activeInvestigationId!;
+    const prov = ctx.investigationProvenance.get(draftId);
     expect(prov).toBeDefined();
-    expect(prov!.runId).toBe('inv_p1');
+    expect(prov!.runId).toBe(draftId);
     expect(prov!.model).toBe('test-model');
     expect(prov!.toolCalls).toBe(0);
 
@@ -224,7 +227,7 @@ describe('investigation handlers', () => {
       panel: { title: 'CPU', visualization: 'time_series', queries: [] },
     });
 
-    const after = ctx.investigationProvenance.get('inv_p1')!;
+    const after = ctx.investigationProvenance.get(draftId)!;
     expect(after.toolCalls).toBe(2);
     expect(after.evidenceCount).toBe(1);
     // Citations dedup by ref — m1 referenced twice → counted once.
@@ -279,6 +282,7 @@ describe('investigation handlers', () => {
     });
 
     await handleInvestigationCreate(ctx, { question: 'why' });
+    const draftId = ctx.activeInvestigationId!;
 
     warnSpy.mockClear();
     await handleInvestigationAddSection(ctx, {
@@ -292,7 +296,7 @@ describe('investigation handlers', () => {
     });
 
     // Section persisted with a captureError provenance marker.
-    const sections = ctx.investigationSections.get('inv_cap')!;
+    const sections = ctx.investigationSections.get(draftId)!;
     expect(sections).toHaveLength(1);
     const panel = sections[0]!.panel!;
     expect(panel.snapshotData?.captureError).toMatch(/prom unreachable/);
@@ -303,7 +307,7 @@ describe('investigation handlers', () => {
     );
     expect(snapshotWarn).toBeDefined();
     const ctxFields = snapshotWarn![0] as Record<string, unknown>;
-    expect(ctxFields.investigationId).toBe('inv_cap');
+    expect(ctxFields.investigationId).toBe(draftId);
     expect(ctxFields.queryKind).toBe('range');
     expect(ctxFields.adapterId).toBe('prom-1');
     expect(ctxFields.panelTitle).toBe('CPU');

--- a/packages/agent-core/src/agent/handlers/investigation.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.ts
@@ -51,63 +51,42 @@ export async function handleInvestigationCreate(
   const question = String(args.question ?? '');
   if (!question) return 'Error: "question" is required.';
 
-  let createdId = '';
+  let draftId = '';
   let observationText = '';
   await withToolEventBoundary(
     ctx.sendEvent,
     'investigation_create',
     { question },
-    `Creating investigation: "${question.slice(0, 60)}"`,
+    `Preparing investigation: "${question.slice(0, 60)}"`,
     async () => {
-      // Same reason as dashboard_create: the GET route filters by
-      // workspaceId; missing this field makes the investigation unreachable
-      // even though the row is in the store.
-      const investigation = await ctx.investigationStore!.create(
-        withWorkspaceScope(ctx.identity, {
-          question,
-          sessionId: ctx.sessionId,
-          userId: 'agent',
-        }),
-      );
-
-      createdId = investigation.id;
-      void ctx.auditWriter?.({
-        action: AuditAction.InvestigationCreate,
-        actorType: 'user',
-        actorId: ctx.identity.userId,
-        orgId: ctx.identity.orgId,
-        targetType: 'investigation',
-        targetId: investigation.id,
-        targetName: question,
-        outcome: 'success',
-        metadata: { sessionId: ctx.sessionId, via: 'agent_tool' },
-      });
+      draftId = `draft_investigation_${randomUUID()}`;
+      ctx.pendingInvestigationCreates.set(draftId, { question });
       // Mark this investigation as the active one for the session.
       // `add_section` and `complete` read from here; the LLM no longer
       // has to copy the id back through tool params (which it sometimes
       // truncated, silently re-keying sections to a phantom map slot).
-      ctx.activeInvestigationId = createdId;
+      ctx.activeInvestigationId = draftId;
       // Seed the provenance accumulator with model + runId + start time.
       // Cost / latency get filled in at completion (latency from startedAt;
       // cost is left undefined here — the UI joins llm_audit by sessionId
       // when it needs aggregate spend). See ActionContext docs for the
       // full lifecycle.
-      ctx.investigationProvenance.set(createdId, {
+      ctx.investigationProvenance.set(draftId, {
         model: ctx.model,
-        runId: createdId,
+        runId: draftId,
         toolCalls: 0,
         evidenceCount: 0,
         citations: [],
         startedAt: Date.now(),
       });
-      observationText = `Created investigation "${question.slice(0, 60)}" (id: ${investigation.id}).`;
+      observationText = `Prepared investigation "${question.slice(0, 60)}" (draft id: ${draftId}). It will be created when the report is complete.`;
       return observationText;
     },
   );
   ctx.emitAgentEvent(
     ctx.makeAgentEvent('agent.tool_completed', {
       tool: 'investigation_create',
-      investigationId: createdId,
+      investigationId: draftId,
       summary: observationText,
     }),
   );
@@ -376,16 +355,28 @@ export async function handleInvestigationComplete(
     { investigationId },
     `Completing investigation`,
     async () => {
-      if (!ctx.investigationStore?.findById) {
+      if (!ctx.investigationStore) {
         return 'Error: investigation store is not available.';
       }
 
-      const investigation = await ctx.investigationStore.findById(investigationId);
-      if (!investigation) {
-        return `Error: investigation "${investigationId}" was not found.`;
+      const pendingCreate = ctx.pendingInvestigationCreates.get(investigationId);
+      if (pendingCreate && !ctx.investigationStore.create) {
+        return 'Error: investigation store is not available.';
       }
-      if (investigation.workspaceId !== ctx.identity.orgId) {
-        return `Error: investigation "${investigationId}" was not found.`;
+      if (!pendingCreate && !ctx.investigationStore.findById) {
+        return 'Error: investigation store is not available.';
+      }
+      let persistedInvestigationId = investigationId;
+      let question = pendingCreate?.question ?? '';
+      if (!pendingCreate) {
+        const investigation = await ctx.investigationStore.findById!(investigationId);
+        if (!investigation) {
+          return `Error: investigation "${investigationId}" was not found.`;
+        }
+        if (investigation.workspaceId !== ctx.identity.orgId) {
+          return `Error: investigation "${investigationId}" was not found.`;
+        }
+        question = investigation.intent;
       }
 
       const sections = ctx.investigationSections.get(investigationId) ?? [];
@@ -400,7 +391,7 @@ export async function handleInvestigationComplete(
       let unresolvedGap: string | null = null;
       if (ctx.runAuditor && provForAudit) {
         const reportText = [summary, ...sections.map((s) => s.content)].join('\n\n');
-        const { verdict, gap } = await ctx.runAuditor({ question: investigation.intent, report: reportText });
+        const { verdict, gap } = await ctx.runAuditor({ question, report: reportText });
         if (verdict === 'NEEDS_MORE') {
           const rounds = provForAudit.auditorRounds ?? 0;
           if (rounds < MAX_AUDIT_ROUNDS) {
@@ -417,6 +408,40 @@ export async function handleInvestigationComplete(
         }
       }
 
+      if (pendingCreate) {
+        const investigation = await ctx.investigationStore.create(
+          withWorkspaceScope(ctx.identity, {
+            question: pendingCreate.question,
+            sessionId: ctx.sessionId,
+            userId: 'agent',
+          }),
+        );
+        persistedInvestigationId = investigation.id;
+        ctx.pendingInvestigationCreates.delete(investigationId);
+        ctx.activeInvestigationId = persistedInvestigationId;
+        ctx.investigationSections.delete(investigationId);
+        ctx.investigationSections.set(persistedInvestigationId, sections);
+        const draftProvenance = ctx.investigationProvenance.get(investigationId);
+        if (draftProvenance) {
+          ctx.investigationProvenance.delete(investigationId);
+          ctx.investigationProvenance.set(persistedInvestigationId, {
+            ...draftProvenance,
+            runId: persistedInvestigationId,
+          });
+        }
+        void ctx.auditWriter?.({
+          action: AuditAction.InvestigationCreate,
+          actorType: 'user',
+          actorId: ctx.identity.userId,
+          orgId: ctx.identity.orgId,
+          targetType: 'investigation',
+          targetId: investigation.id,
+          targetName: pendingCreate.question,
+          outcome: 'success',
+          metadata: { sessionId: ctx.sessionId, via: 'agent_tool' },
+        });
+      }
+
       if (unresolvedGap) {
         sections.push({
           type: 'text',
@@ -427,7 +452,7 @@ export async function handleInvestigationComplete(
       // Finalise provenance: copy out a clean Provenance (drop `startedAt`
       // bookkeeping field) and compute end-to-end latency. Cost is left
       // undefined — UI will fall back to "—" or fetch from llm_audit.
-      const provState = ctx.investigationProvenance.get(investigationId);
+      const provState = ctx.investigationProvenance.get(persistedInvestigationId);
       let finalProvenance: Provenance | undefined;
       if (provState) {
         // Drop bookkeeping-only fields (`startedAt`, `auditorRounds`,
@@ -447,7 +472,7 @@ export async function handleInvestigationComplete(
         const citCount = finalProvenance.citations?.length ?? 0;
         if (evCount > 0 && citCount === 0) {
           log.warn(
-            { investigationId, evidenceCount: evCount, citationCount: citCount },
+            { investigationId: persistedInvestigationId, evidenceCount: evCount, citationCount: citCount },
             'investigation has evidence sections but no inline citations',
           );
         }
@@ -458,7 +483,7 @@ export async function handleInvestigationComplete(
       // fresh id inserts a new report.
       await ctx.investigationReportStore.save({
         id: provState?.reportId ?? randomUUID(),
-        dashboardId: investigationId,
+        dashboardId: persistedInvestigationId,
         goal: summary,
         summary,
         sections,
@@ -472,11 +497,11 @@ export async function handleInvestigationComplete(
       // mismatch is discoverable instead of silent.
       if (ctx.investigationStore) {
         try {
-          await ctx.investigationStore.updateStatus(investigationId, 'completed');
+          await ctx.investigationStore.updateStatus(persistedInvestigationId, 'completed');
         } catch (err) {
           log.warn(
             {
-              investigationId,
+              investigationId: persistedInvestigationId,
               targetStatus: 'completed',
               errorClass: err instanceof Error ? err.constructor.name : typeof err,
               error: err instanceof Error ? err.message : String(err),
@@ -488,13 +513,15 @@ export async function handleInvestigationComplete(
 
       // Clean up accumulated sections + provenance
       ctx.investigationSections.delete(investigationId);
+      ctx.investigationSections.delete(persistedInvestigationId);
       ctx.investigationProvenance.delete(investigationId);
+      ctx.investigationProvenance.delete(persistedInvestigationId);
       // Clear active id so the next investigation_create starts a fresh one.
       ctx.activeInvestigationId = null;
 
       // Navigate to the investigation page
-      ctx.setNavigateTo(`/investigations/${investigationId}`);
-      ctx.recordCreatedResource('investigation', investigationId);
+      ctx.setNavigateTo(`/investigations/${persistedInvestigationId}`);
+      ctx.recordCreatedResource('investigation', persistedInvestigationId);
 
       return `Investigation completed and report saved with ${sections.length} sections. Summary: ${summary}`;
     },

--- a/packages/agent-core/src/agent/handlers/investigation.ts
+++ b/packages/agent-core/src/agent/handlers/investigation.ts
@@ -521,6 +521,7 @@ export async function handleInvestigationComplete(
 
       // Navigate to the investigation page
       ctx.setNavigateTo(`/investigations/${persistedInvestigationId}`);
+      ctx.sendEvent({ type: 'navigate', path: `/investigations/${persistedInvestigationId}` });
       ctx.recordCreatedResource('investigation', persistedInvestigationId);
 
       return `Investigation completed and report saved with ${sections.length} sections. Summary: ${summary}`;

--- a/packages/agent-core/src/agent/orchestrator-action-context.ts
+++ b/packages/agent-core/src/agent/orchestrator-action-context.ts
@@ -92,6 +92,8 @@ export interface OrchestratorActionRuntime {
   ): void;
   investigationSections: Map<string, InvestigationReportSection[]>;
   investigationProvenance: Map<string, Provenance & { startedAt?: number; auditorRounds?: number; reportId?: string }>;
+  pendingDashboardCreates: ActionContext['pendingDashboardCreates'];
+  pendingInvestigationCreates: ActionContext['pendingInvestigationCreates'];
   /** Spawns the read-only investigation auditor. Omitted on the auditor's own
    *  action ctx so the auditor can never recursively re-trigger itself. */
   runAuditor?: ActionContext['runAuditor'];
@@ -150,6 +152,8 @@ export function buildActionContext(
     recordCreatedResource: runtime.recordCreatedResource,
     investigationSections: runtime.investigationSections,
     investigationProvenance: runtime.investigationProvenance,
+    pendingDashboardCreates: runtime.pendingDashboardCreates,
+    pendingInvestigationCreates: runtime.pendingInvestigationCreates,
     runAuditor: runtime.runAuditor,
     get activeInvestigationId() { return invRef.current; },
     set activeInvestigationId(v: string | null) { invRef.current = v; },

--- a/packages/agent-core/src/agent/orchestrator-agent.ts
+++ b/packages/agent-core/src/agent/orchestrator-agent.ts
@@ -183,6 +183,8 @@ export class OrchestratorAgent {
    *  `auditorRounds` rides along here (seeded by investigation_create, survives
    *  the audit↔resume bounce) and is stripped before the report row is saved. */
   private readonly investigationProvenance = new Map<string, Provenance & { startedAt?: number; auditorRounds?: number; reportId?: string }>()
+  private readonly pendingDashboardCreates = new Map<string, import('./handlers/_context.js').PendingDashboardCreate>()
+  private readonly pendingInvestigationCreates = new Map<string, import('./handlers/_context.js').PendingInvestigationCreate>()
   /**
    * Active investigation id for this session. Implicit context for
    * investigation_add_section / investigation_complete so the LLM doesn't
@@ -454,6 +456,8 @@ export class OrchestratorAgent {
       },
       investigationSections: this.investigationSections,
       investigationProvenance: this.investigationProvenance,
+      pendingDashboardCreates: this.pendingDashboardCreates,
+      pendingInvestigationCreates: this.pendingInvestigationCreates,
       activeInvestigationIdRef: this.activeInvestigationIdRef,
       activeDashboardIdRef: this.activeDashboardIdRef,
       freshlyCreatedDashboards: this.freshlyCreatedDashboards,

--- a/packages/agent-core/src/agent/permission-gate.test.ts
+++ b/packages/agent-core/src/agent/permission-gate.test.ts
@@ -25,6 +25,8 @@ function makeCtx(allowAll = true): ActionContext {
     setNavigateTo: () => {},
     investigationSections: new Map(),
     investigationProvenance: new Map(),
+    pendingDashboardCreates: new Map(),
+    pendingInvestigationCreates: new Map(),
     freshlyCreatedDashboards: new Set<string>(),
     dashboardBuildEvidence: {
       kbConsultCount: 0,

--- a/packages/agent-core/src/agent/tool-schema-registry.ts
+++ b/packages/agent-core/src/agent/tool-schema-registry.ts
@@ -633,7 +633,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: {
       name: 'dashboard_create',
       description:
-        'Create an empty dashboard. Returns dashboardId. Follow with dashboard_add_panels to populate it. Required before any other dashboard.* mutation when there is no current dashboard context. Requires a primary datasourceId — pick one via connectors_suggest first (or reuse the session pin if set).',
+        'Prepare a new dashboard draft. It is not persisted or shown to the user until dashboard_add_panels succeeds with real content. Follow with dashboard_add_panels to create and populate it in one step. Required before any other dashboard.* mutation when there is no current dashboard context. Requires a primary datasourceId — pick one via connectors_suggest first (or reuse the session pin if set).',
       input_schema: {
         type: 'object',
         properties: {
@@ -939,7 +939,7 @@ export const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: {
       name: 'investigation_create',
       description:
-        'Start a new investigation record for a "why is X" question. Returns investigationId.\n\n' +
+        'Start a new investigation draft for a "why is X" question. The persisted investigation record is created only when investigation_complete saves the report.\n\n' +
         'Trigger on diagnostic intents: "why is X" / "investigate X" / "diagnose X" / "排查 X" / "为什么 X 这么慢/高/坏". Do NOT trigger on read intents like "show me X", "what\'s the value of X", "list X" — those are queries, not investigations.\n\n' +
         'Call this at the START of the diagnosis, BEFORE running discovery queries. Investigation sections should capture the actual reasoning trace; if you query first then create the record, the record only contains the writeup, not the live trail.',
       input_schema: {

--- a/packages/common/src/models/dashboard.ts
+++ b/packages/common/src/models/dashboard.ts
@@ -314,6 +314,7 @@ export type DashboardSseEvent =
       error?: string;
     }
   | { type: 'reply'; content: string }
+  | { type: 'navigate'; path: string }
   | { type: 'ask_user'; question: string; options: Array<{ id: string; label: string; hint?: string }> }
   | {
       // Inline narration of the agent's datasource pick. The chat UI renders

--- a/packages/web/src/components/Navigation.tsx
+++ b/packages/web/src/components/Navigation.tsx
@@ -103,17 +103,19 @@ interface SidebarItemProps {
   icon: React.ReactNode;
   end?: boolean;
   expanded: boolean;
+  onClick?: () => void;
   /** Optional small badge (e.g. pending count) shown on the icon / label. */
   badge?: number;
 }
 
-function SidebarItem({ to, label, icon, end, expanded, badge }: SidebarItemProps) {
+function SidebarItem({ to, label, icon, end, expanded, onClick, badge }: SidebarItemProps) {
   const showBadge = typeof badge === 'number' && badge > 0;
   const badgeLabel = showBadge ? (badge > 99 ? '99+' : String(badge)) : null;
   return (
     <NavLink
       to={to}
       end={end}
+      onClick={onClick}
       title={expanded ? undefined : (showBadge ? `${label} (${badgeLabel} pending)` : label)}
       className={({ isActive }) =>
         `relative flex items-center gap-3 h-10 rounded-lg transition-colors ${
@@ -334,7 +336,7 @@ export default function Navigation() {
       void globalChat.loadSession(sessionId);
       // No URL mutation — session id lives in ChatProvider's React state.
       // Just ensure we're on Home so the conversation surface is visible.
-      if (location.pathname !== '/') navigate('/');
+      if (location.pathname !== '/') navigate('/', { state: { resumeChat: true } });
     },
     [globalChat, navigate, location.pathname],
   );
@@ -477,7 +479,7 @@ export default function Navigation() {
           mode only when the Nav tab is active. */}
       {(activeTab === 'nav' || !expanded) && (
         <div className={`flex flex-col gap-1 flex-1 ${expanded ? '' : 'items-center'}`}>
-          <SidebarItem to="/" label="Home" icon={<HomeIcon />} end expanded={expanded} />
+          <SidebarItem to="/" label="Home" icon={<HomeIcon />} end expanded={expanded} onClick={globalChat.startNewSession} />
           <SidebarItem to="/dashboards" label="Dashboards" icon={<DashboardIcon />} expanded={expanded} />
           <SidebarItem to="/investigations" label="Investigations" icon={<InvestigationIcon />} expanded={expanded} />
           <SidebarItem to="/alerts" label="Alerts" icon={<AlertsIcon />} expanded={expanded} />

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -476,11 +476,16 @@ export function useChat(): UseChatResult {
   // empty initial state = new conversation, Recents covers explicit resume.
   const [currentSessionId, setCurrentSessionId] = useState<string>('');
   const sessionIdRef = useRef<string>('');
+  const isGeneratingRef = useRef(false);
 
   // Keep ref in sync with state
   useEffect(() => {
     sessionIdRef.current = currentSessionId;
   }, [currentSessionId]);
+
+  useEffect(() => {
+    isGeneratingRef.current = isGenerating;
+  }, [isGenerating]);
 
   // Best-effort cleanup of any stale id from previous app versions. Run once
   // on mount; ignored if the key was already cleared.
@@ -1096,10 +1101,21 @@ export function useChat(): UseChatResult {
           const res = await apiClient.get<{ sessions: Array<{ id: string }> }>(
             `/chat/sessions/by-context?resourceType=${encodeURIComponent(resourceType)}&resourceId=${encodeURIComponent(resourceId)}&limit=1`,
           );
+          const currentContext = pageContextRef.current;
+          if (
+            !currentContext ||
+            currentContext.kind !== resourceType ||
+            currentContext.id !== resourceId
+          ) {
+            return;
+          }
           const latest = res.data?.sessions?.[0];
           if (latest?.id && latest.id !== sessionIdRef.current) {
             await loadSessionRef.current?.(latest.id);
           } else if (!latest) {
+            if (isGeneratingRef.current) {
+              return;
+            }
             // No session yet for this resource — leave the panel empty so
             // user sees the "ask me anything" prompt rather than the prior
             // page's conversation bleeding through.

--- a/packages/web/src/pages/Home.tsx
+++ b/packages/web/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { fadeIn } from '../animations.js';
 import { useGlobalChat } from '../contexts/ChatContext.js';
@@ -80,6 +81,7 @@ const QUICK_ACTIONS = [
 
 export default function Home() {
   const globalChat = useGlobalChat();
+  const location = useLocation();
   const {
     events,
     queuedMessages,
@@ -95,6 +97,18 @@ export default function Home() {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   const hasMessages = events.length > 0;
+
+  useEffect(() => {
+    const state = location.state as { resumeChat?: boolean } | null;
+    if (state?.resumeChat) {
+      return;
+    }
+    globalChat.startNewSession();
+    // Run only when Home is entered. `globalChat` is intentionally omitted
+    // because it changes as events stream in; including it would clear the
+    // conversation on every chat update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.key]);
 
   // Auto-scroll on new events. First mount jumps to the bottom instantly
   // (no animated scroll-from-top when the page reloads with N existing


### PR DESCRIPTION
## Summary
- defer dashboard and investigation persistence until generated content/report is ready
- navigate immediately after deferred dashboard/investigation resources are persisted
- reset Home to a fresh chat while preserving explicit Recents resumes
- keep active resource chat stable during in-flight navigation/by-context races

## Verification
- npm run typecheck
- npm --workspace @agentic-obs/web run build
- npm test -- --run packages/agent-core/src/agent/handlers/__tests__/dashboard.test.ts packages/agent-core/src/agent/handlers/__tests__/dashboard-build-flow.regression.test.ts packages/agent-core/src/agent/handlers/investigation.test.ts packages/agent-core/src/agent/factory.test.ts