### PR TITLE
Fix the chart's image registry before cutting 0.0.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest. Contributions of any size are welcome — typo fixes, 
 
 The `main` branch is protected — direct pushes are blocked, all changes flow through pull requests.
 
-1. **Fork** the repo: <https://github.com/syntropize/rounds/fork>
+1. **Fork** the repo: <https://github.com/syntropize-ai/rounds/fork>
 2. **Clone** your fork and create a topic branch:
    ```bash
    git clone https://github.com/<you>/rounds.git
@@ -21,14 +21,14 @@ The `main` branch is protected — direct pushes are blocked, all changes flow t
    npm test
    npm run build
    ```
-5. **Commit, push, open a PR** against `syntropize/rounds:main`. Fill out the PR template.
+5. **Commit, push, open a PR** against `syntropize-ai/rounds:main`. Fill out the PR template.
 6. **Wait for review.** A maintainer will leave comments or approve. PRs need ≥1 approval and green CI before merge.
 
 If you're tackling something non-trivial, open an issue first to align on the approach — saves rework if the design needs adjusting.
 
 ## Reporting bugs
 
-Open an issue at <https://github.com/syntropize/rounds/issues> with: what you expected, what happened, steps to reproduce, and your `rounds --version` / Node version / OS.
+Open an issue at <https://github.com/syntropize-ai/rounds/issues> with: what you expected, what happened, steps to reproduce, and your `rounds --version` / Node version / OS.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@
 
 ## Quick Start
 
-Rounds ships as a Helm chart — that's the supported way to install and upgrade.
+You'll need a Kubernetes cluster and an API key for an LLM provider (Anthropic,
+OpenAI, Gemini, DeepSeek, Azure OpenAI, or a local Ollama endpoint). Rounds
+cannot investigate anything without a model, so have the key ready before you
+start — the setup wizard asks for it and won't let you past that step.
 
 ```bash
 helm install rounds oci://ghcr.io/syntropize-ai/charts/rounds \
@@ -49,15 +52,33 @@ The chart creates a private `ClusterIP` service. To open it locally:
 kubectl -n observability port-forward svc/rounds 3000:80
 ```
 
-Then open **http://127.0.0.1:3000** and follow the setup wizard.
+Then open **http://127.0.0.1:3000**. The setup wizard walks through six steps:
+create an admin account, paste your LLM key, and connect a datasource. The
+connector and notification steps can be skipped and done later in Settings.
 
-Try:
+Once you're in, try:
 
 - `Create a dashboard for HTTP latency`
 - `Alert me when p95 latency is above 500ms for 10 minutes`
 - `Why is checkout latency high right now?`
 
+Questions about your own systems need a datasource connected — point Rounds at
+your Prometheus in the wizard's Connectors step, or later under
+Settings → Connectors.
+
 For shared access, expose Rounds with Ingress or `service.type=LoadBalancer` — see [docs/install/kubernetes.md](./docs/install/kubernetes.md).
+
+### Try it without a cluster
+
+To see the product before committing to an install, the npm package runs the
+same binary on a laptop with SQLite under `~/.rounds/`:
+
+```bash
+npx @syntropize/rounds
+```
+
+Then open **http://localhost:3000**. Single-node and unauthenticated by
+default — fine for evaluation, not for production.
 
 ## What can it do?
 
@@ -100,14 +121,9 @@ helm template rounds ./helm/rounds   # render manifests locally
 
 ## Run without Kubernetes
 
-For local evaluation on a laptop, the npm package runs the same binary with a single-node SQLite store under `~/.rounds/rounds.db`:
-
-```bash
-npm install -g @syntropize/rounds
-rounds
-```
-
-Then open **http://localhost:3000**. Not recommended for production.
+See [Try it without a cluster](#try-it-without-a-cluster) above, or the
+[npm install guide](./docs/install/npm.md) for persistent installs, upgrades,
+and where data lives.
 
 ## Build from source
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ npx @syntropize/rounds
 
 ```bash [Helm (Kubernetes)]
 helm upgrade --install rounds \
-  oci://ghcr.io/syntropize/charts/rounds \
+  oci://ghcr.io/syntropize-ai/charts/rounds \
   --namespace observability \
   --create-namespace
 ```

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -5,7 +5,7 @@ Rounds includes a first-party Helm chart in this repository at `helm/rounds`.
 ## Basic install
 
 ```bash
-helm upgrade --install rounds oci://ghcr.io/syntropize/charts/rounds \
+helm upgrade --install rounds oci://ghcr.io/syntropize-ai/charts/rounds \
   --namespace observability \
   --create-namespace
 ```
@@ -36,7 +36,7 @@ shared access, use one of the options below instead.
 Use this when your Kubernetes environment can provision external load balancers:
 
 ```bash
-helm upgrade --install rounds oci://ghcr.io/syntropize/charts/rounds \
+helm upgrade --install rounds oci://ghcr.io/syntropize-ai/charts/rounds \
   --namespace observability \
   --create-namespace \
   --set service.type=LoadBalancer
@@ -54,7 +54,7 @@ Use this when your cluster already has an Ingress controller such as nginx,
 Traefik, or a cloud provider ingress controller:
 
 ```bash
-helm upgrade --install rounds oci://ghcr.io/syntropize/charts/rounds \
+helm upgrade --install rounds oci://ghcr.io/syntropize-ai/charts/rounds \
   --namespace observability \
   --create-namespace \
   --set ingress.enabled=true \
@@ -78,7 +78,7 @@ For production Kubernetes and any multi-replica deployment, use Postgres. Set
 `secretEnv.DATABASE_URL` before the first Rounds pod starts:
 
 ```bash
-helm install rounds oci://ghcr.io/syntropize/charts/rounds \
+helm install rounds oci://ghcr.io/syntropize-ai/charts/rounds \
   --namespace observability --create-namespace \
   --set secretEnv.DATABASE_URL='postgresql://rounds:password@postgres.example.com:5432/rounds' \
   --set env.DATABASE_SSL=true

--- a/helm/rounds/values.yaml
+++ b/helm/rounds/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/syntropize/rounds
+  repository: ghcr.io/syntropize-ai/rounds
   # Empty defaults to .Chart.AppVersion.
   tag: ""
   pullPolicy: IfNotPresent

--- a/packages/api-gateway/src/services/ops-command-runner.test.ts
+++ b/packages/api-gateway/src/services/ops-command-runner.test.ts
@@ -450,7 +450,11 @@ describe('KubectlOpsCommandRunner.runCommand — connector policy gate', () => {
     expect(r.observation).toContain('rejected');
   });
 
-  it('background bypass skips confirmation for read-safe runtime.exec when policy is allow', async () => {
+  // Bypassing the confirmation is the point of this case, so the runner goes
+  // on to spawn a real kubectl that has no cluster to reach. The default 5s
+  // budget covers that on a warm machine but not under coverage instrumentation
+  // in CI, where this timed out.
+  it('background bypass skips confirmation for read-safe runtime.exec when policy is allow', { timeout: 30_000 }, async () => {
     const runner = new KubectlOpsCommandRunner({
       connectors: fakeConnectorRepo({
         connectors: [


### PR DESCRIPTION
#262 was squashed at 02:46, but two commits landed on that branch afterwards and were left behind. They are the ones that make `helm install` actually work, so they need to be on main before the 0.0.11 tag.

## `helm install` currently cannot succeed

`helm/rounds/values.yaml` defaults to `ghcr.io/syntropize/rounds`, but images publish to `ghcr.io/syntropize-ai/rounds` — the docker workflow uses `github.repository`. Verified against the registry with an anonymous pull token:

```
ghcr.io/v2/syntropize/rounds/tags/list     → 403  (org does not exist)
ghcr.io/v2/syntropize-ai/rounds/tags/list  → 200  tags: 0.0.8, 0.0.9, 0.0.10, 0.0, …
```

So the README's one-liner has only ever produced `ImagePullBackOff`. This has been true since v0.0.3. The same wrong org appeared in four helm commands across `docs/getting-started.md` and `docs/install/kubernetes.md`, and in CONTRIBUTING's fork/issue links.

After the fix, `helm template` renders `image: "ghcr.io/syntropize-ai/rounds:<appVersion>"`.

## README quick start was missing its prerequisite

Walking a fresh install in a browser: the setup wizard's LLM Provider step has no "Skip", and Continue stays disabled until a key is entered — so a user following the README gets stuck three steps in with no warning. The quick start now states the API key requirement up front, describes the six wizard steps, notes that questions about your own systems need a datasource connected, and leads with `npx @syntropize/rounds` for anyone who wants to try it without a cluster. The duplicate npm section further down now points at the install guide instead of repeating itself.

## Test timeout

`ops-command-runner.test.ts`'s background-bypass case spawns a real kubectl (bypassing the confirmation is the point of the case). That fits the default 5s budget locally but timed out under coverage instrumentation in CI. Given a 30s budget; verified the override applies by forcing `--testTimeout=1` and watching the case still pass.

## Verification

```
npm run typecheck → PASS (tsc --build)
npx vitest run    → 274 passed | 5 skipped (279 files)
                    2839 passed | 28 skipped (2867 tests)
helm lint         → 0 charts failed
helm template     → image: ghcr.io/syntropize-ai/rounds:<appVersion>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup prerequisites, including a Kubernetes cluster and LLM provider API key.
  * Expanded instructions for trying Rounds without a cluster, including setup steps, local evaluation defaults, URL, and data storage details.
  * Updated Kubernetes installation commands and container image references for the current distribution location.
  * Improved contribution and bug-reporting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->