### PR TITLE
Make "Configure by chat" real by implementing AgentConfigService

### DIFF
--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -62,6 +62,9 @@ export type {
   RemediationPlanStepKind,
   RemediationPlanStore,
   AgentConfigService,
+  AgentConnectorSummary,
+  AgentConnectorTemplateSummary,
+  AgentConnectorCandidate,
 } from './types.js'
 
 // Context compaction

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -30,6 +30,9 @@ export {
   type RemediationPlanStepKind,
   type RemediationPlanStore,
   type AgentConfigService,
+  type AgentConnectorSummary,
+  type AgentConnectorTemplateSummary,
+  type AgentConnectorCandidate,
   // Compat aliases
   type IConversationStore as IDashboardConversationStore,
   type IAlertRuleStore as IDashboardAlertRuleStore,

--- a/packages/api-gateway/src/app/domain-routes.ts
+++ b/packages/api-gateway/src/app/domain-routes.ts
@@ -426,6 +426,9 @@ export function mountDomainRoutes(deps: MountDomainRoutesDeps): void {
     // kubernetes connectors directly from the full data-layer repo (we want
     // `getSecret` here — the local `ConnectorRepository` view drops it).
     connectorRepo: repos.connectors,
+    // Backs the agent's `setting_*` tools. The service allowlists which keys
+    // chat may write; the repo itself is the same one the settings UI uses.
+    instanceConfigRepo: repos.instanceConfig,
     // GitHub agent tools (github_list_repos/_prs, github_get_pr/_diff).
     // The token service caches installation tokens in-process so each chat
     // turn doesn't pay a JWT-sign + 2x GitHub round-trip. Only wired when

--- a/packages/api-gateway/src/services/agent-config-service.test.ts
+++ b/packages/api-gateway/src/services/agent-config-service.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentConfigServiceImpl } from './agent-config-service.js';
+import type { ConnectorService } from './connector-service.js';
+
+function fakeConnectorService(over: Partial<ConnectorService> = {}): ConnectorService {
+  return {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn(async (input: Record<string, unknown>) => ({
+      id: 'conn_1',
+      status: 'active',
+      ...input,
+    })),
+    test: vi.fn().mockResolvedValue({ ok: true, capabilities: ['metrics.query'] }),
+    ...over,
+  } as unknown as ConnectorService;
+}
+
+describe('AgentConfigServiceImpl — connector proposal', () => {
+  it('creates nothing until the draft is applied', async () => {
+    const connectors = fakeConnectorService();
+    const svc = new AgentConfigServiceImpl({ connectors });
+
+    const draft = await svc.proposeConnector({
+      orgId: 'org_a',
+      template: 'prometheus',
+      name: 'cluster-prometheus',
+      config: { url: 'http://prometheus.monitoring.svc.cluster.local:9090' },
+    });
+
+    expect(draft.draftId).toBeTruthy();
+    expect(connectors.create).not.toHaveBeenCalled();
+
+    const applied = await svc.applyConnectorDraft({ orgId: 'org_a', draftId: draft.draftId });
+    expect(connectors.create).toHaveBeenCalledTimes(1);
+    expect(applied.connectorId).toBe('conn_1');
+  });
+
+  it('refuses a template it does not know instead of creating something odd', async () => {
+    const connectors = fakeConnectorService();
+    const svc = new AgentConfigServiceImpl({ connectors });
+
+    await expect(
+      svc.proposeConnector({ orgId: 'org_a', template: 'not-a-backend', name: 'x', config: {} }),
+    ).rejects.toThrow(/Unknown connector template/);
+    expect(connectors.create).not.toHaveBeenCalled();
+  });
+
+  it('names the missing required fields rather than creating a broken connector', async () => {
+    const connectors = fakeConnectorService();
+    const svc = new AgentConfigServiceImpl({ connectors });
+
+    await expect(
+      svc.proposeConnector({ orgId: 'org_a', template: 'prometheus', name: 'p', config: {} }),
+    ).rejects.toThrow(/url/);
+    expect(connectors.create).not.toHaveBeenCalled();
+  });
+
+  it('will not apply the same draft twice', async () => {
+    const connectors = fakeConnectorService();
+    const svc = new AgentConfigServiceImpl({ connectors });
+    const draft = await svc.proposeConnector({
+      orgId: 'org_a',
+      template: 'prometheus',
+      name: 'p',
+      config: { url: 'http://prom:9090' },
+    });
+
+    await svc.applyConnectorDraft({ orgId: 'org_a', draftId: draft.draftId });
+    await expect(
+      svc.applyConnectorDraft({ orgId: 'org_a', draftId: draft.draftId }),
+    ).rejects.toThrow(/expired or was already applied/);
+    expect(connectors.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not apply a draft belonging to another org', async () => {
+    const connectors = fakeConnectorService();
+    const svc = new AgentConfigServiceImpl({ connectors });
+    const draft = await svc.proposeConnector({
+      orgId: 'org_a',
+      template: 'prometheus',
+      name: 'p',
+      config: { url: 'http://prom:9090' },
+    });
+
+    await expect(
+      svc.applyConnectorDraft({ orgId: 'org_b', draftId: draft.draftId }),
+    ).rejects.toThrow(/expired or was already applied/);
+    expect(connectors.create).not.toHaveBeenCalled();
+  });
+
+  it('tells the agent a secret is still required, without handling one', async () => {
+    const svc = new AgentConfigServiceImpl({ connectors: fakeConnectorService() });
+    const draft = await svc.proposeConnector({
+      orgId: 'org_a',
+      template: 'prometheus',
+      name: 'p',
+      config: { url: 'http://prom:9090' },
+    });
+    // The prometheus template declares `credential: 'token'`, so the agent is
+    // told a secret is still needed — it must not invent one.
+    expect(draft.needsCredential).toBe(true);
+    expect(draft.capabilityPreview).toContain('metrics.query');
+  });
+});
+
+describe('AgentConfigServiceImpl — templates', () => {
+  it('lists prometheus with its required fields so the agent can ask for them', async () => {
+    const svc = new AgentConfigServiceImpl({ connectors: fakeConnectorService() });
+    const templates = await svc.listConnectorTemplates({});
+    const prom = templates.find((t) => t.type === 'prometheus');
+
+    expect(prom).toBeDefined();
+    expect(prom?.requiredFields).toContain('url');
+    expect(prom?.credentialRequired).toBe(true);
+  });
+});
+
+describe('AgentConfigServiceImpl — settings', () => {
+  it('refuses a key that is not on the agent allowlist', async () => {
+    const setSetting = vi.fn();
+    const svc = new AgentConfigServiceImpl({
+      connectors: fakeConnectorService(),
+      settings: { getSetting: vi.fn().mockResolvedValue(null), setSetting },
+    });
+
+    await expect(
+      svc.setSetting('auth.session_ttl', '5m', { orgId: 'org_a', userId: 'u1' }),
+    ).rejects.toThrow(/cannot be changed from chat/);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it('writes an allowlisted key', async () => {
+    const setSetting = vi.fn();
+    const svc = new AgentConfigServiceImpl({
+      connectors: fakeConnectorService(),
+      settings: { getSetting: vi.fn().mockResolvedValue(null), setSetting },
+    });
+
+    await svc.setSetting('investigation.default_time_range', '6h', {
+      orgId: 'org_a',
+      userId: 'u1',
+    });
+    expect(setSetting).toHaveBeenCalledWith('investigation.default_time_range', '6h');
+  });
+
+  it('fails loudly when no settings store is wired rather than pretending to save', async () => {
+    const svc = new AgentConfigServiceImpl({ connectors: fakeConnectorService() });
+    await expect(
+      svc.setSetting('investigation.default_time_range', '6h', { orgId: 'org_a', userId: 'u1' }),
+    ).rejects.toThrow(/not available/);
+  });
+});

--- a/packages/api-gateway/src/services/agent-config-service.ts
+++ b/packages/api-gateway/src/services/agent-config-service.ts
@@ -1,0 +1,360 @@
+/**
+ * The implementation `AgentConfigService` has been waiting for.
+ *
+ * `packages/agent-core/src/agent/types.ts` declares this surface and the
+ * `connector_*` / `setting_*` handlers in `agent-core/src/agent/handlers/
+ * config.ts` are written against it, but nothing ever constructed one — so
+ * every one of those tools answered "not available in this deployment" in
+ * every deployment, and README's "Configure by chat" bullet described a
+ * capability the build did not ship.
+ *
+ * This is deliberately a thin adapter. Connector reads and writes go through
+ * the same `ConnectorService` the HTTP routes use, so the agent cannot reach
+ * a path the API does not already expose, and templates come from the shared
+ * registry rather than a second list that would drift.
+ *
+ * Two invariants hold the security line:
+ *
+ *   - Raw credentials never pass through here. `proposeConnector` takes
+ *     config only; a connector that needs a secret is created without one and
+ *     reports `needsCredential`, leaving capture to the existing
+ *     `POST /api/connectors/:id/secret` endpoint. `handleConnectorPropose`
+ *     already rejects credential-shaped arguments before we are called, and
+ *     this class does not accept them either.
+ *   - Nothing is written until `applyConnectorDraft`. A proposal parks in
+ *     memory so the model can describe what it is about to do and the user
+ *     can say no. Drafts are per-org, expire, and are lost on restart —
+ *     losing one costs a re-proposal, never a half-created connector.
+ *
+ * RBAC is not re-implemented here: `tool-permissions.ts` already gates
+ * `connector_propose` / `connector_apply` behind `connectors:write` and
+ * `setting_set` behind instance-config write, and the permission gate runs
+ * before the handler.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  CONNECTOR_TEMPLATES,
+  getConnectorTemplate,
+  type ConnectorTemplate,
+  type ConnectorType,
+} from '@agentic-obs/common';
+import type {
+  AgentConfigService,
+  AgentConnectorCandidate,
+  AgentConnectorSummary,
+  AgentConnectorTemplateSummary,
+} from '@agentic-obs/agent-core';
+import type { ConnectorService } from './connector-service.js';
+
+/** How long a proposal stays applicable. Long enough to talk it over, short
+ *  enough that a forgotten draft cannot be applied later by surprise. */
+const DRAFT_TTL_MS = 30 * 60 * 1000;
+
+/** Detection runs inside a chat turn, so a dead address must not stall it. */
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Settings the agent may write. Everything absent from this list is
+ * read-only to the agent even for an operator who could change it in the UI:
+ * a chat turn is a weaker intent signal than a settings form, so the blast
+ * radius stays small on purpose. Grow this deliberately.
+ */
+const AGENT_WRITABLE_SETTINGS: ReadonlySet<string> = new Set([
+  'investigation.default_time_range',
+  'dashboard.default_refresh_interval',
+  'alerts.default_evaluation_interval',
+]);
+
+interface ConnectorDraft {
+  orgId: string;
+  template: ConnectorType;
+  name: string;
+  config: Record<string, unknown>;
+  scope: Record<string, unknown> | null;
+  isDefault: boolean;
+  needsCredential: boolean;
+  capabilityPreview: string[];
+  expiresAt: number;
+}
+
+export interface AgentConfigServiceDeps {
+  connectors: ConnectorService;
+  /** Instance settings store. Omit to make every setting tool report that
+   *  settings are unavailable rather than silently no-op. */
+  settings?: {
+    getSetting(key: string): Promise<string | null>;
+    setSetting(key: string, value: string): Promise<void>;
+  };
+  /** Audit sink shared with the HTTP routes, so a connector created by chat
+   *  is indistinguishable in the log from one created in the UI. */
+  audit?: (entry: {
+    action: string;
+    actorId: string | null;
+    orgId: string;
+    targetType: string;
+    targetId: string;
+    outcome: 'success' | 'failure';
+    metadata?: Record<string, unknown>;
+  }) => void | Promise<void>;
+}
+
+export class AgentConfigServiceImpl implements AgentConfigService {
+  private readonly drafts = new Map<string, ConnectorDraft>();
+
+  constructor(private readonly deps: AgentConfigServiceDeps) {}
+
+  async listConnectors(filter: {
+    orgId: string;
+    category?: string;
+    capability?: string;
+    status?: string;
+  }): Promise<AgentConnectorSummary[]> {
+    const connectors = await this.deps.connectors.list({ orgId: filter.orgId });
+    return connectors
+      .map((c) => {
+        const template = safeTemplate(c.type);
+        const capabilities = [...(template?.capabilities ?? [])];
+        return {
+          id: c.id,
+          type: c.type,
+          name: c.name,
+          ...(template ? { category: [...template.category] } : {}),
+          capabilities,
+          status: c.status ?? 'unknown',
+        } satisfies AgentConnectorSummary;
+      })
+      .filter((c) => {
+        if (filter.status && c.status !== filter.status) return false;
+        if (filter.category && !(c.category ?? []).some((cat) => cat === filter.category)) return false;
+        if (filter.capability && !c.capabilities.includes(filter.capability)) return false;
+        return true;
+      });
+  }
+
+  listConnectorTemplates(filter: {
+    category?: string;
+    capability?: string;
+  }): Promise<AgentConnectorTemplateSummary[]> {
+    const summaries = CONNECTOR_TEMPLATES.filter((t) => {
+      if (filter.category && !t.category.includes(filter.category as ConnectorTemplate['category'][number])) {
+        return false;
+      }
+      if (filter.capability && !t.capabilities.includes(filter.capability)) return false;
+      return true;
+    }).map((t) => ({
+      type: t.type,
+      category: [...t.category],
+      capabilities: [...t.capabilities],
+      requiredFields: [...(t.configSchema.required ?? [])],
+      credentialRequired: t.credential !== 'none',
+    } satisfies AgentConnectorTemplateSummary));
+    return Promise.resolve(summaries);
+  }
+
+  /**
+   * Probes the well-known in-cluster addresses each template carries and
+   * reports the ones that answer.
+   *
+   * Deliberately not a Kubernetes API scan: the chart grants the api-gateway
+   * ServiceAccount no cluster read at all (`kubectl auth can-i list services`
+   * is `no` on a default install), so listing services would mean widening
+   * RBAC for a long-lived HTTP process. An HTTP GET to
+   * `http://prometheus.monitoring.svc:9090` needs no permission beyond being
+   * on the network, and a backend that answers its own verify path is far
+   * better evidence than a service whose name merely looks right.
+   *
+   * A candidate is only reported after it responds — nothing here is a guess
+   * the user has to disprove.
+   */
+  async detectConnectors(input: { orgId: string; template?: string }): Promise<AgentConnectorCandidate[]> {
+    const templates = input.template
+      ? [safeTemplate(input.template)].filter((t): t is ConnectorTemplate => t !== null)
+      : CONNECTOR_TEMPLATES;
+
+    const probes = templates.flatMap((template) => {
+      if (template.detect?.kind !== 'k8s-service-probe') return [];
+      const verifyPath = template.verify.kind === 'http-get' ? template.verify.path : '/';
+      return template.detect.candidates.map(async (base): Promise<AgentConnectorCandidate | null> => {
+        const reachable = await probe(`${base.replace(/\/$/, '')}${verifyPath}`);
+        if (!reachable) return null;
+        return {
+          template: template.type,
+          candidate: { url: base },
+          confidence: 0.9,
+          source: 'in-cluster probe',
+        };
+      });
+    });
+
+    const results = await Promise.all(probes);
+    return results.filter((c): c is AgentConnectorCandidate => c !== null);
+  }
+
+  async proposeConnector(input: {
+    orgId: string;
+    template: string;
+    name: string;
+    config: Record<string, unknown>;
+    scope?: Record<string, unknown> | null;
+    isDefault?: boolean;
+    actorUserId?: string | null;
+  }): Promise<{ draftId: string; needsCredential: boolean; capabilityPreview: string[] }> {
+    const template = safeTemplate(input.template);
+    if (!template) {
+      throw new Error(
+        `Unknown connector template "${input.template}". Known templates: ${CONNECTOR_TEMPLATES.map((t) => t.type).join(', ')}.`,
+      );
+    }
+
+    const missing = (template.configSchema.required ?? []).filter(
+      (field) => input.config[field] === undefined || input.config[field] === '',
+    );
+    if (missing.length > 0) {
+      throw new Error(`Missing required config for ${template.type}: ${missing.join(', ')}.`);
+    }
+
+    this.pruneExpiredDrafts();
+    const draftId = randomUUID();
+    this.drafts.set(draftId, {
+      orgId: input.orgId,
+      template: template.type,
+      name: input.name,
+      config: input.config,
+      scope: input.scope ?? null,
+      isDefault: input.isDefault === true,
+      needsCredential: template.credential !== 'none',
+      capabilityPreview: [...template.capabilities],
+      expiresAt: Date.now() + DRAFT_TTL_MS,
+    });
+
+    return {
+      draftId,
+      needsCredential: template.credential !== 'none',
+      capabilityPreview: [...template.capabilities],
+    };
+  }
+
+  async applyConnectorDraft(input: {
+    orgId: string;
+    draftId: string;
+    actorUserId?: string | null;
+  }): Promise<{ connectorId: string; status: string; capabilities: string[] }> {
+    this.pruneExpiredDrafts();
+    const draft = this.drafts.get(input.draftId);
+    if (!draft) {
+      throw new Error(`No draft ${input.draftId} — it expired or was already applied. Propose the connector again.`);
+    }
+    // A draft carries the org it was proposed under; applying it from another
+    // org would let a cross-org chat turn create a connector out of thin air.
+    if (draft.orgId !== input.orgId) {
+      throw new Error(`No draft ${input.draftId} — it expired or was already applied. Propose the connector again.`);
+    }
+
+    const connector = await this.deps.connectors.create({
+      orgId: input.orgId,
+      type: draft.template,
+      name: draft.name,
+      config: draft.config,
+      // Attribute the row to the person whose chat turn asked for it, so a
+      // connector created here is traceable the same way one created in the UI is.
+      createdBy: input.actorUserId ?? 'agent',
+      ...(draft.isDefault ? { isDefault: true } : {}),
+      ...(draft.scope ? { scope: draft.scope } : {}),
+    } as Parameters<ConnectorService['create']>[0]);
+
+    // Single-use: a draft that has become a connector must not be applicable
+    // again, or a retry would create a duplicate.
+    this.drafts.delete(input.draftId);
+
+    await this.deps.audit?.({
+      action: 'connector.create',
+      actorId: input.actorUserId ?? null,
+      orgId: input.orgId,
+      targetType: 'connector',
+      targetId: connector.id,
+      outcome: 'success',
+      metadata: { via: 'agent_tool', template: draft.template, needsCredential: draft.needsCredential },
+    });
+
+    return {
+      connectorId: connector.id,
+      status: connector.status ?? 'unknown',
+      capabilities: draft.capabilityPreview,
+    };
+  }
+
+  async testConnector(
+    connectorId: string,
+    orgId: string,
+  ): Promise<{ ok: boolean; latencyMs?: number; capabilities: string[]; error?: string }> {
+    const startedAt = Date.now();
+    const result = await this.deps.connectors.test(orgId, connectorId);
+    if (!result) {
+      return { ok: false, capabilities: [], error: `No connector ${connectorId} in this organisation.` };
+    }
+    return {
+      ok: result.ok,
+      latencyMs: Date.now() - startedAt,
+      capabilities: [...(result.capabilities ?? [])],
+      ...(result.ok ? {} : { error: result.error ?? "Connection failed" }),
+    };
+  }
+
+  async getSetting(key: string, _orgId: string): Promise<string | null> {
+    if (!this.deps.settings) throw new Error('Settings are not available in this deployment.');
+    return this.deps.settings.getSetting(key);
+  }
+
+  async setSetting(
+    key: string,
+    value: string,
+    actor: { orgId: string; userId: string | null },
+  ): Promise<void> {
+    if (!this.deps.settings) throw new Error('Settings are not available in this deployment.');
+    if (!AGENT_WRITABLE_SETTINGS.has(key)) {
+      throw new Error(
+        `"${key}" cannot be changed from chat. Agent-writable settings: ${[...AGENT_WRITABLE_SETTINGS].join(', ')}.`,
+      );
+    }
+    await this.deps.settings.setSetting(key, value);
+    await this.deps.audit?.({
+      action: 'settings.update',
+      actorId: actor.userId,
+      orgId: actor.orgId,
+      targetType: 'setting',
+      targetId: key,
+      outcome: 'success',
+      metadata: { via: 'agent_tool' },
+    });
+  }
+
+  private pruneExpiredDrafts(): void {
+    const now = Date.now();
+    for (const [id, draft] of this.drafts) {
+      if (draft.expiresAt <= now) this.drafts.delete(id);
+    }
+  }
+}
+
+function safeTemplate(type: string): ConnectorTemplate | null {
+  try {
+    return getConnectorTemplate(type as ConnectorType) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A short, failure-tolerant reachability check. Any answer at all — including
+ * 401/403 — means something is listening and speaking HTTP there, which is
+ * what "detected" claims; only the URL is reported, never a response body.
+ */
+async function probe(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) });
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}

--- a/packages/api-gateway/src/services/chat-service.ts
+++ b/packages/api-gateway/src/services/chat-service.ts
@@ -30,7 +30,7 @@ import { DuckDuckGoSearchAdapter } from '@agentic-obs/adapters';
 // backend, so a single shared instance per process is fine.
 const sharedWebSearchAdapter = new DuckDuckGoSearchAdapter();
 import type { AccessControlSurface } from './accesscontrol-holder.js';
-import type { AuditWriter } from '../auth/audit-writer.js';
+import type { AuditWriter, AuditLogInput } from '../auth/audit-writer.js';
 import type { SetupConfigService } from './setup-config-service.js';
 import type { IGatewayDashboardStore } from '../repositories/types.js';
 import type {
@@ -48,6 +48,9 @@ import type {
 } from '@agentic-obs/data-layer';
 import { KubectlOpsCommandRunner, connectorToOpsConfig } from './ops-command-runner.js';
 import { GithubToolRunner } from './github-tool-runner.js';
+import { AgentConfigServiceImpl } from './agent-config-service.js';
+import { ConnectorService } from './connector-service.js';
+import { testConnectorAgainstBackend } from './connector-test.js';
 import type { GithubAppTokenService } from './github-app-token-service.js';
 import type { OpsConnectorConfig } from '@agentic-obs/agent-core';
 
@@ -273,6 +276,9 @@ export interface ChatServiceDeps {
    * ops tool reports "no ops connectors configured".
    */
   connectorRepo?: IConnectorRepository;
+  /** Instance settings store for the agent's `setting_*` tools. Optional:
+   *  without it those tools report that settings are unavailable. */
+  instanceConfigRepo?: { getSetting(key: string): Promise<string | null>; setSetting(key: string, value: string): Promise<void> };
   /**
    * GitHub App installation-token service. When wired alongside
    * `connectorRepo`, the four `github_*` agent tools are usable.
@@ -549,6 +555,23 @@ export class ChatService {
           ...(this.deps.auditWriter ? { audit: this.deps.auditWriter } : {}),
         })
       : undefined;
+    // Connector/settings surface for the `connector_*` and `setting_*` tools.
+    // Built on the same ConnectorService the HTTP routes use, so chat cannot
+    // reach a write path the API does not already expose. Without the
+    // connector repo the tools keep reporting that configuration is
+    // unavailable, which is what they did everywhere before this was wired.
+    const configService = this.deps.connectorRepo
+      ? new AgentConfigServiceImpl({
+          connectors: new ConnectorService({
+            connectors: this.deps.connectorRepo,
+            testConnector: (connector) => testConnectorAgainstBackend(connector, null),
+          }),
+          ...(this.deps.instanceConfigRepo ? { settings: this.deps.instanceConfigRepo } : {}),
+          ...(this.deps.auditWriter
+            ? { audit: (entry) => this.deps.auditWriter?.log(entry as AuditLogInput) }
+            : {}),
+        })
+      : undefined;
     // GitHub tool runner: read-only VCS surface (github_list_repos /
     // github_list_prs / github_get_pr / github_get_diff). Requires both the
     // connector repo (for resolution + policy lookup) and the App token
@@ -676,6 +699,7 @@ export class ChatService {
         // Ops connector view derived from the connectors table — see filter above.
         opsConnectors,
         ...(opsCommandRunner ? { opsCommandRunner } : {}),
+        ...(configService ? { configService } : {}),
         ...(githubToolRunner ? { githubToolRunner } : {}),
         // Live pin bag for this session — the agent mutates it via
         // connectors.pin/unpin and we read it back across messages.

--- a/packages/data-layer/src/db/sqlite-client.transaction.test.ts
+++ b/packages/data-layer/src/db/sqlite-client.transaction.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { createSqliteClient } from './sqlite-client.js';
+import { sql } from 'drizzle-orm';
+
+/**
+ * Overlapping transactions on the shared connection.
+ *
+ * An agent turn writes chat_session_event rows continuously while tools run,
+ * so a tool that writes inside a transaction — creating a connector — used to
+ * hit `cannot start a transaction within a transaction` and fail the whole
+ * tool call. HTTP handlers rarely overlap, which is why it stayed hidden.
+ */
+describe('sqlite withTransaction', () => {
+  it('serialises transactions that overlap instead of failing the second one', async () => {
+    const db = createSqliteClient({ path: ':memory:', wal: false });
+    await db.run(sql`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`);
+
+    // Start one transaction and keep it open across an await, then start a
+    // second while the first is still in flight — the exact interleaving an
+    // agent turn produces.
+    const first = db.withTransaction(async (tx) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await tx.run(sql`INSERT INTO t (v) VALUES ('first')`);
+      return 'first';
+    });
+    const second = db.withTransaction(async (tx) => {
+      await tx.run(sql`INSERT INTO t (v) VALUES ('second')`);
+      return 'second';
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
+
+    const rows = await db.all<{ v: string }>(sql`SELECT v FROM t ORDER BY id`);
+    expect(rows.map((r) => r.v)).toEqual(['first', 'second']);
+  });
+
+  it('rolls the failing transaction back without blocking the queue behind it', async () => {
+    const db = createSqliteClient({ path: ':memory:', wal: false });
+    await db.run(sql`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`);
+
+    const failing = db.withTransaction(async (tx) => {
+      await tx.run(sql`INSERT INTO t (v) VALUES ('doomed')`);
+      throw new Error('tool failed mid-write');
+    });
+    const following = db.withTransaction(async (tx) => {
+      await tx.run(sql`INSERT INTO t (v) VALUES ('after')`);
+      return 'after';
+    });
+
+    await expect(failing).rejects.toThrow('tool failed mid-write');
+    await expect(following).resolves.toBe('after');
+
+    const rows = await db.all<{ v: string }>(sql`SELECT v FROM t`);
+    expect(rows.map((r) => r.v)).toEqual(['after']);
+  });
+});

--- a/packages/data-layer/src/db/sqlite-client.ts
+++ b/packages/data-layer/src/db/sqlite-client.ts
@@ -32,24 +32,46 @@ export function createSqliteClient(opts: SqliteClientOptions): ReturnType<typeof
   sqlite.pragma('busy_timeout = 5000');
 
   const db = drizzle(sqlite, { schema });
+  // Serialises overlapping withTransaction calls on the single connection.
+  let transactionQueue: Promise<void> = Promise.resolve();
   return Object.assign(db, {
-    // better-sqlite3 is single-connection by design, so the same `db` is
-    // already pinned to one session. We just bracket the work with
-    // BEGIN/COMMIT and roll back on throw.
+    // better-sqlite3 is single-connection by design, so BEGIN/COMMIT here
+    // bracket the one session. That makes overlap the hazard rather than
+    // isolation: `fn` is async, so a second caller reaching BEGIN while the
+    // first is awaiting throws "cannot start a transaction within a
+    // transaction" on the shared connection.
+    //
+    // It stayed invisible while transactions came from HTTP handlers, which
+    // rarely overlap. An agent turn breaks that: chat_session_event rows are
+    // written continuously as the model streams, so any tool that writes in a
+    // transaction — creating a connector, say — lands inside someone else's
+    // BEGIN and fails. Serialising is enough; the queue is FIFO and a failed
+    // transaction does not poison the ones behind it.
+    //
+    // Callers must not nest `withTransaction` (no sqlite repository does):
+    // an inner call would wait on the outer one and deadlock.
     async withTransaction<T>(fn: (tx: QueryClient) => Promise<T>): Promise<T> {
-      sqlite.exec('BEGIN');
-      try {
-        const result = await fn(db as unknown as QueryClient);
-        sqlite.exec('COMMIT');
-        return result;
-      } catch (err) {
+      const run = async (): Promise<T> => {
+        sqlite.exec('BEGIN');
         try {
-          sqlite.exec('ROLLBACK');
-        } catch {
-          /* swallow rollback failure; surface the original error */
+          const result = await fn(db as unknown as QueryClient);
+          sqlite.exec('COMMIT');
+          return result;
+        } catch (err) {
+          try {
+            sqlite.exec('ROLLBACK');
+          } catch {
+            /* swallow rollback failure; surface the original error */
+          }
+          throw err;
         }
-        throw err;
-      }
+      };
+      const queued = transactionQueue.then(run, run);
+      transactionQueue = queued.then(
+        () => undefined,
+        () => undefined,
+      );
+      return queued;
     },
   });
 }

--- a/packages/data-layer/src/repository/postgres/connector.ts
+++ b/packages/data-layer/src/repository/postgres/connector.ts
@@ -186,7 +186,7 @@ export class PostgresConnectorRepository implements IConnectorRepository {
           ${input.lastVerifiedAt ?? null},
           ${input.lastVerifyError ?? null},
           ${input.isDefault ?? false},
-          ${input.createdBy},
+          ${input.createdBy ?? null},
           ${now},
           ${now}
         )

--- a/packages/data-layer/src/repository/sqlite/connector.ts
+++ b/packages/data-layer/src/repository/sqlite/connector.ts
@@ -183,7 +183,7 @@ export class SqliteConnectorRepository implements IConnectorRepository {
           ${input.lastVerifiedAt ?? null},
           ${input.lastVerifyError ?? null},
           ${fromBool(input.isDefault)},
-          ${input.createdBy},
+          ${input.createdBy ?? null},
           ${now},
           ${now}
         )


### PR DESCRIPTION
README advertises adding datasources through the agent. agent-core has carried the whole surface for it the entire time — an `AgentConfigService` interface, eight `connector_*` / `setting_*` handlers, RBAC entries gating propose/apply behind `connectors:write`. Nothing ever constructed the service:

```
$ grep -rn "configService" packages/api-gateway/src
(no matches)
```

So every one of those tools answered *"not available in this deployment"* — in **every** deployment. The interface comment reads *"Implemented by api-gateway once the new connector routes land."* The routes landed; this did not.

Found by installing the released chart, skipping the connectors step, and asking a fresh instance `帮我连接 prometheus，地址是 …`. The agent did everything right — listed templates, loaded `connector_detect` via tool search, then degraded gracefully to "go to Settings → Connectors" — because the backend had nothing to answer with.

## It now works end to end

Same sentence into a fresh install with zero connectors:

```
Proposed prometheus connector "cluster-prom" (draftId: 8c429f9a…)
Applied connector draft 8c429f9a…  connectorId=f39b2ddd…
  capabilities=metrics.discover, metrics.query, metrics.validate
```

```sql
sqlite> SELECT type, name, config, created_by FROM connectors;
prometheus|cluster-prom|{"url":"http://prometheus.monitoring.svc.cluster.local:9090"}|b6cc01ad…
```

## Two defects underneath it

Neither was introduced here; both blocked the last step.

**`sqlite withTransaction` had no guard against overlap.** It runs a bare `BEGIN` on the single shared connection, and `fn` is async — so a second caller reaching `BEGIN` while the first awaits throws `cannot start a transaction within a transaction`. Invisible while transactions came from HTTP handlers, which rarely interleave. An agent turn breaks that: `chat_session_event` rows are written continuously as the model streams, so any tool writing in a transaction lands inside someone else's `BEGIN`. Transactions are now serialised FIFO, and a failed one does not poison the queue behind it. The regression test reproduces the exact interleaving and fails with that error message on the old client.

**The connector INSERT interpolated `${input.createdBy}`** while every neighbouring nullable used `?? null`. An undefined author renders as an empty slot rather than a bound NULL:

```
) VALUES (
  ?, ?, ?, ?, ?, ?, ?, ?, ?,
  ,        ← created_by
  ?, ?
)
```

Malformed SQL, reachable from any caller that omits `createdBy`. Fixed in both backends.

## Boundaries

RBAC is not re-implemented — `tool-permissions.ts` already gates `connector_propose` / `connector_apply` behind `connectors:write` and `setting_set` behind instance-config write, and the permission gate runs before the handler.

- **Raw credentials never pass through.** `proposeConnector` takes config only; a connector needing a secret is created without one and reports `needsCredential`, leaving capture to the existing `POST /api/connectors/:id/secret`.
- **Nothing is written until apply.** A proposal parks in memory so the model can say what it is about to do. Drafts are per-org, single-use, expire after 30 minutes, and are lost on restart — losing one costs a re-proposal, never a half-created connector.
- **Settings are allowlisted.** Three keys today. A chat turn is a weaker intent signal than a settings form, so the blast radius stays small on purpose; grow the list deliberately.
- **Writes reuse `ConnectorService`,** so chat cannot reach a path the HTTP API does not already expose, and templates come from the shared registry rather than a second list that would drift.
- **`detectConnectors` probes, it does not scan.** Templates already carry well-known in-cluster addresses; probing them needs no permission beyond being on the network, whereas listing Kubernetes services would mean widening RBAC for a long-lived HTTP process (`kubectl auth can-i list services` is `no` for the api-gateway ServiceAccount on a default install). A candidate is only reported after it answers its own verify path.

## Verification

```
npm run typecheck → exit 0
npx vitest run packages/api-gateway packages/data-layer packages/agent-core
                → 176 files passed | 1894 tests passed
```

Plus the end-to-end run above against a real cluster. The transaction test was confirmed to fail on the pre-fix client with `cannot start a transaction within a transaction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for discovering, previewing, testing, and provisioning connectors through agent interactions.
  - Connector creation now uses a secure draft-and-apply workflow with expiration and organization safeguards.
  - Added connector template metadata, including required fields and credential requirements.
  - Added controlled agent access to supported settings, with audit tracking for updates.

- **Bug Fixes**
  - Improved reliability for overlapping database transactions and ensured failed transactions do not block later operations.
  - Missing connector creator information is now stored safely as empty database values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->